### PR TITLE
Update supplier app check to "/_status"

### DIFF
--- a/features/apps_are_up.feature
+++ b/features/apps_are_up.feature
@@ -25,7 +25,7 @@ Feature: Apps are up
   @supplier-frontend
   Scenario: Check the supplier frontend is up
     Given I have a URL for "dm_supplier_frontend"
-    When I send a GET request to the home page
+    When I send a GET request to "/_status"
     Then the response code should be "200"
 
   @admin-frontend


### PR DESCRIPTION
The supplier app home page returns 404 without authorization.  Checking the _status endpoint allows us to test app is up without needing auth.

Once we have supplier data imported we can update the tests to log in.