### PR TITLE
Changed path on supplier test

### DIFF
--- a/features/apps_are_up.feature
+++ b/features/apps_are_up.feature
@@ -25,7 +25,7 @@ Feature: Apps are up
   @supplier-frontend
   Scenario: Check the supplier frontend is up
     Given I have a URL for "dm_supplier_frontend"
-    When I send a GET request to "/supplier/"
+    When I send a GET request to "/suppliers/login"
     Then the response code should be "200"
 
   @admin-frontend


### PR DESCRIPTION
This is as the root url is no longer valid and 'app is up' checks should look for the login page