### PR TITLE
/_status endpoint tests

### DIFF
--- a/features/apps_are_up.feature
+++ b/features/apps_are_up.feature
@@ -7,7 +7,7 @@ Feature: Apps are up
     When I send a GET request with authorization to "/services"
     Then the response code should be "200"
     And the response should contain a JSON list of "services"
-   
+
   @search-api
   Scenario: Check the search API is up
     Given I have a URL for "dm_search_api"
@@ -25,7 +25,7 @@ Feature: Apps are up
   @supplier-frontend
   Scenario: Check the supplier frontend is up
     Given I have a URL for "dm_supplier_frontend"
-    When I send a GET request to the home page
+    When I send a GET request to "/supplier/"
     Then the response code should be "200"
 
   @admin-frontend

--- a/features/apps_status.feature
+++ b/features/apps_status.feature
@@ -1,0 +1,31 @@
+Feature: Apps /_status is ok
+
+  @status @api
+  Scenario: Check the data API /_status
+    Given I have a URL for "dm_api"
+    When I send a GET request to the status page
+    Then the response JSON field "status" should be "ok"
+
+  @status @search-api
+  Scenario: Check the search API /_status
+    Given I have a URL for "dm_search_api"
+    When I send a GET request to the status page
+    Then the response JSON field "status" should be "ok"
+
+  @status @buyer-frontend
+  Scenario: Check the buyer frontend /_status
+    Given I have a URL for "dm_buyer_frontend"
+    When I send a GET request to the status page
+    Then the response JSON field "status" should be "ok"
+
+  @status @supplier-frontend
+  Scenario: Check the supplier frontend /_status
+    Given I have a URL for "dm_supplier_frontend"
+    When I send a GET request to the status page
+    Then the response JSON field "status" should be "ok"
+
+  @status @admin-frontend
+  Scenario: Check the admin frontend /_status
+    Given I have a URL for "dm_admin_frontend"
+    When I send a GET request to the status page
+    Then the response JSON field "status" should be "ok"

--- a/features/step_definitions/api_steps.rb
+++ b/features/step_definitions/api_steps.rb
@@ -51,6 +51,12 @@ When(/^I send a GET request to the home page$/) do
       @last_response = @response
 end
 
+When(/^I send a GET request to the status page$/) do
+  @response = RestClient.get("#{@last_domain}/_status") { |response| response }
+  puts "Release version: " + JSON.parse(@response)["version"]
+  @last_response = @response
+end
+
 
 When(/^I send a GET request to "([^\"]*)"$/) do |path|
   @response = RestClient.get("#{@last_domain}#{path}"){|response, request, result| response }  # Don't raise exceptions but return the response
@@ -67,6 +73,11 @@ Then /^the response should contain a JSON list of "([^\"]*)"$/ do |list_name|
   top_level_list = json["#{list_name}"]
   assert_not_nil (top_level_list)
   top_level_list.class.should == Array
+end
+
+Then /^the response JSON field "([^\"]*)" should be "([^\"]*)"$/ do |field, value|
+  json = JSON.parse(@last_response.body)
+  assert_equal json[field], value
 end
 
 Then /^the response should contain a JSON object "([^\"]*)"$/ do |object_key|

--- a/features/step_definitions/api_steps.rb
+++ b/features/step_definitions/api_steps.rb
@@ -19,48 +19,48 @@ end
 
 
 Then /^The new json file has a new service name$/ do
-    assert_equal @json['services']['serviceName'].start_with?("NEW NAME "),true
+  assert_equal @json['services']['serviceName'].start_with?("NEW NAME "),true
 end
 
 
 Given /^I have a URL for "([^\"]*)"$/ do |app|
-    app_domain= eval "#{app}_domain"
-    assert_not_nil("#{app_domain}", "No URL supplied for #{app}")
-    puts("DOMAIN  : #{app_domain}")
-    @last_domain = app_domain
+  app_domain= eval "#{app}_domain"
+  assert_not_nil("#{app_domain}", "No URL supplied for #{app}")
+  puts("DOMAIN  : #{app_domain}")
+  @last_domain = app_domain
 end
 
 
 Given /^I have an auth token for "([^\"]*)"$/ do |app|
-    app_token= eval "#{app}_access_token"
-    assert_not_nil("#{app_token}", "No access token supplied for #{app}")
-    puts("ACCESS TOKEN: #{app_token}")
-    @last_token = app_token
+  app_token= eval "#{app}_access_token"
+  assert_not_nil("#{app_token}", "No access token supplied for #{app}")
+  puts("ACCESS TOKEN: #{app_token}")
+  @last_token = app_token
 end
 
 
 When /^I send a GET request with authorization to "([^\"]*)"$/ do |path|
-    @response = RestClient.get("#{@last_domain}#{path}",
-      authorization: "Bearer #{@last_token}"){|response, request, result| response }  # Don't raise exceptions but return the response
-    @last_response = @response
+  response = RestClient.get("#{@last_domain}#{path}",
+    authorization: "Bearer #{@last_token}"){|response, request, result| response }  # Don't raise exceptions but return the response
+  @last_response = response
 end
 
 
 When(/^I send a GET request to the home page$/) do
