### PR TITLE
Use the not-production tag for smoke tests

### DIFF
--- a/features/smoke_tests.feature
+++ b/features/smoke_tests.feature
@@ -1,6 +1,6 @@
 @smoke-test
 Feature: Smoke tests
-@smoke-test-not-production
+@not-production
 Scenario: As supplier user I wish be able to log in and to log out of Digital Marketplace
   Given I am on the 'Supplier' login page
   When I login as a 'Supplier' user


### PR DESCRIPTION
Rather than having different tags for different cases of not running on
production use just one so that it's easier to switch off tests in
production.