### PR TITLE
Updated link to be framework then servcie

### DIFF
--- a/features/step_definitions/journey_test_steps.rb
+++ b/features/step_definitions/journey_test_steps.rb
@@ -364,7 +364,7 @@ end
 
 #Visit service link currently not set to go to correct place.
 Then /I am presented with the service details page for that service$/ do
-  visit("#{dm_frontend_domain}/services/#{@serviceID}")
+  visit("#{dm_frontend_domain}/g-cloud/services/#{@serviceID}")
   current_url.should end_with("#{dm_frontend_domain}/services/#{@serviceID}")
   page.should have_content(@existing_values['servicename'])
   page.should have_content(@existing_values['servicesummary'])


### PR DESCRIPTION
Changed path to be framework then service:

/g-cloud/services/{:id}

Matches new URLs.