### PR TITLE
Single frontend domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,4 +45,4 @@ The test environment can be controlled with environment variables
 | `DM_API_ACCESS_TOKEN`          | API Access Token           | myToken               |
 | `DM_SEARCH_API_DOMAIN`         | Search API Domain          | http://localhost:5001 |
 | `DM_SEARCH_API_ACCESS_TOKEN`   | Search API Access Token    | myToken               |
-| `DM_FRONTEND_DOMAIN`           | Frontend domain            | http://localhost:5002 |
+| `DM_FRONTEND_DOMAIN`           | Frontend domain            |                       |

--- a/README.md
+++ b/README.md
@@ -45,6 +45,4 @@ The test environment can be controlled with environment variables
 | `DM_API_ACCESS_TOKEN`          | API Access Token           | myToken               |
 | `DM_SEARCH_API_DOMAIN`         | Search API Domain          | http://localhost:5001 |
 | `DM_SEARCH_API_ACCESS_TOKEN`   | Search API Access Token    | myToken               |
-| `DM_BUYER_FRONTEND_DOMAIN`     | Buyer frontend domain      | http://localhost:5002 |
-| `DM_SUPPLIER_FRONTEND_DOMAIN`  | Supplier frontend domain   | http://localhost:5003 |
-| `DM_ADMIN_FRONTEND_DOMAIN`     | Admin frontend domain      | http://localhost:5004 |
+| `DM_FRONTEND_DOMAIN`           | Frontend domain            | http://localhost:5002 |

--- a/features/apps_are_up.feature
+++ b/features/apps_are_up.feature
@@ -18,18 +18,18 @@ Feature: Apps are up
 
   @buyer-frontend
   Scenario: Check the buyer frontend is up
-    Given I have a URL for "dm_buyer_frontend"
+    Given I have a URL for "dm_frontend"
     When I send a GET request to the home page
     Then the response code should be "200"
 
   @supplier-frontend
   Scenario: Check the supplier frontend is up
-    Given I have a URL for "dm_supplier_frontend"
+    Given I have a URL for "dm_frontend"
     When I send a GET request to "/suppliers/login"
     Then the response code should be "200"
 
   @admin-frontend
   Scenario: Check the admin frontend is up
-    Given I have a URL for "dm_admin_frontend"
+    Given I have a URL for "dm_frontend"
     When I send a GET request to "/admin/login"
     Then the response code should be "200"

--- a/features/apps_status.feature
+++ b/features/apps_status.feature
@@ -3,29 +3,29 @@ Feature: Apps /_status is ok
   @status @api
   Scenario: Check the data API /_status
     Given I have a URL for "dm_api"
-    When I send a GET request to the status page
+    When I send a GET request to the "/" status page
     Then the response JSON field "status" should be "ok"
 
   @status @search-api
   Scenario: Check the search API /_status
     Given I have a URL for "dm_search_api"
-    When I send a GET request to the status page
+    When I send a GET request to the "/" status page
     Then the response JSON field "status" should be "ok"
 
   @status @buyer-frontend
-  Scenario: Check the buyer frontend /_status
-    Given I have a URL for "dm_buyer_frontend"
-    When I send a GET request to the status page
+  Scenario: Check the buyers frontend /_status
+    Given I have a URL for "dm_frontend"
+    When I send a GET request to the "/" status page
     Then the response JSON field "status" should be "ok"
 
   @status @supplier-frontend
-  Scenario: Check the supplier frontend /_status
-    Given I have a URL for "dm_supplier_frontend"
-    When I send a GET request to the status page
+  Scenario: Check the suppliers frontend /_status
+    Given I have a URL for "dm_frontend"
+    When I send a GET request to the "/suppliers/" status page
     Then the response JSON field "status" should be "ok"
 
   @status @admin-frontend
   Scenario: Check the admin frontend /_status
-    Given I have a URL for "dm_admin_frontend"
-    When I send a GET request to the status page
+    Given I have a URL for "dm_frontend"
+    When I send a GET request to the "/admin/" status page
     Then the response JSON field "status" should be "ok"

--- a/features/step_definitions/api_steps.rb
+++ b/features/step_definitions/api_steps.rb
@@ -51,8 +51,8 @@ When(/^I send a GET request to the home page$/) do
   @last_response = response
 end
 
-When(/^I send a GET request to the status page$/) do
-  response = RestClient.get("#{@last_domain}/_status") { |response| response }
+When(/^I send a GET request to the "([\"]*)" status page$/) do |path|
+  response = RestClient.get("#{@last_domain}#{path}_status") { |response| response }
   puts "Release version: " + JSON.parse(response)["version"]
   @last_response = response
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -45,16 +45,8 @@ def dm_search_api_access_token()
   ENV['DM_SEARCH_API_ACCESS_TOKEN'] || 'myToken'
 end
 
-def dm_buyer_frontend_domain()
-  ENV['DM_BUYER_FRONTEND_DOMAIN'] || 'http://localhost:5002'
-end
-
-def dm_supplier_frontend_domain()
-  ENV['DM_SUPPLIER_FRONTEND_DOMAIN'] || 'http://localhost:5003'
-end
-
-def dm_admin_frontend_domain()
-  ENV['DM_ADMIN_FRONTEND_DOMAIN'] || 'http://localhost:5004'
+def dm_frontend_domain()
+  ENV['DM_FRONTEND_DOMAIN'] || 'http://localhost:5002'
 end
 
 Capybara::Screenshot.prune_strategy = { keep: 100 }

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -46,7 +46,7 @@ def dm_search_api_access_token()
 end
 
 def dm_frontend_domain()
-  ENV['DM_FRONTEND_DOMAIN'] || 'http://localhost:5002'
+  ENV['DM_FRONTEND_DOMAIN']
 end
 
 Capybara::Screenshot.prune_strategy = { keep: 100 }


### PR DESCRIPTION
Preview and production environments no longer have public per-app
domains. Instead, there's a single domain for all frontend apps.

The frontend status pages have moved to /_status, /admin/_status, and /suppliers/_status