### PR TITLE
Only request published services when choosing a random service

### DIFF
--- a/features/step_definitions/api_steps.rb
+++ b/features/step_definitions/api_steps.rb
@@ -25,8 +25,11 @@ end
 
 
 Given /^I have a random service from the API$/ do
-  response = RestClient.get("#{dm_api_domain}/services?page=#{1 + rand(100)}",
-    authorization: "Bearer #{dm_api_access_token}")
+  response = RestClient.get(
+    "#{dm_api_domain}/services",
+    params: {page: 1 + rand(100), status: "published"},
+    authorization: "Bearer #{dm_api_access_token}"
+  )
   @service = JSON.parse(response)['services'][rand(100)]
   puts "Service ID: #{@service['id']}"
   puts "Service name: #{@service['serviceName']}"


### PR DESCRIPTION
By default API returns all services from the /services endpoint,
so when a test chooses a random service it could end up with a
disabled or unpublished one, which aren't returned by the search
api and are invisible in the buyer frontend.

Setting a status filter on the API request makes sure that the
selected service will always have a "published" status.

(Caveat: API doesn't return the total number of services for the
given request, so the range of pages is hardcoded. If the number
of published services drops below 10000 the step might fail to
select a random one. At the same time, any services > 10000 will
never be selected. This could be fixed by returning a service
count from the API or by using the search-api for random published
service selection.)