### PR TITLE
Random service smoke tests

### DIFF
--- a/features/smoke_tests.feature
+++ b/features/smoke_tests.feature
@@ -39,15 +39,20 @@ Scenario: User selects SCS lot from the g-cloud page is presented with search re
 
 Scenario: User able to search by service ID and have result returned
   Given I am on the 'Cloud technology and support' landing page
-  When I enter '1123456789012346' in the 'q' field
+  And I have a random service from the API
+  When I enter that service.id in the 'q' field
   And I click 'Show services'
-  Then I am taken to the search results page with a result for the service '1123456789012346'
+  Then I am on a page with that service.id in search summary text
+  And There is 1 search result
+  And I am on a page with that service in search results
 
 Scenario: User is able to search by service name and have result returned.
   Given I am on the 'Cloud technology and support' landing page
-  When I enter '1123456789012346 DM Functional Test N3 Secure Remote Access' in the 'q' field
+  And I have a random service from the API
+  When I enter that service.serviceName in the 'q' field
   And I click 'Show services'
-  Then I am taken to the search results page with a result for the service '1123456789012346 DM Functional Test N3 Secure Remote Access'
+  Then I am on a page with that service.serviceName in search summary text
+  And I am on a page with that service in search results
 
 Scenario: User is able to navigate to service listing page via selecting the service from the search results
   Given I am on the search results page with results for 'Platform as a Service' lot displayed
@@ -55,7 +60,11 @@ Scenario: User is able to navigate to service listing page via selecting the ser
   Then I am taken to the service listing page of that specific record selected
 
 Scenario: User able to search by keywords field on the search results page to narrow down the results returned
-  Given I am on the search results page with results for 'Infrastructure as a Service' lot displayed
-  When I enter '1123456789012346' in the 'q' field
+  Given I have a random service from the API
+  Given I am on the search results page with results for that service.lot displayed
+  When I enter that service.id in the 'q' field
   And I click 'Filter'
-  Then The search results is filtered returning just one result for the service '1123456789012346'
+  Then I am on a page with that service.id in search summary text
+  And There is 1 search result
+  And Selected lot is that service.lot with links to the search for that service.id
+  And I am on a page with that service in search results

--- a/features/step_definitions/api_steps.rb
+++ b/features/step_definitions/api_steps.rb
@@ -24,6 +24,15 @@ Then /^The new json file has a new service name$/ do
 end
 
 
+Given /^I have a random service from the API$/ do
+  response = RestClient.get("#{dm_api_domain}/services?page=#{1 + rand(100)}",
+    authorization: "Bearer #{dm_api_access_token}")
+  @service = JSON.parse(response)['services'][rand(100)]
+  puts "Service ID: #{@service['id']}"
+  puts "Service name: #{@service['serviceName']}"
+end
+
+
 Given /^I have a URL for "([^\"]*)"$/ do |app|
   app_domain= eval "#{app}_domain"
   assert_not_nil("#{app_domain}", "No URL supplied for #{app}")

--- a/features/support/helpers.rb
+++ b/features/support/helpers.rb
@@ -1,0 +1,11 @@
+LOTS = {
+  all: 'All categories',
+  SaaS: 'Software as a Service',
+  PaaS: 'Platform as a Service',
+  IaaS: 'Infrastructure as a Service',
+  SCS: 'Specialist Cloud Services'
+}
+
+def full_lot(lot)
+  LOTS[lot.to_sym]
+end

--- a/features/support/patches.rb
+++ b/features/support/patches.rb
@@ -1,0 +1,7 @@
+module Capybara::Poltergeist
+  class Driver
+    def current_url
+      browser.current_url.gsub('%25', '%')
+    end
+  end
+end


### PR DESCRIPTION
### Add a step to retrieve a random service data from the API
Selects a random page from the API services list and returns data
for one of the services.

Service data is stored in `@service`. Since this creates a variable
dependency between this API step and any step that relies on the
`@service` being set I suggest we use `that service` in any steps
that use `@service`, e.g.:

    Then I can search for that service
    When I enter that service.id in the 'q' field
    Then I am on a page with that service in search results

This way `that service` always refers to full service data stored in
`@service`. The service doesn't need to be random, so any steps that
create or request from API full or partial service data should store
it in `@service` as long as the key names match the ones in API
response.

### Change smoke tests to use random service from the API
Instead of using a preset service that doesn't exist in production
use a randomly selected service to test buyer-frontend search and
filtering.

Since some of the steps were relying on the given service data for
some of the checks (e.g. service supplier and lot) changing them to
work with the randomly selected service required splitting some of the
steps.

Individual steps that require few fields (e.g. "Selected lot") have a
generic version that accepts the data directly and "that service"
version that takes the relevant value from `@service` data and uses it
to call the generic step.

### Add support/helpers.rb and G-Cloud LOTS mapping
`full_lot` allows converting lot abbreviation to full lot names.
`LOTS` can be used to check that lot links are in place since it
includes 'All categories'.

### Add a support/patches.rb file with fix for current_url double escape
Poltergeist capybara driver returns `current_url` that was encoded
twice. E.g. '%' in query string becomes '%2525' instead of '%25'.

(teampoltergeist/poltergeist#418)

This is fixed in the master branch, but not in the current 1.6 release.

The patch replaces `current_url` method with the one that returns a
decoded value by changing all instances of '%25' to '%'. This should
be removed once poltergeist is updated to the release that includes
the master fix.