### PR TITLE
Request login for admin frontend

### DIFF
--- a/features/apps_are_up.feature
+++ b/features/apps_are_up.feature
@@ -31,5 +31,5 @@ Feature: Apps are up
   @admin-frontend
   Scenario: Check the admin frontend is up
     Given I have a URL for "dm_admin_frontend"
-    When I send a GET request to the home page
+    When I send a GET request to "/login"
     Then the response code should be "200"

--- a/features/step_definitions/api_steps.rb
+++ b/features/step_definitions/api_steps.rb
@@ -54,6 +54,12 @@ When(/^I send a GET request to the home page$/) do
 end
 
 
+When(/^I send a GET request to "([^\"]*)"$/) do |path|
+  @response = RestClient.get("#{store.last_domain}#{path}"){|response, request, result| response }  # Don't raise exceptions but return the response
+      store.last_response = @response
+end
+
+
 Then /^the response code should be "([^\"]*)"$/ do |status|
   store.last_response.code.should == status.to_i
 end


### PR DESCRIPTION
The admin frontend app immediately redirects the user to the /login
route.