### PR TITLE
add delay in attempt to fix intermittent preview functional test failure

### DIFF
--- a/features/step_definitions/journey_test_steps.rb
+++ b/features/step_definitions/journey_test_steps.rb
@@ -381,8 +381,6 @@ Then /I am presented with the dashboard page with the changes that were made to 
 end
 
 Then /I am presented with the summary page with the changes that were made to the '(.*)'$/ do |service_aspect|
-  sleep 1
-  current_url.should end_with(@existing_values['summarypageurl'])
   if service_aspect == 'Description'
     page.should have_content(@changed_fields['serviceName'])
     page.should have_content(@changed_fields['serviceSummary'])
@@ -431,6 +429,7 @@ Then /I am presented with the summary page with the changes that were made to th
       raise "The pricing document has not been changed as expected"
     end
   end
+  current_url.should end_with(@existing_values['summarypageurl'])
 end
 
 When /I change '(.*)' file to '(.*)'$/ do |document_to_change,new_document|

--- a/features/step_definitions/journey_test_steps.rb
+++ b/features/step_definitions/journey_test_steps.rb
@@ -381,6 +381,7 @@ Then /I am presented with the dashboard page with the changes that were made to 
 end
 
 Then /I am presented with the summary page with the changes that were made to the '(.*)'$/ do |service_aspect|
+  sleep 1
   current_url.should end_with(@existing_values['summarypageurl'])
   if service_aspect == 'Description'
     page.should have_content(@changed_fields['serviceName'])


### PR DESCRIPTION
Getting intermittent failures when page expected is not presented in time. Added "Sleep 1" to delay checking of the page existence