-  @response = RestClient.get("#{@last_domain}"){|response, request, result| response }  # Don't raise exceptions but return the response
-      @last_response = @response
+  response = RestClient.get("#{@last_domain}"){|response, request, result| response }  # Don't raise exceptions but return the response
+  @last_response = response
 end
 
 When(/^I send a GET request to the status page$/) do
-  @response = RestClient.get("#{@last_domain}/_status") { |response| response }
-  puts "Release version: " + JSON.parse(@response)["version"]
-  @last_response = @response
+  response = RestClient.get("#{@last_domain}/_status") { |response| response }
+  puts "Release version: " + JSON.parse(response)["version"]
+  @last_response = response
 end
 
 
 When(/^I send a GET request to "([^\"]*)"$/) do |path|
-  @response = RestClient.get("#{@last_domain}#{path}"){|response, request, result| response }  # Don't raise exceptions but return the response
-      @last_response = @response
+  response = RestClient.get("#{@last_domain}#{path}"){|response, request, result| response }  # Don't raise exceptions but return the response
+  @last_response = response
 end
 
 

--- a/features/step_definitions/api_steps.rb
+++ b/features/step_definitions/api_steps.rb
@@ -5,23 +5,21 @@ require "test/unit"
 
 include Test::Unit::Assertions
 
-store = OpenStruct.new
-
 
 Given /^I have opened a json file$/ do
   file = File.read('./fixtures/g6-test-iaas-service-upload.json')
   json = JSON.parse(file)
-  store.json = json
+  @json = json
 end
 
 
 When /^I update the service name of the stored json file$/ do
-  store.json['services']['serviceName'] = 'NEW NAME '+Time.now.strftime('%Y%m%d%H%M%S')
+  @json['services']['serviceName'] = 'NEW NAME '+Time.now.strftime('%Y%m%d%H%M%S')
 end
 
 
 Then /^The new json file has a new service name$/ do
-    assert_equal store.json['services']['serviceName'].start_with?("NEW NAME "),true
+    assert_equal @json['services']['serviceName'].start_with?("NEW NAME "),true
 end
 
 
@@ -29,7 +27,7 @@ Given /^I have a URL for "([^\"]*)"$/ do |app|
     app_domain= eval "#{app}_domain"
     assert_not_nil("#{app_domain}", "No URL supplied for #{app}")
     puts("DOMAIN  : #{app_domain}")
-    store.last_domain = app_domain
+    @last_domain = app_domain
 end
 
 
@@ -37,42 +35,41 @@ Given /^I have an auth token for "([^\"]*)"$/ do |app|
     app_token= eval "#{app}_access_token"
     assert_not_nil("#{app_token}", "No access token supplied for #{app}")
     puts("ACCESS TOKEN: #{app_token}")
-    store.last_token = app_token
+    @last_token = app_token
 end
 
 
 When /^I send a GET request with authorization to "([^\"]*)"$/ do |path|
-    @response = RestClient.get("#{store.last_domain}#{path}",
-      authorization: "Bearer #{store.last_token}"){|response, request, result| response }  # Don't raise exceptions but return the response
-    store.last_response = @response
+    @response = RestClient.get("#{@last_domain}#{path}",
+      authorization: "Bearer #{@last_token}"){|response, request, result| response }  # Don't raise exceptions but return the response
+    @last_response = @response
 end
 
 
 When(/^I send a GET request to the home page$/) do
-  @response = RestClient.get("#{store.last_domain}"){|response, request, result| response }  # Don't raise exceptions but return the response
-      store.last_response = @response
+  @response = RestClient.get("#{@last_domain}"){|response, request, result| response }  # Don't raise exceptions but return the response
+      @last_response = @response
 end
 
 
 When(/^I send a GET request to "([^\"]*)"$/) do |path|
-  @response = RestClient.get("#{store.last_domain}#{path}"){|response, request, result| response }  # Don't raise exceptions but return the response
-      store.last_response = @response
+  @response = RestClient.get("#{@last_domain}#{path}"){|response, request, result| response }  # Don't raise exceptions but return the response
+      @last_response = @response
 end
 
 
 Then /^the response code should be "([^\"]*)"$/ do |status|
-  store.last_response.code.should == status.to_i
+  @last_response.code.should == status.to_i
 end
 
-
 Then /^the response should contain a JSON list of "([^\"]*)"$/ do |list_name|
-  json = JSON.parse(store.last_response.body)
+  json = JSON.parse(@last_response.body)
   top_level_list = json["#{list_name}"]
   assert_not_nil (top_level_list)
   top_level_list.class.should == Array
 end
 
 Then /^the response should contain a JSON object "([^\"]*)"$/ do |object_key|
-  json = JSON.parse(store.last_response.body)
+  json = JSON.parse(@last_response.body)
   assert_not_nil (json["#{object_key}"])
 end


### PR DESCRIPTION
Replaces global store with instance variables and adds separate tests for the /_status endpoints for each app. I'll set up the CI to run the /_status tests first, that way the report will always contain the current release version for all apps.