### PR TITLE
account for double spaces in service or supplier names and added supplier login scenario to smoke test

### DIFF
--- a/features/smoke_tests.feature
+++ b/features/smoke_tests.feature
@@ -4,10 +4,10 @@ Feature: Smoke tests
 Scenario: As supplier user I wish be able to log in and to log out of Digital Marketplace
   Given I am on the 'Supplier' login page
   When I login as a 'Supplier' user
-  Then I am presented with the 'DM Functional Test Supplier' supplier dashboard page
+  Then I am presented with the 'Digital Marketplace Team' supplier dashboard page
 
-  When I click 'View'
-  Then I am presented with the 'DM Functional Test Supplier' supplier service listings page
+#  When I click 'View'
+#  Then I am presented with the 'DM Functional Test Supplier' supplier service listings page
 
   When I click 'Log out'
   Then I am logged out of Digital Marketplace as a 'Supplier' user

--- a/features/smoke_tests.feature
+++ b/features/smoke_tests.feature
@@ -1,6 +1,6 @@
 @smoke-test
 Feature: Smoke tests
-@not-production
+
 Scenario: As supplier user I wish be able to log in and to log out of Digital Marketplace
   Given I am on the 'Supplier' login page
   When I login as a 'Supplier' user

--- a/features/step_definitions/journey_test_steps.rb
+++ b/features/step_definitions/journey_test_steps.rb
@@ -417,6 +417,10 @@ Then /I am presented with the '(.*)' supplier dashboard page$/ do |supplier_name
   page.should have_content(eval "dm_supplier_uname")
   current_url.should end_with("#{dm_frontend_domain}/suppliers")
   page.should have_selector(:xpath, ".//*[@id='global-breadcrumb']//*[@role='breadcrumbs']//li[1]//*[contains(text(), 'Digital Marketplace')]")
+
+  if supplier_name == 'Digital Marketplace Team'
+    page.should have_content('You don\'t have any services on the Digital Marketplace')
+  end
 end
 
 Given /I am logged in as a '(.*)' '(.*)' user and am on the dashboard page$/ do |supplier_name,user_type|
@@ -744,8 +748,6 @@ Then /I am on a page with that service\.(.*) in search summary text$/ do |attr_n
 end
 
 Then /I am on a page with '(.*)' in search summary text$/ do |value|
-  puts value
-  puts value.gsub('  ',' ')
   query_string = CGI.escape value.gsub('  ',' ')
   current_url.should include("q=#{query_string}")
 

--- a/features/step_definitions/journey_test_steps.rb
+++ b/features/step_definitions/journey_test_steps.rb
@@ -744,7 +744,9 @@ Then /I am on a page with that service\.(.*) in search summary text$/ do |attr_n
 end
 
 Then /I am on a page with '(.*)' in search summary text$/ do |value|
-  query_string = CGI.escape value
+  puts value
+  puts value.gsub('  ',' ')
+  query_string = CGI.escape value.gsub('  ',' ')
   current_url.should include("q=#{query_string}")
 
   find(:xpath, "//*[@class='search-summary']/em[1]").text().should == value
@@ -806,8 +808,8 @@ Then /I am on a page with that service in search results$/ do
   search_results = all(:xpath, ".//div[@class='search-result']")
   service_result = search_results.find { |r| r.first(:xpath, './h2/a')[:href].include? @service['id']}
 
-  service_result.first(:xpath, "./h2[@class='search-result-title']/a").text.should == @service['serviceName']
-  service_result.first(:xpath, "./p[@class='search-result-supplier']").text.should == @service['supplierName']
+  service_result.first(:xpath, "./h2[@class='search-result-title']/a").text.should == @service['serviceName'].gsub('  ',' ')
+  service_result.first(:xpath, "./p[@class='search-result-supplier']").text.should == @service['supplierName'].gsub('  ',' ')
   service_result.first(:xpath, ".//li[@class='search-result-metadata-item'][1]").text.should == full_lot(@service['lot'])
   service_result.first(:xpath, ".//li[@class='search-result-metadata-item'][2]").text.should == @service['frameworkName']
 end


### PR DESCRIPTION
Added test supplier login scenario for smoke test. NOTE: jenkins smoke test config updated to include supplier login credentials.
Some supplier and service names in JSON have double spaces and this is resulting in the tests failing when checking for these on the page.
Fi applied replaces instances of double spaces with a single space