### PR TITLE
Normalize whitespace in .text comparisons

### DIFF
--- a/features/step_definitions/journey_test_steps.rb
+++ b/features/step_definitions/journey_test_steps.rb
@@ -748,7 +748,7 @@ Then /I am on a page with that service\.(.*) in search summary text$/ do |attr_n
 end
 
 Then /I am on a page with '(.*)' in search summary text$/ do |value|
-  query_string = CGI.escape value.gsub('  ',' ')
+  query_string = CGI.escape value
   current_url.should include("q=#{query_string}")
 
   find(:xpath, "//*[@class='search-summary']/em[1]").text().should == value
@@ -810,8 +810,8 @@ Then /I am on a page with that service in search results$/ do
   search_results = all(:xpath, ".//div[@class='search-result']")
   service_result = search_results.find { |r| r.first(:xpath, './h2/a')[:href].include? @service['id']}
 
-  service_result.first(:xpath, "./h2[@class='search-result-title']/a").text.should == @service['serviceName'].gsub('  ',' ')
-  service_result.first(:xpath, "./p[@class='search-result-supplier']").text.should == @service['supplierName'].gsub('  ',' ')
+  service_result.first(:xpath, "./h2[@class='search-result-title']/a").text.should == normalize_whitespace(@service['serviceName'])
+  service_result.first(:xpath, "./p[@class='search-result-supplier']").text.should == normalize_whitespace(@service['supplierName'])
   service_result.first(:xpath, ".//li[@class='search-result-metadata-item'][1]").text.should == full_lot(@service['lot'])
   service_result.first(:xpath, ".//li[@class='search-result-metadata-item'][2]").text.should == @service['frameworkName']
 end

--- a/features/support/helpers.rb
+++ b/features/support/helpers.rb
@@ -1,3 +1,5 @@
+require 'capybara/helpers'
+
 LOTS = {
   all: 'All categories',
   SaaS: 'Software as a Service',
@@ -8,4 +10,8 @@ LOTS = {
 
 def full_lot(lot)
   LOTS[lot.to_sym]
+end
+
+def normalize_whitespace(text)
+  Capybara::Helpers.normalize_whitespace(text)
 end


### PR DESCRIPTION
Capybara Node.text methods normalizes whitespace, removing leading
and trailing spaces and merging repeating spaces.

This means that to match `.text` we need to normalize whitespace
too.