### PR TITLE
Mask part of the access_token in the report output

### DIFF
--- a/features/step_definitions/api_steps.rb
+++ b/features/step_definitions/api_steps.rb
@@ -34,7 +34,7 @@ end
 Given /^I have an auth token for "([^\"]*)"$/ do |app|
   app_token= eval "#{app}_access_token"
   assert_not_nil("#{app_token}", "No access token supplied for #{app}")
-  puts("ACCESS TOKEN: #{app_token}")
+  puts("ACCESS TOKEN: #{app_token[0..2]}***#{app_token[-3..-1]}")
   @last_token = app_token
 end
 


### PR DESCRIPTION
It's useful to have the first and last characters of the access token in the report to make sure token is the one we expect and is complete, but we can get probably away without outputting the full token.