### PR TITLE
Make xpath for supplier update more specific

### DIFF
--- a/features/step_definitions/journey_test_steps.rb
+++ b/features/step_definitions/journey_test_steps.rb
@@ -333,50 +333,50 @@ Then /I am presented with the dashboard page with the changes that were made to 
 
   find(
     :xpath,
-    "//*[contains(text(), 'Supplier summary')]/../../td[2]/span"
+    "//caption[contains(text(), '#{service_aspect}')]/..//*[contains(text(), 'Supplier summary')]/../../td[2]/span"
   ).text().should have_content(@changed_fields['description'])
   find(
     :xpath,
-    "//*[contains(text(), 'Clients')]/../..//li[2]"
+    "//caption[contains(text(), '#{service_aspect}')]/..//*[contains(text(), 'Clients')]/../..//li[2]"
   ).text().should have_content(@changed_fields['clients-3'])
   page.should have_no_content(@changed_fields['clients-2'])
   find(
     :xpath,
-    "//*[contains(text(), 'Clients')]/../..//li[3]"
+    "//caption[contains(text(), '#{service_aspect}')]/..//*[contains(text(), 'Clients')]/../..//li[3]"
   ).text().should have_content(@changed_fields['clients'])
 
   find(
     :xpath,
-    "//*[contains(text(), 'Contact name')]/../../td[2]/span"
+    "//caption[contains(text(), '#{service_aspect}')]/..//*[contains(text(), 'Contact name')]/../../td[2]/span"
   ).text().should have_content(@changed_fields['contact_contactName'])
   find(
     :xpath,
-    "//*[contains(text(), 'Website')]/../../td[2]/span"
+    "//caption[contains(text(), '#{service_aspect}')]/..//*[contains(text(), 'Website')]/../../td[2]/span"
   ).text().should have_content(@changed_fields['contact_website'])
   find(
     :xpath,
-    "//*[contains(text(), '#{service_aspect}')]/..//*[contains(text(), 'Email address')]/../../td[2]/span"
+    "//caption[contains(text(), '#{service_aspect}')]/..//*[contains(text(), 'Email address')]/../../td[2]/span"
   ).text().should have_content(@changed_fields['contact_email'])
   find(
     :xpath,
-    "//*[contains(text(), 'Phone number')]/../../td[2]/span"
+    "//caption[contains(text(), '#{service_aspect}')]/..//*[contains(text(), 'Phone number')]/../../td[2]/span"
   ).text().should have_content(@changed_fields['contact_phoneNumber'])
 
   find(
     :xpath,
-    "//*[contains(text(), 'Address')]/../../td[2]/span"
+    "//caption[contains(text(), '#{service_aspect}')]/..//*[contains(text(), 'Address')]/../../td[2]/span"
   ).text().should have_content(@changed_fields['contact_address1'])
   find(
     :xpath,
-    "//*[contains(text(), 'Address')]/../../td[2]/span"
+    "//caption[contains(text(), '#{service_aspect}')]/..//*[contains(text(), 'Address')]/../../td[2]/span"
   ).text().should have_content(@changed_fields['contact_city'])
   find(
     :xpath,
-    "//*[contains(text(), 'Address')]/../../td[2]/span"
+    "//caption[contains(text(), '#{service_aspect}')]/..//*[contains(text(), 'Address')]/../../td[2]/span"
   ).text().should have_content(@changed_fields['contact_country'])
   find(
     :xpath,
-    "//*[contains(text(), 'Address')]/../../td[2]/span"
+    "//caption[contains(text(), '#{service_aspect}')]/..//*[contains(text(), 'Address')]/../../td[2]/span"
   ).text().should have_content(@changed_fields['contact_postcode'])
 end
 


### PR DESCRIPTION
The xpath was too general and matching multiple elements on the supplier dashboard page.
This ties the xpath lookup to the table specified by the `service_path`.

Fixes this bug:
![screen shot 2015-08-06 at 14 24 16](https://cloud.githubusercontent.com/assets/2454380/9112515/de62da66-3c46-11e5-8835-4fac51fc7286.png)
