### PR TITLE
[##97631496] Add SSP create-draft features for all lots

### DIFF
--- a/features/ssp_iaas_service.feature
+++ b/features/ssp_iaas_service.feature
@@ -1,0 +1,489 @@
+@not-production @functional-test
+Feature: Submitting a new service for IaaS
+  In order to submit my services as a supplier user
+  I want to answer questions about my service
+
+  Background: Log in as a supplier
+    Given I am on the 'Supplier' login page
+    When I login as a 'Supplier' user
+    Then I should be on the supplier home page
+
+  Scenario: Select lot
+    Given I am at '/suppliers'
+    When I click 'Apply to become a G-Cloud 7 supplier and add services'
+    And I click 'Add a service'
+    When I choose 'Infrastructure as a Service (IaaS)'
+    And I click 'Save and continue'
+    Then I should be on the 'Service description' page
+
+
+  Scenario: Provide a service description
+    Given I am on ssp page 'service_description'
+    When I fill in 'serviceName' with 'My IaaS service'
+    And I fill in 'serviceSummary' with:
+      """
+      My IaaS service that does stuff with stuff.
+      """
+    And I click 'Save and continue'
+    Then I should be on the 'Service type' page
+
+  Scenario: Select a service type
+    Given I am on ssp page 'service_type'
+    When I check 'Compute'
+    And I click 'Save and continue'
+    Then I should be on the 'Features and benefits' page
+
+  Scenario: Features and benefits
+    Given I am on ssp page 'features_and_benefits'
+    When I fill in 'serviceFeatures-1' with 'Super greatness'
+    And I fill in 'serviceBenefits-1' with 'Great superness'
+    And I click 'Save and continue'
+    Then I should be on the 'Pricing' page
+    
+  Scenario: Pricing
+    Given I am on ssp page 'pricing'
+    When I fill in 'priceStringMinPrice' with '100'
+    And I fill in 'priceStringMaxPrice' with '1000'
+    And I select 'Unit' from 'priceStringUnit'
+    And I select 'Second' from 'priceStringInterval'
+    And I choose 'vatIncluded-yes'
+    And I choose 'educationPricing-no'
+    And I choose 'trialOption-yes'
+    And I choose 'freeOption-no'
+    And I click 'Save and continue'
+    Then I should be on the 'Terms and conditions' page
+
+  Scenario: Terms and conditions
+    Given I am on ssp page 'terms_and_conditions'
+    When I choose 'terminationCost-no'
+    And I choose 'minimumContractPeriod-3'
+    And I click 'Save and continue'
+    Then I should be on the 'Support' page
+
+  Scenario: Support
+    Given I am on ssp page 'support'
+    When I check 'Service desk'
+    And I choose 'supportForThirdParties-yes'
+    And I fill in 'supportAvailability' with '24/7'
+    And I fill in 'supportResponseTime' with '1 hour'
+    And I choose 'incidentEscalation-no'
+    And I click 'Save and continue'
+    Then I should be on the 'Open standards' page
+
+  Scenario: Open standards
+    Given I am on ssp page 'open_standards'
+    When I choose 'openStandardsSupported-yes'
+    And I click 'Save and continue'
+    Then I should be on the 'Onboarding and offboarding' page
+
+  Scenario: Onboarding and offboarding
+    Given I am on ssp page 'onboarding_and_offboarding'
+    When I choose 'serviceOnboarding-no'
+    And I choose 'serviceOffboarding-yes'
+    And I click 'Save and continue'
+    Then I should be on the 'Analytics' page
+
+  Scenario: Analytics
+    Given I am on ssp page 'analytics'
+    When I choose 'analyticsAvailable-no'
+    And I click 'Save and continue'
+    Then I should be on the 'Cloud features' page
+    
+  Scenario: Cloud features
+    Given I am on ssp page 'cloud_features'
+    When I choose 'elasticCloud-yes'
+    And I choose 'guaranteedResources-no'
+    And I choose 'persistentStorage-no'
+    And I click 'Save and continue'
+    Then I should be on the 'Provisioning' page
+
+  Scenario: Provisioning
+    Given I am on ssp page 'provisioning'
+    When I choose 'selfServiceProvisioning-yes'
+    And I fill in 'provisioningTime' with '5 hours'
+    And I fill in 'deprovisioningTime' with '6 hours'
+    And I click 'Save and continue'
+    Then I should be on the 'Open source' page
+
+  Scenario: Open source
+    Given I am on ssp page 'open_source'
+    When I choose 'openSource-yes'
+    And I click 'Save and continue'
+    Then I should be on the 'API access' page
+
+  Scenario: API access
+    Given I am on ssp page 'api_access'
+    When I choose 'apiAccess-yes'
+    And I fill in 'apiType' with 'JSON'
+    And I click 'Save and continue'
+    Then I should be on the 'Networks and connectivity' page
+
+  Scenario: Networks and connectivity
+    Given I am on ssp page 'networks_and_connectivity'
+    When I check 'Internet'
+    And I click 'Save and continue'
+    Then I should be on the 'Access' page
+
+  Scenario: Access
+    Given I am on ssp page 'access'
+    When I check 'Opera'
+    And I choose 'offlineWorking-yes'
+    And I check 'PC'
+    And I click 'Save and continue'
+    Then I should be on the 'Certifications' page
+
+  Scenario: Certifications
+    Given I am on ssp page 'certifications'
+    When I fill in 'vendorCertifications-1' with 'Stuff magic'
+    And I click 'Save and continue'
+    Then I should be on the 'Data storage' page
+
+  Scenario: Data storage
+    Given I am on ssp page 'data_storage'
+    When I choose 'datacentresEUCode-no'
+    And I choose 'datacentresSpecifyLocation-yes'
+    And I choose 'datacentreTier-5'
+    And I choose 'dataBackupRecovery-yes'
+    And I choose 'dataExtractionRemoval-yes'
+    And I click 'Save and continue'
+    Then I should be on the 'Data-in-transit protection' page
+
+  Scenario: Data-in-transit protection
+    Given I am on ssp page 'data_in_transit_protection'
+    When I check 'dataProtectionBetweenUserAndService-1'
+    And I choose 'dataProtectionBetweenUserAndService--assurance-2'
+    And I check 'dataProtectionWithinService-3'
+    And I choose 'dataProtectionWithinService--assurance-2'
+    And I check 'dataProtectionBetweenServices-1'
+    And I choose 'dataProtectionBetweenServices--assurance-4'
+    And I click 'Save and continue'
+    Then I should be on the 'Asset protection and resilience' page
+
+  Scenario: Asset protection and resilience
+    Given I am on ssp page 'asset_protection_and_resilience'
+    When I check 'datacentreLocations-1'
+    And I choose 'datacentreLocations--assurance-1'
+    And I check 'dataManagementLocations-1'
+    And I choose 'dataManagementLocations--assurance-1'
+    And I choose 'legalJurisdiction-1'
+    And I choose 'legalJurisdiction--assurance-1'
+    And I choose 'datacentreProtectionDisclosure-yes'
+    And I choose 'datacentreProtectionDisclosure--assurance-1'
+    And I check 'dataAtRestProtections-1'
+    And I choose 'dataAtRestProtections--assurance-1'
+    And I choose 'dataSecureDeletion-2'
+    And I choose 'dataSecureDeletion--assurance-1'
+    And I choose 'dataStorageMediaDisposal-1'
+    And I choose 'dataStorageMediaDisposal--assurance-1'
+    And I choose 'dataSecureEquipmentDisposal-yes'
+    And I choose 'dataSecureEquipmentDisposal--assurance-1'
+    And I choose 'dataRedundantEquipmentAccountsRevoked-no'
+    And I choose 'dataRedundantEquipmentAccountsRevoked--assurance-1'
+    And I fill in 'serviceAvailabilityPercentage' with '99.99'
+    And I choose 'serviceAvailabilityPercentage--assurance-1'
+    And I click 'Save and continue'
+    Then I should be on the 'Separation between consumers' page
+
+  Scenario: Separation between consumers
+    Given I am on ssp page 'separation_between_consumers'
+    When I choose 'cloudDeploymentModel-1'
+    And I choose 'cloudDeploymentModel--assurance-1'
+    And I choose 'otherConsumers-1'
+    And I choose 'otherConsumers--assurance-1'
+    And I choose 'servicesSeparation-yes'
+    And I choose 'servicesSeparation--assurance-1'
+    And I choose 'servicesManagementSeparation-yes'
+    And I choose 'servicesManagementSeparation--assurance-1'
+    And I click 'Save and continue'
+    Then I should be on the 'Governance' page
+
+  Scenario: Governance
+    Given I am on ssp page 'governance'
+    When I choose 'governanceFramework-yes'
+    And I choose 'governanceFramework--assurance-1'
+    And I click 'Save and continue'
+    Then I should be on the 'Configuration and change management' page
+
+  Scenario: Configuration and change management
+    Given I am on ssp page 'configuration_and_change_management'
+    When I choose 'configurationTracking-yes'
+    And I choose 'configurationTracking--assurance-1'
+    And I choose 'changeImpactAssessment-yes'
+    And I choose 'changeImpactAssessment--assurance-1'
+    And I click 'Save and continue'
+    Then I should be on the 'Vulnerabilility management' page
+
+  Scenario: Vulnerabilility management
+    Given I am on ssp page 'vulnerabilility_management'
+    When I choose 'vulnerabilityAssessment-yes'
+    And I choose 'vulnerabilityAssessment--assurance-1'
+    And I choose 'vulnerabilityMonitoring-yes'
+    And I choose 'vulnerabilityMonitoring--assurance-1'
+    And I choose 'vulnerabilityMitigationPrioritisation-no'
+    And I choose 'vulnerabilityMitigationPrioritisation--assurance-1'
+    And I choose 'vulnerabilityTracking-yes'
+    And I choose 'vulnerabilityTracking--assurance-1'
+    And I choose 'vulnerabilityTimescales-yes'
+    And I choose 'vulnerabilityTimescales--assurance-1'
+    And I click 'Save and continue'
+    Then I should be on the 'Event monitoring' page
+
+  Scenario: Event monitoring
+    Given I am on ssp page 'event_monitoring'
+    When I choose 'eventMonitoring-yes'
+    And I choose 'eventMonitoring--assurance-1'
+    And I click 'Save and continue'
+    Then I should be on the 'Incident management' page
+
+  Scenario: Incident management
+    Given I am on ssp page 'incident_management'
+    When I choose 'incidentManagementProcess-yes'
+    And I choose 'incidentManagementProcess--assurance-1'
+    And I choose 'incidentManagementReporting-no'
+    And I choose 'incidentManagementReporting--assurance-1'
+    And I choose 'incidentDefinitionPublished-yes'
+    And I choose 'incidentDefinitionPublished--assurance-1'
+    And I click 'Save and continue'
+    Then I should be on the 'Personnel security' page
+
+  @listing_page
+  Scenario: Go to listing page and the service is not complete
+    Given I am at the g7 supplier dashboard page
+    When I click my service
+    Then I should be on the 'My IaaS service' page
+    And The string 'Answer required' should be on the page
+    And The string 'The service is complete' should not be on the page
+
+  Scenario: Personnel security
+    Given I am on ssp page 'personnel_security'
+    When I check 'Security clearance national vetting (SC)'
+    And I choose 'personnelSecurityChecks--assurance-1'
+    And I click 'Save and continue'
+    Then I should be on the 'Secure development' page
+
+  Scenario: Secure development
+    Given I am on ssp page 'secure_development'
+    When I choose 'secureDevelopment-yes'
+    And I choose 'secureDevelopment--assurance-1'
+    And I choose 'secureDesign-yes'
+    And I choose 'secureDesign--assurance-1'
+    And I choose 'secureConfigurationManagement-yes'
+    And I choose 'secureConfigurationManagement--assurance-1'
+    And I click 'Save and continue'
+    Then I should be on the 'Supply-chain security' page
+
+  Scenario: Supply-chain security
+    Given I am on ssp page 'supply_chain_security'
+    When I choose 'thirdPartyDataSharingInformation-yes'
+    And I choose 'thirdPartyDataSharingInformation--assurance-1'
+    And I choose 'thirdPartySecurityRequirements-yes'
+    And I choose 'thirdPartySecurityRequirements--assurance-1'
+    And I choose 'thirdPartyRiskAssessment-yes'
+    And I choose 'thirdPartyRiskAssessment--assurance-1'
+    And I choose 'thirdPartyComplianceMonitoring-yes'
+    And I choose 'thirdPartyComplianceMonitoring--assurance-1'
+    And I choose 'hardwareSoftwareVerification-yes'
+    And I choose 'hardwareSoftwareVerification--assurance-1'
+    And I click 'Save and continue'
+    Then I should be on the 'Authentication of consumers' page
+
+  Scenario: Authentication of consumers
+    Given I am on ssp page 'authentication_of_consumers'
+    When I choose 'userAuthenticateManagement-yes'
+    And I choose 'userAuthenticateManagement--assurance-1'
+    And I choose 'userAuthenticateSupport-yes'
+    And I choose 'userAuthenticateSupport--assurance-1'
+    And I click 'Save and continue'
+    Then I should be on the 'Separation and access control within management interfaces' page
+
+  Scenario: Separation and access control within management interfaces
+    Given I am on ssp page 'separation_and_access_control_within_management_interfaces'
+    When I choose 'userAccessControlManagement-yes'
+    And I choose 'userAccessControlManagement--assurance-1'
+    And I choose 'restrictAdministratorPermissions-yes'
+    And I choose 'restrictAdministratorPermissions--assurance-1'
+    And I choose 'managementInterfaceProtection-yes'
+    And I choose 'managementInterfaceProtection--assurance-1'
+    And I click 'Save and continue'
+    Then I should be on the 'Identity and authentication' page
+
+  Scenario: Identity and authentication
+    Given I am on ssp page 'identity_and_authentication'
+    When I check 'Username and two-factor authentication'
+    And I choose 'identityAuthenticationControls--assurance-1'
+    And I click 'Save and continue'
+    Then I should be on the 'External interface protection' page
+
+  Scenario: External interface protection
+    Given I am on ssp page 'external_interface_protection'
+    When I choose 'onboardingGuidance-yes'
+    And I choose 'onboardingGuidance--assurance-1'
+    And I check 'Encrypted PSN service'
+    And I choose 'interconnectionMethods--assurance-1'
+    And I click 'Save and continue'
+    Then I should be on the 'Secure service administration' page
+
+  Scenario: Secure service administration
+    Given I am on ssp page 'secure_service_administration'
+    When I check 'Dedicated devices on a segregated network'
+    And I choose 'serviceManagementModel--assurance-1'
+    And I click 'Save and continue'
+    Then I should be on the 'Audit information provision to consumers' page
+
+  Scenario: Audit information provision to consumers
+    Given I am on ssp page 'audit_information_provision_to_consumers'
+    When I choose 'auditInformationProvided-1'
+    And I choose 'auditInformationProvided--assurance-1'
+    And I click 'Save and continue'
+    Then I should be on the 'Secure use of the service by the customer' page
+
+  Scenario: Secure use of the service by the customer
+    Given I am on ssp page 'secure_use_of_the_service_by_the_customer'
+    When I check 'Corporate/enterprise devices'
+    And I choose 'deviceAccessMethod--assurance-1'
+    And I choose 'serviceConfigurationGuidance-yes'
+    And I choose 'serviceConfigurationGuidance--assurance-1'
+    And I choose 'trainingProvided-yes'
+    And I choose 'trainingProvided--assurance-1'
+    And I click 'Save and continue'
+    Then I should be on the 'Service definition' page
+
+  Scenario: Service definition document
+    Given I am on ssp page 'service_definition'
+    When I choose file 'test.pdf' for 'serviceDefinitionDocumentURL'
+    And I click 'Save and continue'
+    Then I should be on the 'Terms and conditions document' page
+
+  Scenario: Terms and conditions document
+    Given I am on ssp page 'terms_and_conditions_document'
+    When I choose file 'test.pdf' for 'termsAndConditionsDocumentURL'
+    And I click 'Save and continue'
+    Then I should be on the 'Pricing document' page
+
+  Scenario: Pricing document
+    Given I am on ssp page 'pricing_document'
+    When I choose file 'test.pdf' for 'pricingDocumentURL'
+    And I click 'Save and continue'
+    Then I should be on the 'SFIA rate card' page
+    
+  Scenario: SFIA rate card document
+    Given I am on ssp page 'sfia_rate_card'
+    When I choose file 'test.pdf' for 'sfiaRateDocumentURL'
+    And I click 'Save and continue'
+    Then I should be on the 'My IaaS service' page
+
+  # TODO: Remove WIP once completing services is implemented
+  @wip
+  Scenario: The service is complete
+    Given I am on the summary page
+    Then The string 'Answer required' should not be on the page
+    And The string 'The service is complete' should be on the page
+
+  Scenario: Verify text on summary page
+    Given I am on the summary page
+    Then Summary row 'Service type' should contain 'IaaS'
+    And Summary row 'Service name' should contain 'My IaaS service'
+    And Summary row 'Service summary' should contain 'My IaaS service that does stuff with stuff.'
+    # TODO: Uncomment once serviceType bug has been fixed
+    # And Summary row 'Service type' should contain 'Compute'
+    And Summary row 'Service features' should contain 'Super greatness'
+    And Summary row 'Service benefits' should contain 'Great superness'
+    And Summary row 'Service price' should contain '£100 to £1000 per unit per second'
+    And Summary row 'VAT included' should contain 'Yes'
+    And Summary row 'Education pricing' should contain 'No'
+    And Summary row 'Trial option' should contain 'Yes'
+    And Summary row 'Free option' should contain 'No'
+    And Summary row 'Termination cost' should contain 'No'
+    And Summary row 'Minimum contract period' should contain 'Month'
+    And Summary row 'Support service type' should contain 'Service desk'
+    And Summary row 'Support accessible to any third-party suppliers' should contain 'Yes'
+    And Summary row 'Support availability' should contain '24/7'
+    And Summary row 'Standard support response times' should contain '1 hour'
+    And Summary row 'Incident escalation process available' should contain 'No'
+    And Summary row 'Open standards supported and documented' should contain 'Yes'
+    And Summary row 'Service onboarding process included' should contain 'No'
+    And Summary row 'Service offboarding process included' should contain 'Yes'
+    And Summary row 'Real-time management information available' should contain 'No'
+    And Summary row 'Elastic cloud approach supported' should contain 'Yes'
+    And Summary row 'Guaranteed resources defined' should contain 'No'
+    And Summary row 'Persistent storage supported' should contain 'No'
+    And Summary row 'Self-service provisioning supported' should contain 'Yes'
+    And Summary row 'Service provisioning time' should contain '5 hours'
+    And Summary row 'Service deprovisioning time' should contain '6 hours'
+    And Summary row 'Open-source software used and supported' should contain 'Yes'
+    And Summary row 'API access available and supported' should contain 'Yes'
+    And Summary row 'API type' should contain 'JSON'
+    And Summary row 'Networks the service is directly connected to' should contain 'Internet'
+    And Summary row 'Supported web browsers' should contain 'Opera'
+    And Summary row 'Offline working and syncing supported' should contain 'Yes'
+    And Summary row 'Supported devices' should contain 'PC'
+    And Summary row 'Vendor certification(s)' should contain 'Stuff magic'
+    And Summary row 'Datacentres adhere to EU Code of Conduct for Operations' should contain 'No'
+    And Summary row 'User-defined data location' should contain 'Yes'
+    And Summary row 'Datacentre tier' should contain 'Uptime Institute Tier 1'
+    And Summary row 'Backup, disaster recovery and resilience plan in place' should contain 'Yes'
+    And Summary row 'Data extraction/removal plan in place' should contain 'Yes'
+    And Summary row 'Data protection between user device and service' should contain 'Encrypted PSN service, assured by independent validation of assertion'
+    And Summary row 'Data protection within service' should contain 'VLAN, assured by independent validation of assertion'
+    And Summary row 'Data protection between services' should contain 'Encrypted PSN service, assured by CESG-assured components'
+    And Summary row 'Datacentre location' should contain 'UK'
+    And Summary row 'Data management location' should contain 'UK'
+    And Summary row 'Legal jurisdiction of service provider' should contain 'UK'
+    And Summary row 'Datacentre protection' should contain 'Yes'
+    And Summary row 'Data-at-rest protection' should contain 'CPA Foundation-grade assured components'
+    And Summary row 'Secure data deletion' should contain 'CESG or CPNI-approved erasure process'
+    And Summary row 'Storage media disposal' should contain 'CESG-assured destruction service (CAS(T))'
+    And Summary row 'Secure equipment disposal' should contain 'Yes'
+    And Summary row 'Redundant equipment accounts revoked' should contain 'No'
+    And Summary row 'Service availability' should contain '99.99%'
+    And Summary row 'Cloud deployment model' should contain 'Public cloud'
+    And Summary row 'Type of consumer' should contain 'No other consumer'
+    And Summary row 'Services separation' should contain 'Yes'
+    And Summary row 'Services management separation' should contain 'Yes'
+    And Summary row 'Governance framework' should contain 'Yes'
+    And Summary row 'Configuration and change management tracking' should contain 'Yes'
+    And Summary row 'Change impact assessment' should contain 'Yes'
+    And Summary row 'Vulnerability assessment' should contain 'Yes'
+    And Summary row 'Vulnerability monitoring' should contain 'Yes'
+    And Summary row 'Vulnerability mitigation prioritisation' should contain 'No'
+    And Summary row 'Vulnerability tracking' should contain 'Yes'
+    And Summary row 'Vulnerability mitigation timescales' should contain 'Yes'
+    And Summary row 'Event monitoring' should contain 'Yes'
+    And Summary row 'Incident management processes' should contain 'Yes'
+    And Summary row 'Consumer reporting of security incidents' should contain 'No'
+    And Summary row 'Security incident definition published' should contain 'Yes'
+    And Summary row 'Personnel security checks' should contain 'Security clearance national vetting (SC)'
+    And Summary row 'Secure development' should contain 'Yes'
+    And Summary row 'Secure design, coding, testing and deployment' should contain 'Yes'
+    And Summary row 'Software configuration management' should contain 'Yes'
+    And Summary row 'Visibility of data shared with third-party suppliers' should contain 'Yes'
+    And Summary row 'Third-party supplier security requirements' should contain 'Yes'
+    And Summary row 'Third-party supplier risk assessment' should contain 'Yes'
+    And Summary row 'Third-party supplier compliance monitoring' should contain 'Yes'
+    And Summary row 'Hardware and software verification' should contain 'Yes'
+    And Summary row 'User authentication and access management' should contain 'Yes'
+    And Summary row 'User access control through support channels' should contain 'Yes'
+    And Summary row 'User access control within management interfaces' should contain 'Yes'
+    And Summary row 'Administrator permissions' should contain 'Yes'
+    And Summary row 'Management interface protection' should contain 'Yes'
+    And Summary row 'Identity and authentication controls' should contain 'Username and two-factor authentication'
+    And Summary row 'Onboarding guidance provided' should contain 'Yes'
+    And Summary row 'Interconnection method provided' should contain 'Encrypted PSN service'
+    And Summary row 'Service management model' should contain 'Dedicated devices on a segregated network'
+    And Summary row 'Audit information provided' should contain 'None'
+    And Summary row 'Device access method' should contain 'Corporate/enterprise devices'
+    And Summary row 'Service configuration guidance' should contain 'Yes'
+    And Summary row 'Training' should contain 'Yes'
+    And Summary row 'Service definition document' should not contain 'Answer required'
+    # TODO: Uncomment once SSP content change has been merged
+    # And Summary row 'Terms and conditions document' should not contain 'Answer required'
+    And Summary row 'Pricing document' should not contain 'Answer required'
+    And Summary row 'Skills Framework for the Information Age (SFIA) rate card' should not be empty
+
+  @delete_service
+  Scenario: Delete the service
+    Given I am on the summary page
+    When I click 'Delete this service'
+    And I click 'Yes, delete “My IaaS service”'
+    Then I should be on the g7 supplier dashboard page
+    And My service should not be in the list

--- a/features/ssp_iaas_service.feature
+++ b/features/ssp_iaas_service.feature
@@ -11,6 +11,7 @@ Feature: Submitting a new service for IaaS
   Scenario: Select lot
     Given I am at '/suppliers'
     When I click 'Apply to become a G-Cloud 7 supplier and add services'
+    And I click 'Add services'
     And I click 'Add a service'
     When I choose 'Infrastructure as a Service (IaaS)'
     And I click 'Save and continue'
@@ -39,7 +40,7 @@ Feature: Submitting a new service for IaaS
     And I fill in 'serviceBenefits-1' with 'Great superness'
     And I click 'Save and continue'
     Then I should be on the 'Pricing' page
-    
+
   Scenario: Pricing
     Given I am on ssp page 'pricing'
     When I fill in 'priceStringMinPrice' with '100'
@@ -88,7 +89,7 @@ Feature: Submitting a new service for IaaS
     When I choose 'analyticsAvailable-no'
     And I click 'Save and continue'
     Then I should be on the 'Cloud features' page
-    
+
   Scenario: Cloud features
     Given I am on ssp page 'cloud_features'
     When I choose 'elasticCloud-yes'
@@ -365,7 +366,7 @@ Feature: Submitting a new service for IaaS
     When I choose file 'test.pdf' for 'pricingDocumentURL'
     And I click 'Save and continue'
     Then I should be on the 'SFIA rate card' page
-    
+
   Scenario: SFIA rate card document
     Given I am on ssp page 'sfia_rate_card'
     When I choose file 'test.pdf' for 'sfiaRateDocumentURL'
@@ -485,5 +486,5 @@ Feature: Submitting a new service for IaaS
     Given I am on the summary page
     When I click 'Delete this service'
     And I click 'Yes, delete “My IaaS service”'
-    Then I should be on the g7 supplier dashboard page
+    Then I should be on the g7 services page
     And My service should not be in the list

--- a/features/ssp_iaas_service.feature
+++ b/features/ssp_iaas_service.feature
@@ -249,7 +249,7 @@ Feature: Submitting a new service for IaaS
 
   @listing_page
   Scenario: Go to listing page and the service is not complete
-    Given I am at the g7 supplier dashboard page
+    Given I am at the g7 services page
     When I click my service
     Then I should be on the 'My IaaS service' page
     And The string 'Answer required' should be on the page

--- a/features/ssp_paas_service.feature
+++ b/features/ssp_paas_service.feature
@@ -143,7 +143,7 @@ Feature: Submitting a new service for PaaS
 
   @listing_page
   Scenario: Go to listing page and the service is not complete
-    Given I am at the g7 supplier dashboard page
+    Given I am at the g7 services page
     When I click my service
     Then I should be on the 'My PaaS service' page
     And The string 'Answer required' should be on the page

--- a/features/ssp_paas_service.feature
+++ b/features/ssp_paas_service.feature
@@ -1,0 +1,380 @@
+@not-production @functional-test
+Feature: Submitting a new service for PaaS
+  In order to submit my services as a supplier user
+  I want to answer questions about my service
+
+  Background: Log in as a supplier
+    Given I am on the 'Supplier' login page
+    When I login as a 'Supplier' user
+    Then I should be on the supplier home page
+
+  Scenario: Select lot
+    Given I am at '/suppliers'
+    When I click 'Apply to become a G-Cloud 7 supplier and add services'
+    And I click 'Add a service'
+    When I choose 'Platform as a Service (PaaS)'
+    And I click 'Save and continue'
+    Then I should be on the 'Service description' page
+
+  Scenario: Provide a service description
+    Given I am on ssp page 'service_description'
+    When I fill in 'serviceName' with 'My PaaS service'
+    And I fill in 'serviceSummary' with:
+      """
+      Platform as a service (PaaS) is a category of cloud computing services that provides a computing platform and a solution stack as a service.
+      """
+    And I click 'Save and continue'
+    Then I should be on the 'Features and benefits' page
+
+  Scenario: Features and benefits
+    Given I am on ssp page 'features_and_benefits'
+    When I fill in 'serviceFeatures-1' with 'Super greatness'
+    And I fill in 'serviceBenefits-1' with 'Great superness'
+    And I click 'Save and continue'
+    Then I should be on the 'Pricing' page
+
+  Scenario: Pricing
+    Given I am on ssp page 'pricing'
+    When I fill in 'priceStringMinPrice' with '99'
+    And I fill in 'priceStringMaxPrice' with '100'
+    And I select 'Unit' from 'priceStringUnit'
+    And I select 'Second' from 'priceStringInterval'
+    And I choose 'vatIncluded-no'
+    And I choose 'educationPricing-yes'
+    And I choose 'trialOption-yes'
+    And I choose 'freeOption-no'
+    And I click 'Save and continue'
+    Then I should be on the 'Terms and conditions' page
+
+  Scenario: Terms and conditions
+    Given I am on ssp page 'terms_and_conditions'
+    When I choose 'terminationCost-yes'
+    And I choose 'minimumContractPeriod-3'
+    And I click 'Save and continue'
+    Then I should be on the 'Support' page
+
+  Scenario: Support
+    Given I am on ssp page 'support'
+    When I check 'supportTypes-1'
+    And I choose 'supportForThirdParties-yes'
+    And I fill in 'supportAvailability' with '24/7'
+    And I fill in 'supportResponseTime' with '1 hour'
+    And I choose 'incidentEscalation-no'
+    And I click 'Save and continue'
+    Then I should be on the 'Open standards' page
+
+  Scenario: Open standards
+    Given I am on ssp page 'open_standards'
+    When I choose 'openStandardsSupported-yes'
+    And I click 'Save and continue'
+    Then I should be on the 'Onboarding and offboarding' page
+
+  Scenario: Onboarding and offboarding
+    Given I am on ssp page 'onboarding_and_offboarding'
+    When I choose 'serviceOnboarding-no'
+    And I choose 'serviceOffboarding-yes'
+    And I click 'Save and continue'
+    Then I should be on the 'Analytics' page
+
+  Scenario: Analytics
+    Given I am on ssp page 'analytics'
+    When I choose 'analyticsAvailable-no'
+    And I click 'Save and continue'
+    Then I should be on the 'Cloud features' page
+
+  Scenario: Cloud features
+    Given I am on ssp page 'cloud_features'
+    When I choose 'elasticCloud-yes'
+    And I choose 'guaranteedResources-no'
+    And I choose 'persistentStorage-no'
+    And I click 'Save and continue'
+    Then I should be on the 'Provisioning' page
+
+  Scenario: Provisioning
+    Given I am on ssp page 'provisioning'
+    When I choose 'selfServiceProvisioning-yes'
+    And I fill in 'provisioningTime' with '5 hours'
+    And I fill in 'deprovisioningTime' with '6 hours'
+    And I click 'Save and continue'
+    Then I should be on the 'Open source' page
+
+  Scenario: Open source
+    Given I am on ssp page 'open_source'
+    When I choose 'openSource-yes'
+    And I click 'Save and continue'
+    Then I should be on the 'API access' page
+
+  Scenario: API access
+    Given I am on ssp page 'api_access'
+    When I choose 'apiAccess-yes'
+    And I fill in 'apiType' with 'SOAP'
+    And I click 'Save and continue'
+    Then I should be on the 'Networks and connectivity' page
+
+  Scenario: Networks and connectivity
+    Given I am on ssp page 'networks_and_connectivity'
+    When I check 'Internet'
+    And I click 'Save and continue'
+    Then I should be on the 'Access' page
+
+  Scenario: Access
+    Given I am on ssp page 'access'
+    When I check 'Opera'
+    And I choose 'offlineWorking-yes'
+    And I check 'PC'
+    And I click 'Save and continue'
+    Then I should be on the 'Certifications' page
+
+  Scenario: Certifications
+    Given I am on ssp page 'certifications'
+    When I click 'Save and continue'
+    Then I should be on the 'Data storage' page
+
+  Scenario: Data storage
+    Given I am on ssp page 'data_storage'
+    When I choose 'datacentresEUCode-no'
+    And I choose 'datacentresSpecifyLocation-yes'
+    And I choose 'datacentreTier-5'
+    And I choose 'dataBackupRecovery-yes'
+    And I choose 'dataExtractionRemoval-yes'
+    And I click 'Save and continue'
+    Then I should be on the 'Data-in-transit protection' page
+
+  @listing_page
+  Scenario: Go to listing page and the service is not complete
+    Given I am at the g7 supplier dashboard page
+    When I click my service
+    Then I should be on the 'My PaaS service' page
+    And The string 'Answer required' should be on the page
+    And The string 'The service is complete' should not be on the page
+
+  Scenario: Data-in-transit protection
+    Given I am on ssp page 'data_in_transit_protection'
+    When I check 'dataProtectionBetweenUserAndService-1'
+    And I choose 'dataProtectionBetweenUserAndService--assurance-2'
+    And I check 'dataProtectionWithinService-3'
+    And I choose 'dataProtectionWithinService--assurance-2'
+    And I check 'dataProtectionBetweenServices-1'
+    And I choose 'dataProtectionBetweenServices--assurance-4'
+    And I click 'Save and continue'
+    Then I should be on the 'Asset protection and resilience' page
+
+  Scenario: Asset protection and resilience
+    Given I am on ssp page 'asset_protection_and_resilience'
+    When I check 'datacentreLocations-1'
+    And I choose 'datacentreLocations--assurance-1'
+    And I check 'dataManagementLocations-1'
+    And I choose 'dataManagementLocations--assurance-1'
+    And I choose 'legalJurisdiction-1'
+    And I choose 'legalJurisdiction--assurance-1'
+    And I choose 'datacentreProtectionDisclosure-yes'
+    And I choose 'datacentreProtectionDisclosure--assurance-1'
+    And I check 'dataAtRestProtections-1'
+    And I choose 'dataAtRestProtections--assurance-1'
+    And I choose 'dataSecureDeletion-2'
+    And I choose 'dataSecureDeletion--assurance-1'
+    And I choose 'dataStorageMediaDisposal-1'
+    And I choose 'dataStorageMediaDisposal--assurance-1'
+    And I choose 'dataSecureEquipmentDisposal-yes'
+    And I choose 'dataSecureEquipmentDisposal--assurance-1'
+    And I choose 'dataRedundantEquipmentAccountsRevoked-no'
+    And I choose 'dataRedundantEquipmentAccountsRevoked--assurance-1'
+    And I fill in 'serviceAvailabilityPercentage' with '99.99'
+    And I choose 'serviceAvailabilityPercentage--assurance-1'
+    And I click 'Save and continue'
+    Then I should be on the 'Separation between consumers' page
+
+  Scenario: Separation between consumers
+    Given I am on ssp page 'separation_between_consumers'
+    When I choose 'cloudDeploymentModel-1'
+    And I choose 'cloudDeploymentModel--assurance-1'
+    And I choose 'otherConsumers-1'
+    And I choose 'otherConsumers--assurance-1'
+    And I choose 'servicesSeparation-yes'
+    And I choose 'servicesSeparation--assurance-1'
+    And I choose 'servicesManagementSeparation-yes'
+    And I choose 'servicesManagementSeparation--assurance-1'
+    And I click 'Save and continue'
+    Then I should be on the 'Governance' page
+
+  Scenario: Governance
+    Given I am on ssp page 'governance'
+    When I choose 'governanceFramework-yes'
+    And I choose 'governanceFramework--assurance-1'
+    And I click 'Save and continue'
+    Then I should be on the 'Configuration and change management' page
+
+  Scenario: Configuration and change management
+    Given I am on ssp page 'configuration_and_change_management'
+    When I choose 'configurationTracking-yes'
+    And I choose 'configurationTracking--assurance-1'
+    And I choose 'changeImpactAssessment-yes'
+    And I choose 'changeImpactAssessment--assurance-1'
+    And I click 'Save and continue'
+    Then I should be on the 'Vulnerabilility management' page
+
+  Scenario: Vulnerabilility management
+    Given I am on ssp page 'vulnerabilility_management'
+    When I choose 'vulnerabilityAssessment-yes'
+    And I choose 'vulnerabilityAssessment--assurance-1'
+    And I choose 'vulnerabilityMonitoring-yes'
+    And I choose 'vulnerabilityMonitoring--assurance-1'
+    And I choose 'vulnerabilityMitigationPrioritisation-no'
+    And I choose 'vulnerabilityMitigationPrioritisation--assurance-1'
+    And I choose 'vulnerabilityTracking-yes'
+    And I choose 'vulnerabilityTracking--assurance-1'
+    And I choose 'vulnerabilityTimescales-yes'
+    And I choose 'vulnerabilityTimescales--assurance-1'
+    And I click 'Save and continue'
+    Then I should be on the 'Event monitoring' page
+
+  Scenario: Event monitoring
+    Given I am on ssp page 'event_monitoring'
+    When I choose 'eventMonitoring-yes'
+    And I choose 'eventMonitoring--assurance-1'
+    And I click 'Save and continue'
+    Then I should be on the 'Incident management' page
+
+  Scenario: Incident management
+    Given I am on ssp page 'incident_management'
+    When I choose 'incidentManagementProcess-yes'
+    And I choose 'incidentManagementProcess--assurance-1'
+    And I choose 'incidentManagementReporting-no'
+    And I choose 'incidentManagementReporting--assurance-1'
+    And I choose 'incidentDefinitionPublished-yes'
+    And I choose 'incidentDefinitionPublished--assurance-1'
+    And I click 'Save and continue'
+    Then I should be on the 'Personnel security' page
+
+  Scenario: Personnel security
+    Given I am on ssp page 'personnel_security'
+    When I check 'Security clearance national vetting (SC)'
+    And I choose 'personnelSecurityChecks--assurance-1'
+    And I click 'Save and continue'
+    Then I should be on the 'Secure development' page
+
+  Scenario: Secure development
+    Given I am on ssp page 'secure_development'
+    When I choose 'secureDevelopment-yes'
+    And I choose 'secureDevelopment--assurance-1'
+    And I choose 'secureDesign-yes'
+    And I choose 'secureDesign--assurance-1'
+    And I choose 'secureConfigurationManagement-yes'
+    And I choose 'secureConfigurationManagement--assurance-1'
+    And I click 'Save and continue'
+    Then I should be on the 'Supply-chain security' page
+
+  Scenario: Supply-chain security
+    Given I am on ssp page 'supply_chain_security'
+    When I choose 'thirdPartyDataSharingInformation-yes'
+    And I choose 'thirdPartyDataSharingInformation--assurance-1'
+    And I choose 'thirdPartySecurityRequirements-yes'
+    And I choose 'thirdPartySecurityRequirements--assurance-1'
+    And I choose 'thirdPartyRiskAssessment-yes'
+    And I choose 'thirdPartyRiskAssessment--assurance-1'
+    And I choose 'thirdPartyComplianceMonitoring-yes'
+    And I choose 'thirdPartyComplianceMonitoring--assurance-1'
+    And I choose 'hardwareSoftwareVerification-yes'
+    And I choose 'hardwareSoftwareVerification--assurance-1'
+    And I click 'Save and continue'
+    Then I should be on the 'Authentication of consumers' page
+
+  Scenario: Authentication of consumers
+    Given I am on ssp page 'authentication_of_consumers'
+    When I choose 'userAuthenticateManagement-yes'
+    And I choose 'userAuthenticateManagement--assurance-1'
+    And I choose 'userAuthenticateSupport-yes'
+    And I choose 'userAuthenticateSupport--assurance-1'
+    And I click 'Save and continue'
+    Then I should be on the 'Separation and access control within management interfaces' page
+
+  Scenario: Separation and access control within management interfaces
+    Given I am on ssp page 'separation_and_access_control_within_management_interfaces'
+    When I choose 'userAccessControlManagement-yes'
+    And I choose 'userAccessControlManagement--assurance-1'
+    And I choose 'restrictAdministratorPermissions-yes'
+    And I choose 'restrictAdministratorPermissions--assurance-1'
+    And I choose 'managementInterfaceProtection-yes'
+    And I choose 'managementInterfaceProtection--assurance-1'
+    And I click 'Save and continue'
+    Then I should be on the 'Identity and authentication' page
+
+  Scenario: Identity and authentication
+    Given I am on ssp page 'identity_and_authentication'
+    When I check 'Username and two-factor authentication'
+    And I choose 'identityAuthenticationControls--assurance-1'
+    And I click 'Save and continue'
+    Then I should be on the 'External interface protection' page
+
+  Scenario: External interface protection
+    Given I am on ssp page 'external_interface_protection'
+    When I choose 'onboardingGuidance-yes'
+    And I choose 'onboardingGuidance--assurance-1'
+    And I check 'Encrypted PSN service'
+    And I choose 'interconnectionMethods--assurance-1'
+    And I click 'Save and continue'
+    Then I should be on the 'Secure service administration' page
+
+  Scenario: Secure service administration
+    Given I am on ssp page 'secure_service_administration'
+    When I check 'Dedicated devices on a segregated network'
+    And I choose 'serviceManagementModel--assurance-1'
+    And I click 'Save and continue'
+    Then I should be on the 'Audit information provision to consumers' page
+
+  Scenario: Audit information provision to consumers
+    Given I am on ssp page 'audit_information_provision_to_consumers'
+    When I choose 'auditInformationProvided-1'
+    And I choose 'auditInformationProvided--assurance-1'
+    And I click 'Save and continue'
+    Then I should be on the 'Secure use of the service by the customer' page
+
+  Scenario: Secure use of the service by the customer
+    Given I am on ssp page 'secure_use_of_the_service_by_the_customer'
+    When I check 'Corporate/enterprise devices'
+    And I choose 'deviceAccessMethod--assurance-1'
+    And I choose 'serviceConfigurationGuidance-yes'
+    And I choose 'serviceConfigurationGuidance--assurance-1'
+    And I choose 'trainingProvided-yes'
+    And I choose 'trainingProvided--assurance-1'
+    And I click 'Save and continue'
+    Then I should be on the 'Service definition' page
+    
+  Scenario: Service definition document
+    Given I am on ssp page 'service_definition'
+    When I choose file 'test.pdf' for 'serviceDefinitionDocumentURL'
+    And I click 'Save and continue'
+    Then I should be on the 'Terms and conditions document' page
+
+  Scenario: Terms and conditions document
+    Given I am on ssp page 'terms_and_conditions_document'
+    When I choose file 'test.pdf' for 'termsAndConditionsDocumentURL'
+    And I click 'Save and continue'
+    Then I should be on the 'Pricing document' page
+
+  Scenario: Pricing document
+    Given I am on ssp page 'pricing_document'
+    When I choose file 'test.pdf' for 'pricingDocumentURL'
+    And I click 'Save and continue'
+    Then I should be on the 'SFIA rate card' page
+
+  Scenario: SFIA rate card document
+    Given I am on ssp page 'sfia_rate_card'
+    When I choose file 'test.pdf' for 'sfiaRateDocumentURL'
+    And I click 'Save and continue'
+    Then I should be on the 'My PaaS service' page
+
+  # TODO: Remove WIP once completing services is implemented
+  @wip
+  Scenario: The service is complete
+    Given I am on the summary page
+    Then The string 'Answer required' should not be on the page
+    And The string 'The service is complete' should be on the page
+
+  @delete_service
+  Scenario: Delete the service
+    Given I am on the summary page
+    When I click 'Delete this service'
+    And I click 'Yes, delete “My PaaS service”'
+    Then I should be on the g7 supplier dashboard page
+    And My service should not be in the list

--- a/features/ssp_paas_service.feature
+++ b/features/ssp_paas_service.feature
@@ -11,6 +11,7 @@ Feature: Submitting a new service for PaaS
   Scenario: Select lot
     Given I am at '/suppliers'
     When I click 'Apply to become a G-Cloud 7 supplier and add services'
+    And I click 'Add services'
     And I click 'Add a service'
     When I choose 'Platform as a Service (PaaS)'
     And I click 'Save and continue'
@@ -339,7 +340,7 @@ Feature: Submitting a new service for PaaS
     And I choose 'trainingProvided--assurance-1'
     And I click 'Save and continue'
     Then I should be on the 'Service definition' page
-    
+
   Scenario: Service definition document
     Given I am on ssp page 'service_definition'
     When I choose file 'test.pdf' for 'serviceDefinitionDocumentURL'
@@ -376,5 +377,5 @@ Feature: Submitting a new service for PaaS
     Given I am on the summary page
     When I click 'Delete this service'
     And I click 'Yes, delete “My PaaS service”'
-    Then I should be on the g7 supplier dashboard page
+    Then I should be on the g7 services page
     And My service should not be in the list

--- a/features/ssp_saas_service.feature
+++ b/features/ssp_saas_service.feature
@@ -1,0 +1,372 @@
+@not-production @functional-test
+Feature: Submitting a new service for SaaS
+  In order to submit my services as a supplier user
+  I want to answer questions about my service
+
+  Background: Log in as a supplier
+    Given I am on the 'Supplier' login page
+    When I login as a 'Supplier' user
+    Then I should be on the supplier home page
+
+  Scenario: Select lot
+    Given I am at '/suppliers'
+    When I click 'Apply to become a G-Cloud 7 supplier and add services'
+    And I click 'Add a service'
+    When I choose 'Software as a Service (SaaS)'
+    And I click 'Save and continue'
+    Then I should be on the 'Service description' page
+
+  Scenario: Provide a service description
+    Given I am on ssp page 'service_description'
+    When I fill in 'serviceName' with 'My SaaS service'
+    And I fill in 'serviceSummary' with:
+      """
+      It's very SaaSy.
+      """
+    And I click 'Save and continue'
+    Then I should be on the 'Service type' page
+
+  Scenario: Select a service type
+    Given I am on ssp page 'service_type'
+    When I check 'Creative and design'
+    And I click 'Save and continue'
+    Then I should be on the 'Features and benefits' page
+    
+  Scenario: Features and benefits
+    Given I am on ssp page 'features_and_benefits'
+    When I fill in 'serviceFeatures-1' with 'Great superness'
+    And I fill in 'serviceBenefits-1' with 'Super greatness'
+    And I click 'Save and continue'
+    Then I should be on the 'Pricing' page
+
+  Scenario: Pricing
+    Given I am on ssp page 'pricing'
+    When I fill in 'priceStringMinPrice' with '99'
+    And I fill in 'priceStringMaxPrice' with '100'
+    And I select 'Unit' from 'priceStringUnit'
+    And I select 'Second' from 'priceStringInterval'
+    And I choose 'vatIncluded-no'
+    And I choose 'educationPricing-yes'
+    And I choose 'trialOption-yes'
+    And I choose 'freeOption-no'
+    And I click 'Save and continue'
+    Then I should be on the 'Terms and conditions' page
+
+  Scenario: Terms and conditions
+    Given I am on ssp page 'terms_and_conditions'
+    When I choose 'minimumContractPeriod-3'
+    And I click 'Save and continue'
+    Then I should be on the 'Support' page
+
+  Scenario: Support
+    Given I am on ssp page 'support'
+    When I check 'Service desk'
+    And I choose 'supportForThirdParties-yes'
+    And I fill in 'supportAvailability' with '24/7'
+    And I fill in 'supportResponseTime' with '1 hour'
+    And I choose 'incidentEscalation-no'
+    And I click 'Save and continue'
+    Then I should be on the 'Open standards' page
+
+  Scenario: Open standards
+    Given I am on ssp page 'open_standards'
+    When I choose 'openStandardsSupported-yes'
+    And I click 'Save and continue'
+    Then I should be on the 'Onboarding and offboarding' page
+
+  Scenario: Onboarding and offboarding
+    Given I am on ssp page 'onboarding_and_offboarding'
+    When I choose 'serviceOnboarding-no'
+    And I choose 'serviceOffboarding-yes'
+    And I click 'Save and continue'
+    Then I should be on the 'Analytics' page
+
+  Scenario: Analytics
+    Given I am on ssp page 'analytics'
+    When I choose 'analyticsAvailable-no'
+    And I click 'Save and continue'
+    Then I should be on the 'Cloud features' page
+
+  Scenario: Cloud features
+    Given I am on ssp page 'cloud_features'
+    When I choose 'elasticCloud-yes'
+    And I choose 'guaranteedResources-no'
+    And I choose 'persistentStorage-no'
+    And I click 'Save and continue'
+    Then I should be on the 'Provisioning' page
+
+  Scenario: Provisioning
+    Given I am on ssp page 'provisioning'
+    When I choose 'selfServiceProvisioning-yes'
+    And I fill in 'provisioningTime' with '5 hours'
+    And I fill in 'deprovisioningTime' with '6 hours'
+    And I click 'Save and continue'
+    Then I should be on the 'Open source' page
+
+  Scenario: Open source
+    Given I am on ssp page 'open_source'
+    When I choose 'openSource-yes'
+    And I click 'Save and continue'
+    Then I should be on the 'Code Libraries' page
+
+  Scenario: Code libraries
+    Given I am on ssp page 'code_libraries'
+    When I fill in 'codeLibraryLanguages-1' with 'XSLT'
+    And I click 'Save and continue'
+    Then I should be on the 'API Access' page
+
+  Scenario: API access
+    Given I am on ssp page 'api_access'
+    When I choose 'apiAccess-yes'
+    And I fill in 'apiType' with 'XML'
+    And I click 'Save and continue'
+    Then I should be on the 'Networks and connectivity' page
+
+  Scenario: Networks and connectivity
+    Given I am on ssp page 'networks_and_connectivity'
+    When I check 'Internet'
+    And I click 'Save and continue'
+    Then I should be on the 'Access' page
+
+  Scenario: Access
+    Given I am on ssp page 'access'
+    When I check 'Opera'
+    And I choose 'offlineWorking-yes'
+    And I check 'PC'
+    And I click 'Save and continue'
+    Then I should be on the 'Certifications' page
+
+  Scenario: Certifications
+    Given I am on ssp page 'certifications'
+    When I fill in 'vendorCertifications-1' with 'Stuff magic'
+    And I click 'Save and continue'
+    Then I should be on the 'Identity standards' page
+
+  Scenario: Identity standards
+    Given I am on ssp page 'identity_standards'
+    When I fill in 'identityStandards-1' with 'OAuth'
+    And I click 'Save and continue'
+    Then I should be on the 'Data storage' page
+
+  Scenario: Data storage
+    Given I am on ssp page 'data_storage'
+    When I choose 'datacentresEUCode-no'
+    And I choose 'datacentresSpecifyLocation-yes'
+    And I choose 'datacentreTier-5'
+    And I choose 'dataBackupRecovery-yes'
+    And I choose 'dataExtractionRemoval-yes'
+    And I click 'Save and continue'
+    Then I should be on the 'Data-in-transit protection' page
+
+  @listing_page
+  Scenario: Go to listing page and the service is not complete
+    Given I am at the g7 supplier dashboard page
+    When I click my service
+    Then I should be on the 'My SaaS service' page
+    And The string 'Answer required' should be on the page
+    And The string 'The service is complete' should not be on the page
+
+  Scenario: Data-in-transit protection
+    Given I am on ssp page 'data_in_transit_protection'
+    When I check 'Encrypted PSN service'
+    And I choose 'dataProtectionBetweenUserAndService--assurance-2'
+    And I click 'Save and continue'
+    Then I should be on the 'Asset protection and resilience' page
+
+  Scenario: Asset protection and resilience
+    Given I am on ssp page 'asset_protection_and_resilience'
+    When I check 'datacentreLocations-1'
+    And I choose 'datacentreLocations--assurance-1'
+    And I check 'dataManagementLocations-1'
+    And I choose 'dataManagementLocations--assurance-1'
+    And I choose 'legalJurisdiction-1'
+    And I choose 'legalJurisdiction--assurance-1'
+    And I choose 'datacentreProtectionDisclosure-yes'
+    And I choose 'datacentreProtectionDisclosure--assurance-1'
+    And I check 'dataAtRestProtections-2'
+    And I choose 'dataAtRestProtections--assurance-1'
+    And I choose 'dataSecureDeletion-2'
+    And I choose 'dataSecureDeletion--assurance-1'
+    And I fill in 'serviceAvailabilityPercentage' with '99'
+    And I choose 'serviceAvailabilityPercentage--assurance-1'
+    And I click 'Save and continue'
+    Then I should be on the 'Separation between consumers' page
+
+  Scenario: Separation between consumers
+    Given I am on ssp page 'separation_between_consumers'
+    When I choose 'cloudDeploymentModel-1'
+    And I choose 'cloudDeploymentModel--assurance-1'
+    And I choose 'otherConsumers-1'
+    And I choose 'otherConsumers--assurance-1'
+    And I choose 'servicesSeparation-yes'
+    And I choose 'servicesSeparation--assurance-1'
+    And I choose 'servicesManagementSeparation-yes'
+    And I choose 'servicesManagementSeparation--assurance-1'
+    And I click 'Save and continue'
+    Then I should be on the 'Governance' page
+
+  Scenario: Governance
+    Given I am on ssp page 'governance'
+    When I choose 'governanceFramework-yes'
+    And I choose 'governanceFramework--assurance-1'
+    And I click 'Save and continue'
+    Then I should be on the 'Configuration and change management' page
+
+  Scenario: Configuration and change management
+    Given I am on ssp page 'configuration_and_change_management'
+    When I choose 'changeImpactAssessment-yes'
+    And I choose 'changeImpactAssessment--assurance-1'
+    And I click 'Save and continue'
+    Then I should be on the 'Vulnerabilility management' page
+
+  Scenario: Vulnerabilility management
+    Given I am on ssp page 'vulnerabilility_management'
+    When I choose 'vulnerabilityAssessment-yes'
+    And I choose 'vulnerabilityAssessment--assurance-1'
+    And I choose 'vulnerabilityMonitoring-yes'
+    And I choose 'vulnerabilityMonitoring--assurance-1'
+    And I choose 'vulnerabilityMitigationPrioritisation-no'
+    And I choose 'vulnerabilityMitigationPrioritisation--assurance-1'
+    And I choose 'vulnerabilityTracking-yes'
+    And I choose 'vulnerabilityTracking--assurance-1'
+    And I choose 'vulnerabilityTimescales-yes'
+    And I choose 'vulnerabilityTimescales--assurance-1'
+    And I click 'Save and continue'
+    Then I should be on the 'Event monitoring' page
+
+  Scenario: Event monitoring
+    Given I am on ssp page 'event_monitoring'
+    When I choose 'eventMonitoring-yes'
+    And I choose 'eventMonitoring--assurance-1'
+    And I click 'Save and continue'
+    Then I should be on the 'Incident management' page
+
+  Scenario: Incident management
+    Given I am on ssp page 'incident_management'
+    When I choose 'incidentManagementProcess-yes'
+    And I choose 'incidentManagementProcess--assurance-1'
+    And I choose 'incidentManagementReporting-no'
+    And I choose 'incidentManagementReporting--assurance-1'
+    And I choose 'incidentDefinitionPublished-yes'
+    And I choose 'incidentDefinitionPublished--assurance-1'
+    And I click 'Save and continue'
+    Then I should be on the 'Personnel security' page
+
+  Scenario: Personnel security
+    Given I am on ssp page 'personnel_security'
+    When I check 'Security clearance national vetting (SC)'
+    And I choose 'personnelSecurityChecks--assurance-1'
+    And I click 'Save and continue'
+    Then I should be on the 'Secure development' page
+
+  Scenario: Secure development
+    Given I am on ssp page 'secure_development'
+    When I choose 'secureDevelopment-yes'
+    And I choose 'secureDevelopment--assurance-1'
+    And I choose 'secureDesign-yes'
+    And I choose 'secureDesign--assurance-1'
+    And I choose 'secureConfigurationManagement-yes'
+    And I choose 'secureConfigurationManagement--assurance-1'
+    And I click 'Save and continue'
+    Then I should be on the 'Supply-chain security' page
+
+  Scenario: Supply-chain security
+    Given I am on ssp page 'supply_chain_security'
+    When I choose 'thirdPartyDataSharingInformation-yes'
+    And I choose 'thirdPartyDataSharingInformation--assurance-1'
+    And I choose 'thirdPartySecurityRequirements-yes'
+    And I choose 'thirdPartySecurityRequirements--assurance-1'
+    And I choose 'thirdPartyRiskAssessment-yes'
+    And I choose 'thirdPartyRiskAssessment--assurance-1'
+    And I choose 'thirdPartyComplianceMonitoring-yes'
+    And I choose 'thirdPartyComplianceMonitoring--assurance-1'
+    And I click 'Save and continue'
+    Then I should be on the 'Authentication of consumers' page
+
+  Scenario: Authentication of consumers
+    Given I am on ssp page 'authentication_of_consumers'
+    When I choose 'userAuthenticateManagement-yes'
+    And I choose 'userAuthenticateManagement--assurance-1'
+    And I choose 'userAuthenticateSupport-yes'
+    And I choose 'userAuthenticateSupport--assurance-1'
+    And I click 'Save and continue'
+    Then I should be on the 'Separation and access control within management interfaces' page
+
+  Scenario: Separation and access control within management interfaces
+    Given I am on ssp page 'separation_and_access_control_within_management_interfaces'
+    When I choose 'userAccessControlManagement-yes'
+    And I choose 'userAccessControlManagement--assurance-1'
+    And I choose 'restrictAdministratorPermissions-yes'
+    And I choose 'restrictAdministratorPermissions--assurance-1'
+    And I click 'Save and continue'
+    Then I should be on the 'Identity and authentication' page
+
+  Scenario: Identity and authentication
+    Given I am on ssp page 'identity_and_authentication'
+    When I check 'Username and two-factor authentication'
+    And I choose 'identityAuthenticationControls--assurance-1'
+    And I click 'Save and continue'
+    Then I should be on the 'Secure service administration' page
+
+  Scenario: Secure service administration
+    Given I am on ssp page 'secure_service_administration'
+    When I check 'Dedicated devices on a segregated network'
+    And I choose 'serviceManagementModel--assurance-1'
+    And I click 'Save and continue'
+    Then I should be on the 'Audit information provision to consumers' page
+
+  Scenario: Audit information provision to consumers
+    Given I am on ssp page 'audit_information_provision_to_consumers'
+    When I choose 'auditInformationProvided-1'
+    And I choose 'auditInformationProvided--assurance-1'
+    And I click 'Save and continue'
+    Then I should be on the 'Secure use of the service by the customer' page
+
+  Scenario: Secure use of the service by the customer
+    Given I am on ssp page 'secure_use_of_the_service_by_the_customer'
+    When I check 'Corporate/enterprise devices'
+    And I choose 'deviceAccessMethod--assurance-1'
+    And I choose 'trainingProvided-yes'
+    And I choose 'trainingProvided--assurance-1'
+    And I click 'Save and continue'
+    Then I should be on the 'Service definition' page
+
+  Scenario: Service definition document
+    Given I am on ssp page 'service_definition'
+    When I choose file 'test.pdf' for 'serviceDefinitionDocumentURL'
+    And I click 'Save and continue'
+    Then I should be on the 'Terms and conditions document' page
+
+  Scenario: Terms and conditions document
+    Given I am on ssp page 'terms_and_conditions_document'
+    When I choose file 'test.pdf' for 'termsAndConditionsDocumentURL'
+    And I click 'Save and continue'
+    Then I should be on the 'Pricing document' page
+
+  Scenario: Pricing document
+    Given I am on ssp page 'pricing_document'
+    When I choose file 'test.pdf' for 'pricingDocumentURL'
+    And I click 'Save and continue'
+    Then I should be on the 'SFIA rate card' page
+
+  Scenario: SFIA rate card document
+    Given I am on ssp page 'sfia_rate_card'
+    When I choose file 'test.pdf' for 'sfiaRateDocumentURL'
+    And I click 'Save and continue'
+    Then I should be on the 'My SaaS service' page
+
+  # TODO: Remove WIP once completing services is implemented
+  @wip
+  Scenario: The service is complete
+    Given I am on the summary page
+    Then The string 'Answer required' should not be on the page
+    And The string 'The service is complete' should be on the page
+    
+  @delete_service
+  Scenario: Delete the service
+    Given I am on the summary page
+    When I click 'Delete this service'
+    And I click 'Yes, delete “My SaaS service”'
+    Then I should be on the g7 supplier dashboard page
+    And My service should not be in the list
+    

--- a/features/ssp_saas_service.feature
+++ b/features/ssp_saas_service.feature
@@ -11,6 +11,7 @@ Feature: Submitting a new service for SaaS
   Scenario: Select lot
     Given I am at '/suppliers'
     When I click 'Apply to become a G-Cloud 7 supplier and add services'
+    And I click 'Add services'
     And I click 'Add a service'
     When I choose 'Software as a Service (SaaS)'
     And I click 'Save and continue'
@@ -31,7 +32,7 @@ Feature: Submitting a new service for SaaS
     When I check 'Creative and design'
     And I click 'Save and continue'
     Then I should be on the 'Features and benefits' page
-    
+
   Scenario: Features and benefits
     Given I am on ssp page 'features_and_benefits'
     When I fill in 'serviceFeatures-1' with 'Great superness'
@@ -361,12 +362,11 @@ Feature: Submitting a new service for SaaS
     Given I am on the summary page
     Then The string 'Answer required' should not be on the page
     And The string 'The service is complete' should be on the page
-    
+
   @delete_service
   Scenario: Delete the service
     Given I am on the summary page
     When I click 'Delete this service'
     And I click 'Yes, delete “My SaaS service”'
-    Then I should be on the g7 supplier dashboard page
+    Then I should be on the g7 services page
     And My service should not be in the list
-    

--- a/features/ssp_saas_service.feature
+++ b/features/ssp_saas_service.feature
@@ -161,7 +161,7 @@ Feature: Submitting a new service for SaaS
 
   @listing_page
   Scenario: Go to listing page and the service is not complete
-    Given I am at the g7 supplier dashboard page
+    Given I am at the g7 services page
     When I click my service
     Then I should be on the 'My SaaS service' page
     And The string 'Answer required' should be on the page

--- a/features/ssp_scs_service.feature
+++ b/features/ssp_scs_service.feature
@@ -60,7 +60,7 @@ Feature: Submitting a new service for SCS
 
   @listing_page
   Scenario: Go to listing page and the service is not complete
-    Given I am at the g7 supplier dashboard page
+    Given I am at the g7 services page
     When I click my service
     Then I should be on the 'My SCS service name' page
     And The string 'Answer required' should be on the page

--- a/features/ssp_scs_service.feature
+++ b/features/ssp_scs_service.feature
@@ -1,0 +1,139 @@
+@not-production @functional-test
+Feature: Submitting a new service for SCS
+  In order to submit my services as a supplier user
+  I want to answer questions about my service
+
+  Background: Log in as a supplier
+    Given I am on the 'Supplier' login page
+    When I login as a 'Supplier' user
+    Then I should be on the supplier home page
+    
+  Scenario: Select lot
+    Given I am at '/suppliers'
+    When I click 'Apply to become a G-Cloud 7 supplier and add services'
+    And I click 'Add a service'
+    When I choose 'Specialist Cloud Services (SCS)'
+    And I click 'Save and continue'
+    Then I should be on the 'Service description' page
+    
+  Scenario: Provide a service description
+    Given I am on ssp page 'service_description'
+    When I fill in 'serviceName' with 'My SCS service name'
+    And I fill in 'serviceSummary' with:
+      """
+      Service summary for my SCS service that does stuff with stuff.
+      """
+    And I click 'Save and continue'
+    # TODO: The next page will be 'Service type' once document uploads have moved to the end
+    Then I should be on the 'Service definition' page
+    
+  Scenario: Select a service type
+    Given I am on ssp page 'service_type'
+    When I check 'Testing'
+    And I click 'Save and continue'
+    Then I should be on the 'Features and benefits' page
+
+  Scenario: Features and benefits
+    Given I am on ssp page 'features_and_benefits'
+    When I fill in 'serviceFeatures-1' with 'Service feature number one'
+    And I fill in 'serviceBenefits-1' with 'Service benefits number one'
+    And I click 'Save and continue'
+    Then I should be on the 'Pricing' page
+    
+  # TODO: Remove WIP once pricing is merged
+  @wip
+  Scenario: Pricing
+    Given I am on ssp page 'pricing'
+    When I fill in 'minPrice' with '100'
+    And I fill in 'maxPrice' with '1000'
+    And I select 'Unit' from 'priceUnit'
+    And I select 'Second' from 'priceInterval'
+    And I choose 'vatIncluded-yes'
+    And I choose 'educationPricing-no'
+    And I click 'Save and continue'
+    Then I should be on the 'Terms and conditions' page
+
+  # TODO: Remove WIP once documents moved to end
+  @wip
+  Scenario: Terms and conditions
+    Given I am on ssp page 'terms_and_conditions'
+    When I choose 'terminationCost-no'
+    And I choose 'minimumContractPeriod-3'
+    And I click 'Save and continue'
+    Then I should be on the 'Support' page
+
+  @listing_page
+  Scenario: Go to listing page and the service is not complete
+    Given I am at the g7 supplier dashboard page
+    When I click my service
+    Then I should be on the 'My SCS service name' page
+    And The string 'Answer required' should be on the page
+    And The string 'The service is complete' should not be on the page
+
+  Scenario: Support
+    Given I am on ssp page 'support'
+    When I check 'supportTypes-1'
+    And I choose 'supportForThirdParties-yes'
+    And I fill in 'supportAvailability' with '24/7 365 days'
+    And I fill in 'supportResponseTime' with 'Within 1 hour'
+    And I choose 'incidentEscalation-yes'
+    And I click 'Save and continue'
+    Then I should be on the 'Certifications' page
+
+  Scenario: Certifications
+    Given I am on ssp page 'certifications'
+    When I fill in 'vendorCertifications-1' with 'Vendor certification one provided.'
+    And I click 'Save and continue'
+    # TODO: The next page will be 'Service definition' once document uploads have moved to the end
+    Then I should be on the 'My SCS service name' page
+
+  # TODO: Remove WIP once documents moved to end
+  @wip    
+  Scenario: Service definition document
+    Given I am on ssp page 'service_definition'
+    When I choose file 'test.pdf' for 'serviceDefinitionDocumentURL'
+    And I click 'Save and continue'
+    Then I should be on the 'Terms and conditions document' page
+
+  # TODO: Remove WIP once documents moved to end
+  @wip
+  Scenario: Terms and conditions document
+    Given I am on ssp page 'terms_and_conditions_document'
+    When I choose file 'test.pdf' for 'termsAndConditionsDocumentURL'
+    And I click 'Save and continue'
+    Then I should be on the 'Pricing document' page
+
+  # TODO: Remove WIP once documents moved to end
+  @wip
+  Scenario: Pricing document
+    Given I am on ssp page 'pricing_document'
+    When I choose file 'test.pdf' for 'pricingDocumentURL'
+    And I click 'Save and continue'
+    Then I should be on the 'SFIA rate card' page
+
+  # TODO: Remove WIP once documents moved to end
+  @wip
+  Scenario: SFIA rate card document
+    Given I am on ssp page 'sfia_rate_card'
+    When I choose file 'test.pdf' for 'sfiaRateDocumentURL'
+    And I click 'Save and continue'
+    Then I should be on the 'My SCS service name' page
+  
+  # TODO: Remove WIP once completing services is implemented 
+  @wip
+  Scenario: The service is complete
+    Given I am on the summary page
+    Then The string 'Answer required' should not be on the page
+    And The string 'The service is complete' should be on the page
+
+  @delete_service
+  Scenario: Delete the service
+#  TODO: Reinstate this once the delete button is there - and delete the three lines below
+#    Given I am on the summary page
+#    When I click 'Delete this service'
+#    And I click 'Yes, delete “My SCS service name”'
+#    Then I should be on the supplier home page
+#    And My service should not be in the list
+    Given The service is deleted
+    When I am at the g7 supplier dashboard page
+    Then My service should not be in the list

--- a/features/ssp_scs_service.feature
+++ b/features/ssp_scs_service.feature
@@ -7,15 +7,16 @@ Feature: Submitting a new service for SCS
     Given I am on the 'Supplier' login page
     When I login as a 'Supplier' user
     Then I should be on the supplier home page
-    
+
   Scenario: Select lot
     Given I am at '/suppliers'
     When I click 'Apply to become a G-Cloud 7 supplier and add services'
+    And I click 'Add services'
     And I click 'Add a service'
     When I choose 'Specialist Cloud Services (SCS)'
     And I click 'Save and continue'
     Then I should be on the 'Service description' page
-    
+
   Scenario: Provide a service description
     Given I am on ssp page 'service_description'
     When I fill in 'serviceName' with 'My SCS service name'
@@ -25,7 +26,7 @@ Feature: Submitting a new service for SCS
       """
     And I click 'Save and continue'
     Then I should be on the 'Service type' page
-    
+
   Scenario: Select a service type
     Given I am on ssp page 'service_type'
     When I check 'Testing'
@@ -38,7 +39,7 @@ Feature: Submitting a new service for SCS
     And I fill in 'serviceBenefits-1' with 'Service benefits number one'
     And I click 'Save and continue'
     Then I should be on the 'Pricing' page
-    
+
   Scenario: Pricing
     Given I am on ssp page 'pricing'
     When I fill in 'priceStringMinPrice' with '100'
@@ -49,7 +50,7 @@ Feature: Submitting a new service for SCS
     And I choose 'educationPricing-no'
     And I click 'Save and continue'
     Then I should be on the 'Terms and conditions' page
-    
+
   Scenario: Terms and conditions
     Given I am on ssp page 'terms_and_conditions'
     When I choose 'terminationCost-no'
@@ -80,32 +81,32 @@ Feature: Submitting a new service for SCS
     When I fill in 'vendorCertifications-1' with 'Vendor certification one provided.'
     And I click 'Save and continue'
     Then I should be on the 'Service definition' page
-    
+
   Scenario: Service definition document
     Given I am on ssp page 'service_definition'
     When I choose file 'test.pdf' for 'serviceDefinitionDocumentURL'
     And I click 'Save and continue'
     Then I should be on the 'Terms and conditions document' page
-    
+
   Scenario: Terms and conditions document
     Given I am on ssp page 'terms_and_conditions_document'
     When I choose file 'test.pdf' for 'termsAndConditionsDocumentURL'
     And I click 'Save and continue'
     Then I should be on the 'Pricing document' page
-    
+
   Scenario: Pricing document
     Given I am on ssp page 'pricing_document'
     When I choose file 'test.pdf' for 'pricingDocumentURL'
     And I click 'Save and continue'
     Then I should be on the 'SFIA rate card' page
-    
+
   Scenario: SFIA rate card document
     Given I am on ssp page 'sfia_rate_card'
     When I choose file 'test.pdf' for 'sfiaRateDocumentURL'
     And I click 'Save and continue'
     Then I should be on the 'My SCS service name' page
-  
-  # TODO: Remove WIP once completing services is implemented 
+
+  # TODO: Remove WIP once completing services is implemented
   @wip
   Scenario: The service is complete
     Given I am on the summary page
@@ -117,5 +118,5 @@ Feature: Submitting a new service for SCS
     Given I am on the summary page
     When I click 'Delete this service'
     And I click 'Yes, delete “My SCS service name”'
-    Then I should be on the g7 supplier dashboard page
+    Then I should be on the g7 services page
     And My service should not be in the list

--- a/features/ssp_scs_service.feature
+++ b/features/ssp_scs_service.feature
@@ -24,8 +24,7 @@ Feature: Submitting a new service for SCS
       Service summary for my SCS service that does stuff with stuff.
       """
     And I click 'Save and continue'
-    # TODO: The next page will be 'Service type' once document uploads have moved to the end
-    Then I should be on the 'Service definition' page
+    Then I should be on the 'Service type' page
     
   Scenario: Select a service type
     Given I am on ssp page 'service_type'
@@ -40,21 +39,17 @@ Feature: Submitting a new service for SCS
     And I click 'Save and continue'
     Then I should be on the 'Pricing' page
     
-  # TODO: Remove WIP once pricing is merged
-  @wip
   Scenario: Pricing
     Given I am on ssp page 'pricing'
-    When I fill in 'minPrice' with '100'
-    And I fill in 'maxPrice' with '1000'
-    And I select 'Unit' from 'priceUnit'
-    And I select 'Second' from 'priceInterval'
+    When I fill in 'priceStringMinPrice' with '100'
+    And I fill in 'priceStringMaxPrice' with '1000'
+    And I select 'Unit' from 'priceStringUnit'
+    And I select 'Second' from 'priceStringInterval'
     And I choose 'vatIncluded-yes'
     And I choose 'educationPricing-no'
     And I click 'Save and continue'
     Then I should be on the 'Terms and conditions' page
-
-  # TODO: Remove WIP once documents moved to end
-  @wip
+    
   Scenario: Terms and conditions
     Given I am on ssp page 'terms_and_conditions'
     When I choose 'terminationCost-no'
@@ -84,35 +79,26 @@ Feature: Submitting a new service for SCS
     Given I am on ssp page 'certifications'
     When I fill in 'vendorCertifications-1' with 'Vendor certification one provided.'
     And I click 'Save and continue'
-    # TODO: The next page will be 'Service definition' once document uploads have moved to the end
-    Then I should be on the 'My SCS service name' page
-
-  # TODO: Remove WIP once documents moved to end
-  @wip    
+    Then I should be on the 'Service definition' page
+    
   Scenario: Service definition document
     Given I am on ssp page 'service_definition'
     When I choose file 'test.pdf' for 'serviceDefinitionDocumentURL'
     And I click 'Save and continue'
     Then I should be on the 'Terms and conditions document' page
-
-  # TODO: Remove WIP once documents moved to end
-  @wip
+    
   Scenario: Terms and conditions document
     Given I am on ssp page 'terms_and_conditions_document'
     When I choose file 'test.pdf' for 'termsAndConditionsDocumentURL'
     And I click 'Save and continue'
     Then I should be on the 'Pricing document' page
-
-  # TODO: Remove WIP once documents moved to end
-  @wip
+    
   Scenario: Pricing document
     Given I am on ssp page 'pricing_document'
     When I choose file 'test.pdf' for 'pricingDocumentURL'
     And I click 'Save and continue'
     Then I should be on the 'SFIA rate card' page
-
-  # TODO: Remove WIP once documents moved to end
-  @wip
+    
   Scenario: SFIA rate card document
     Given I am on ssp page 'sfia_rate_card'
     When I choose file 'test.pdf' for 'sfiaRateDocumentURL'
@@ -128,12 +114,8 @@ Feature: Submitting a new service for SCS
 
   @delete_service
   Scenario: Delete the service
-#  TODO: Reinstate this once the delete button is there - and delete the three lines below
-#    Given I am on the summary page
-#    When I click 'Delete this service'
-#    And I click 'Yes, delete “My SCS service name”'
-#    Then I should be on the supplier home page
-#    And My service should not be in the list
-    Given The service is deleted
-    When I am at the g7 supplier dashboard page
-    Then My service should not be in the list
+    Given I am on the summary page
+    When I click 'Delete this service'
+    And I click 'Yes, delete “My SCS service name”'
+    Then I should be on the g7 supplier dashboard page
+    And My service should not be in the list

--- a/features/ssp_validation.feature
+++ b/features/ssp_validation.feature
@@ -1,0 +1,408 @@
+#################################################################################
+#                                                                               #
+# NOTE: THIS IS CURRENTLY JUST A COPY OF THE VALIDATION FEATURE FROM THE G6 SSP #
+#                                                                               #
+#################################################################################
+
+@wip
+Feature: Page validation
+
+  Scenario: Select lot
+    Given I am logged in as a 'supplier'
+    And I am at '/addservice'
+    When I choose 'Infrastructure as a Service (IaaS)'
+    And I click 'Save and continue'
+    Then I should be on the 'Service type' page
+
+  Scenario: Service type - no data
+    Given I am on ssp page '1'
+    And I click 'Save and continue'
+    Then I should be on the 'Service type' page
+    And I get a summary error of 'Choose the categories that apply to your service' and an inline error of 'This question requires an answer.' for question 'p1q1'
+
+  Scenario: Service description - no data
+    Given I am on ssp page '4'
+    And I click 'Save and continue'
+    Then I should be on the 'Service description' page
+    And I get a summary error of 'Service name' and an inline error of 'This question requires an answer.' for question 'p4q1'
+    And I get a summary error of 'Service summary' and an inline error of 'This question requires an answer.' for question 'p4q2'
+
+  Scenario: Provide a service description so we can delete it later
+    Given I am on ssp page '4'
+    When I fill in 'p4q1' with 'My IaaS service'
+    And I fill in 'p4q2' with:
+    """
+    My service that does stuff with stuff.
+    """
+    And I click 'Save and continue'
+    Then I should be on the 'Features and benefits' page
+
+  Scenario: Service description - too many characters
+    Given I am on ssp page '4'
+    When I fill in 'p4q1' with 'Way too many characters.Way too many characters.Way too many characters.Way too many characters.Way too many characters.'
+    And I fill in 'p4q2' with:
+    """
+    Way too many characters.Way too many characters.Way too many characters.Way too many characters.
+    Way too many characters.Way too many characters.Way too many characters.Way too many characters.
+    Way too many characters.Way too many characters.Way too many characters.Way too many characters.
+    Way too many characters.Way too many characters.Way too many characters.Way too many characters.
+    Way too many characters.Way too many characters.Way too many characters.Way too many characters.
+    Way too many characters.Way too many characters.Way too many characters.Way too many characters.
+    """
+    And I click 'Save and continue'
+    Then I should be on the 'Service description' page
+    And I get a summary error of 'Service name' and an inline error of 'Your answer must be less than 100 characters in length.' for question 'p4q1'
+    And I get a summary error of 'Service summary' and an inline error of 'Your answer must be less than 50 words.' for question 'p4q2'
+
+  Scenario: Features and benefits - no data
+    Given I am on ssp page '5'
+    And I click 'Save and continue'
+    Then I should be on the 'Features and benefits' page
+    And I get a summary error of 'Service features' and an inline error of 'This question requires an answer.' for question 'p5q1'
+    And I get a summary error of 'Service benefits' and an inline error of 'This question requires an answer.' for question 'p5q2'
+
+  Scenario: Features and benefits - too many words
+    Given I am on ssp page '5'
+    When I fill in 'p5q1val1' with 'way too many characters way too many characters way too many characters'
+    And I fill in 'p5q2val1' with 'way too many characters way too many characters way too many characters'
+    And I click 'Save and continue'
+    Then I should be on the 'Features and benefits' page
+    And I get a summary error of 'Service features' and an inline error of 'Each feature must be less than 10 words.' for question 'p5q1'
+    And I get a summary error of 'Service benefits' and an inline error of 'Each benefit must be less than 10 words.' for question 'p5q2'
+
+  Scenario: Service definition - no data
+    Given I am on ssp page '6'
+    And I click 'Save and continue'
+    Then I should be on the 'Service definition' page
+    And I get a summary error of 'Service definition document' and an inline error of 'This question requires an answer.' for question 'p6q1'
+
+  Scenario: Service definition - file size too large (greater than 5mb)
+    Given I am on ssp page '6'
+    When I choose file 'greater-than-5-mb.pdf' for 'p6q1'
+    And I click 'Save and continue'
+    Then I should be on the 'Service definition' page
+    And I get a summary error of 'Service definition document' and an inline error of 'Your document exceeds the 5MB limit. Please reduce file size.' for question 'p6q1'
+
+  Scenario: Service definition - unsupported file format
+    Given I am on ssp page '6'
+    When I choose file 'a-docx.docx' for 'p6q1'
+    And I click 'Save and continue'
+    Then I should be on the 'Service definition' page
+    And I get a summary error of 'Service definition document' and an inline error of 'Your document is not in an open format. Please save as an Open Document Format (ODF) or PDF/A (eg .pdf, .odt).' for question 'p6q1'
+
+  Scenario: Terms and conditions - no data
+    Given I am on ssp page '7'
+    And I click 'Save and continue'
+    Then I should be on the 'Terms and conditions' page
+    Then I get a summary error of 'Termination cost' and an inline error of 'This question requires an answer.' for question 'p7q1'
+    And I get a summary error of 'Minimum contract period' and an inline error of 'This question requires an answer.' for question 'p7q2'
+    And I get a summary error of 'Please upload your terms and conditions document' and an inline error of 'This question requires an answer.' for question 'p7q3'
+
+  Scenario: Terms and conditions - file size too large
+    Given I am on ssp page '7'
+    And I choose file 'greater-than-5-mb.pdf' for 'p7q3'
+    And I click 'Save and continue'
+    Then I should be on the 'Terms and conditions' page
+    And I get a summary error of 'Please upload your terms and conditions document' and an inline error of 'Your document exceeds the 5MB limit. Please reduce file size.' for question 'p7q3'
+
+  Scenario: Pricing - no data
+    Given I am on ssp page '8'
+    When I click 'Save and continue'
+    Then I should be on the 'Pricing' page
+    And I get a summary error of 'Service price' and an inline error of 'Minimum price requires an answer.' for question 'p8q1'
+    And I get a summary error of 'VAT included' and an inline error of 'This question requires an answer.' for question 'p8q2'
+    And I get a summary error of 'Education pricing' and an inline error of 'This question requires an answer.' for question 'p8q3'
+    And I get a summary error of 'Trial option' and an inline error of 'This question requires an answer.' for question 'p8q4'
+    And I get a summary error of 'Free option' and an inline error of 'This question requires an answer.' for question 'p8q5'
+    And I get a summary error of 'Pricing document' and an inline error of 'This question requires an answer.' for question 'p8q6'
+
+  Scenario: Pricing - no data 2
+    Given I am on ssp page '8'
+    When I fill in 'p8q1MinPrice' with '100'
+    And I choose 'p8q2-option-1'
+    And I choose 'p8q3-option-1'
+    And I choose 'p8q4-option-1'
+    And I choose 'p8q5-option-1'
+    And I choose file 'a-pdf.pdf' for 'p8q6'
+    And I choose file 'a-pdf.pdf' for 'p8q7'
+    And I click 'Save and continue'
+    Then I should be on the 'Pricing' page
+    And I get a summary error of 'Service price' and an inline error of 'Pricing unit requires an answer. If none of the provided units apply, please choose 'Unit'.' for question 'p8q1'
+
+  Scenario: Pricing - unsupported file format
+    Given I am on ssp page '8'
+    And I choose file 'a-docx.docx' for 'p8q6'
+    And I choose file 'a-docx.docx' for 'p8q7'
+    And I click 'Save and continue'
+    Then I should be on the 'Pricing' page
+    And I get a summary error of 'Pricing document' and an inline error of 'Your document is not in an open format. Please save as an Open Document Format (ODF) or PDF/A (eg .pdf, .odt).' for question 'p8q6'
+    And I get a summary error of 'Skills Framework for the Information Age (SFIA) rate card' and an inline error of 'Your document is not in an open format. Please save as an Open Document Format (ODF) or PDF/A (eg .pdf, .odt).' for question 'p8q7'
+
+  Scenario: Pricing - file size too large (greater than 5mb)
+    Given I am on ssp page '8'
+    And I choose file 'greater-than-5-mb.pdf' for 'p8q6'
+    And I choose file 'greater-than-5-mb.pdf' for 'p8q7'
+    And I click 'Save and continue'
+    Then I should be on the 'Pricing' page
+    And I get a summary error of 'Pricing document' and an inline error of 'Your document exceeds the 5MB limit. Please reduce file size.' for question 'p8q6'
+    And I get a summary error of 'Skills Framework for the Information Age (SFIA) rate card' and an inline error of 'Your document exceeds the 5MB limit. Please reduce file size.' for question 'p8q7'
+
+  Scenario: Open standards - no data
+    Given I am on ssp page '9'
+    When I click 'Save and continue'
+    Then I should be on the 'Open standards' page
+    And I get a summary error of 'Open standards supported and documented' and an inline error of 'This question requires an answer.' for question 'p9q1'
+
+  Scenario: Support - no data
+    Given I am on ssp page '10'
+    When I click 'Save and continue'
+    Then I should be on the 'Support' page
+    And I get a summary error of 'Support service type' and an inline error of 'This question requires an answer.' for question 'p10q1'
+    And I get a summary error of 'Support accessible to any third-party suppliers' and an inline error of 'This question requires an answer.' for question 'p10q2'
+    And I get a summary error of 'Support availablility' and an inline error of 'This question requires an answer.' for question 'p10q3'
+    And I get a summary error of 'Standard support response times' and an inline error of 'This question requires an answer.' for question 'p10q4'
+    And I get a summary error of 'Incident escalation process available' and an inline error of 'This question requires an answer.' for question 'p10q5'
+
+  Scenario: Support - exceeds 20 words
+    Given I am on ssp page '10'
+    And I fill in 'p10q3' with:
+     """
+     Way too many characters.Way too many characters. Way too many characters.Way too many characters. Way too many characters.Way too many characters. Way too many characters. Way too many characters. Way too many characters.
+     """
+    And I fill in 'p10q4' with:
+     """
+     Way too many characters.Way too many characters. Way too many characters.Way too many characters. Way too many characters.Way too many characters. Way too many characters. Way too many characters. Way too many characters.
+     """
+    And I choose 'p10q5-option-1'
+    And I click 'Save and continue'
+    Then I should be on the 'Support' page
+    And I get a summary error of 'Support availablility' and an inline error of 'Your answer must be less than 20 words.' for question 'p10q3'
+    And I get a summary error of 'Standard support response times' and an inline error of 'Your answer must be less than 20 words.' for question 'p10q4'
+
+  Scenario: Onboarding and offboarding - no data
+    Given I am on ssp page '11'
+    When I click 'Save and continue'
+    Then I should be on the 'Onboarding and offboarding' page
+    And I get a summary error of 'Service onboarding process included' and an inline error of 'This question requires an answer.' for question 'p11q1'
+    And I get a summary error of 'Service offboarding process included' and an inline error of 'This question requires an answer.' for question 'p11q2'
+
+  Scenario: Analytics - no data
+    Given I am on ssp page '12'
+    When I click 'Save and continue'
+    Then I should be on the 'Analytics' page
+    And I get a summary error of 'Real-time management information available' and an inline error of 'This question requires an answer.' for question 'p12q1'
+
+  Scenario: Cloud features - no data
+    Given I am on ssp page '13'
+    When I click 'Save and continue'
+    Then I should be on the 'Cloud features' page
+    And I get a summary error of 'Elastic cloud approach supported' and an inline error of 'This question requires an answer.' for question 'p13q1'
+    And I get a summary error of 'Guaranteed resources defined' and an inline error of 'This question requires an answer.' for question 'p13q2'
+    And I get a summary error of 'Persistent storage supported' and an inline error of 'This question requires an answer.' for question 'p13q3'
+
+  Scenario: Provisioning - no data
+    Given I am on ssp page '14'
+    When I click 'Save and continue'
+    Then I should be on the 'Provisioning' page
+    And I get a summary error of 'Self-service provisioning supported' and an inline error of 'This question requires an answer.' for question 'p14q1'
+    And I get a summary error of 'Service provisioning time' and an inline error of 'This question requires an answer.' for question 'p14q2'
+    And I get a summary error of 'Service deprovisioning time' and an inline error of 'This question requires an answer.' for question 'p14q3'
+
+  Scenario: Open source - no data
+    Given I am on ssp page '15'
+    When I click 'Save and continue'
+    Then I should be on the 'Open source' page
+    And I get a summary error of 'Open-source software used and supported' and an inline error of 'This question requires an answer.' for question 'p15q1'
+
+  Scenario: API access - no data
+    Given I am on ssp page '17'
+    When I click 'Save and continue'
+    Then I should be on the 'API access' page
+    And I get a summary error of 'API access available and supported' and an inline error of 'This question requires an answer.' for question 'p17q1'
+
+  Scenario: API access - if yes type required
+    Given I am on ssp page '17'
+    When I choose 'p17q1-option-1'
+    And I click 'Save and continue'
+    Then I should be on the 'API access' page
+    And I get a summary error of 'API type' and an inline error of 'This question requires an answer.' for question 'p17q2'
+
+  Scenario: Networks and connectivity - no data
+    Given I am on ssp page '18'
+    When I click 'Save and continue'
+    Then I should be on the 'Networks and connectivity' page
+    And I get a summary error of 'Networks the service is directly connected to' and an inline error of 'This question requires an answer.' for question 'p18q1'
+
+  Scenario: Access - no data
+    Given I am on ssp page '19'
+    When I click 'Save and continue'
+    Then I should be on the 'Access' page
+    And I get a summary error of 'Supported web browsers' and an inline error of 'This question requires an answer.' for question 'p19q1'
+    And I get a summary error of 'Offline working and syncing supported' and an inline error of 'This question requires an answer.' for question 'p19q2'
+    And I get a summary error of 'Supported devices' and an inline error of 'This question requires an answer.' for question 'p19q3'
+
+  Scenario: Certifications - too much data
+    Given I am on ssp page '20'
+    When I fill in 'p20q1val1' with 'Way too many characters.Way too many characters.Way too many characters.Way too many characters.Way too many characters.'
+    When I click 'Save and continue'
+    Then I should be on the 'Certifications' page
+    And I get a summary error of 'Vendor certification(s)' and an inline error of 'Each certification must be less than 100 characters in length.' for question 'p20q1'
+
+  Scenario: Data storage - no data
+    Given I am on ssp page '22'
+    When I click 'Save and continue'
+    Then I should be on the 'Data storage' page
+    And I get a summary error of 'Datacentres adhere to EU Code of Conduct for Operations' and an inline error of 'This question requires an answer.' for question 'p22q1'
+    And I get a summary error of 'User-defined data location' and an inline error of 'This question requires an answer.' for question 'p22q2'
+    And I get a summary error of 'Datacentre tier' and an inline error of 'This question requires an answer.' for question 'p22q3'
+    And I get a summary error of 'Backup, disaster recovery and resilience plan in place' and an inline error of 'Please answer if plans for backup, disaster recovery and resilience are in place' for question 'p22q4'
+    And I get a summary error of 'Data extraction/removal plan in place' and an inline error of 'This question requires an answer.' for question 'p22q5'
+
+  Scenario: Data-in-transit protection - no data
+    Given I am on ssp page '23'
+    When I click 'Save and continue'
+    Then I should be on the 'Data-in-transit protection' page
+    And I get a summary error of 'Data protection between user device and service' and an inline error of 'This question requires an answer.' for question 'p23q1'
+    And I get a summary error of 'Data protection within service' and an inline error of 'This question requires an answer.' for question 'p23q2'
+    And I get a summary error of 'Data protection between services' and an inline error of 'This question requires an answer.' for question 'p23q3'
+
+  Scenario: Asset protection and resilience - no data
+    Given I am on ssp page '24'
+    When I click 'Save and continue'
+    Then I should be on the 'Asset protection and resilience' page
+    And I get a summary error of 'Datacentre location' and an inline error of 'This question requires an answer.' for question 'p24q1'
+    And I get a summary error of 'Data management location' and an inline error of 'This question requires an answer.' for question 'p24q2'
+    And I get a summary error of 'Legal jurisdiction of service provider' and an inline error of 'This question requires an answer.' for question 'p24q3'
+    And I get a summary error of 'Datacentre protection' and an inline error of 'This question requires an answer.' for question 'p24q4'
+    And I get a summary error of 'Data-at-rest protection' and an inline error of 'This question requires an answer.' for question 'p24q5'
+    And I get a summary error of 'Secure data deletion' and an inline error of 'This question requires an answer.' for question 'p24q6'
+    And I get a summary error of 'Storage media disposal' and an inline error of 'This question requires an answer.' for question 'p24q7'
+    And I get a summary error of 'Secure equipment disposal' and an inline error of 'This question requires an answer.' for question 'p24q8'
+    And I get a summary error of 'Redundant equipment accounts revoked' and an inline error of 'This question requires an answer.' for question 'p24q9'
+    And I get a summary error of 'Service availability' and an inline error of 'This question requires an answer.' for question 'p24q10'
+
+  Scenario: Separation between consumers - no data
+    Given I am on ssp page '25'
+    When I click 'Save and continue'
+    Then I should be on the 'Separation between consumers' page
+    And I get a summary error of 'Cloud deployment model' and an inline error of 'This question requires an answer.' for question 'p25q1'
+    And I get a summary error of 'Type of consumer' and an inline error of 'This question requires an answer.' for question 'p25q2'
+    And I get a summary error of 'Services separation' and an inline error of 'This question requires an answer.' for question 'p25q3'
+    And I get a summary error of 'Services management separation' and an inline error of 'This question requires an answer.' for question 'p25q4'
+
+  Scenario: Governance - no data
+    Given I am on ssp page '26'
+    When I click 'Save and continue'
+    Then I should be on the 'Governance' page
+    And I get a summary error of 'Governance framework' and an inline error of 'This question requires an answer.' for question 'p26q1'
+
+  Scenario: Configuration and change management - no data
+    Given I am on ssp page '27'
+    When I click 'Save and continue'
+    Then I should be on the 'Configuration and change management' page
+    And I get a summary error of 'Configuration and change management tracking' and an inline error of 'This question requires an answer.' for question 'p27q1'
+    And I get a summary error of 'Change impact assessment' and an inline error of 'This question requires an answer.' for question 'p27q2'
+
+  Scenario: Vulnerabilility management - no data
+    Given I am on ssp page '28'
+    When I click 'Save and continue'
+    Then I should be on the 'Vulnerabilility management' page
+    And I get a summary error of 'Vulnerability assessment' and an inline error of 'This question requires an answer.' for question 'p28q1'
+    And I get a summary error of 'Vulnerability monitoring' and an inline error of 'This question requires an answer.' for question 'p28q2'
+    And I get a summary error of 'Vulnerability mitigation prioritisation' and an inline error of 'This question requires an answer.' for question 'p28q3'
+    And I get a summary error of 'Vulnerability tracking' and an inline error of 'This question requires an answer.' for question 'p28q4'
+    And I get a summary error of 'Vulnerability mitigation timescales' and an inline error of 'This question requires an answer.' for question 'p28q5'
+
+  Scenario: Event monitoring - no data
+    Given I am on ssp page '29'
+    When I click 'Save and continue'
+    Then I should be on the 'Event monitoring' page
+    And I get a summary error of 'Event monitoring' and an inline error of 'This question requires an answer.' for question 'p29q1'
+
+  Scenario: Incident management - no data
+    Given I am on ssp page '30'
+    When I click 'Save and continue'
+    Then I should be on the 'Incident management' page
+    And I get a summary error of 'Incident management processes' and an inline error of 'This question requires an answer.' for question 'p30q1'
+    And I get a summary error of 'Consumer reporting of security incidents' and an inline error of 'This question requires an answer.' for question 'p30q2'
+    And I get a summary error of 'Security incident definition published' and an inline error of 'This question requires an answer.' for question 'p30q3'
+
+  Scenario: Personnel security - no data
+    Given I am on ssp page '31'
+    When I click 'Save and continue'
+    Then I should be on the 'Personnel security' page
+    And I get a summary error of 'Personnel security checks' and an inline error of 'This question requires an answer.' for question 'p31q1'
+
+  Scenario: Secure development - no data
+    Given I am on ssp page '32'
+    When I click 'Save and continue'
+    Then I should be on the 'Secure development' page
+    And I get a summary error of 'Secure development' and an inline error of 'This question requires an answer.' for question 'p32q1'
+    And I get a summary error of 'Secure design, coding, testing and deployment' and an inline error of 'This question requires an answer.' for question 'p32q2'
+    And I get a summary error of 'Software configuration management' and an inline error of 'This question requires an answer.' for question 'p32q3'
+
+  Scenario: Supply-chain security - no data
+    Given I am on ssp page '33'
+    When I click 'Save and continue'
+    Then I should be on the 'Supply-chain security' page
+    And I get a summary error of 'Visibility of data shared with third-party suppliers' and an inline error of 'This question requires an answer.' for question 'p33q1'
+    And I get a summary error of 'Third-party supplier security requirements' and an inline error of 'This question requires an answer.' for question 'p33q2'
+    And I get a summary error of 'Third-party supplier risk assessment' and an inline error of 'This question requires an answer.' for question 'p33q3'
+    And I get a summary error of 'Third-party supplier compliance monitoring' and an inline error of 'This question requires an answer.' for question 'p33q4'
+    And I get a summary error of 'Hardware and software verification' and an inline error of 'This question requires an answer.' for question 'p33q5'
+
+  Scenario: Authentication of consumers - no data
+    Given I am on ssp page '34'
+    When I click 'Save and continue'
+    Then I should be on the 'Authentication of consumers' page
+    And I get a summary error of 'User authentication and access management' and an inline error of 'This question requires an answer.' for question 'p34q1'
+    And I get a summary error of 'User access control through support channels' and an inline error of 'This question requires an answer.' for question 'p34q2'
+
+  Scenario: Separation and access control within management interfaces - no data
+    Given I am on ssp page '35'
+    When I click 'Save and continue'
+    Then I should be on the 'Separation and access control within management interfaces' page
+    And I get a summary error of 'User access control within management interfaces' and an inline error of 'This question requires an answer.' for question 'p35q1'
+    And I get a summary error of 'Administrator permissions' and an inline error of 'This question requires an answer.' for question 'p35q2'
+    And I get a summary error of 'Management interface protection' and an inline error of 'This question requires an answer.' for question 'p35q3'
+
+  Scenario: Identity and authentication - no data
+    Given I am on ssp page '36'
+    When I click 'Save and continue'
+    Then I should be on the 'Identity and authentication' page
+    And I get a summary error of 'Identity and authentication controls' and an inline error of 'This question requires an answer.' for question 'p36q1'
+
+  Scenario: External interface protection - no data
+    Given I am on ssp page '37'
+    When I click 'Save and continue'
+    Then I should be on the 'External interface protection' page
+    And I get a summary error of 'Onboarding guidance provided' and an inline error of 'This question requires an answer.' for question 'p37q1'
+    And I get a summary error of 'Interconnection method provided' and an inline error of 'This question requires an answer.' for question 'p37q2'
+
+  Scenario: Secure service administration - no data
+    Given I am on ssp page '38'
+    When I click 'Save and continue'
+    Then I should be on the 'Secure service administration' page
+    And I get a summary error of 'Service management model' and an inline error of 'This question requires an answer.' for question 'p38q1'
+
+  Scenario: Audit information provision to consumers - no data
+    Given I am on ssp page '39'
+    When I click 'Save and continue'
+    Then I should be on the 'Audit information provision to consumers' page
+    And I get a summary error of 'Audit information provided' and an inline error of 'This question requires an answer.' for question 'p39q1'
+
+  Scenario: Secure use of the service by the customer - no data
+    Given I am on ssp page '40'
+    When I click 'Save and continue'
+    Then I should be on the 'Secure use of the service by the customer' page
+    And I get a summary error of 'Device access method' and an inline error of 'This question requires an answer.' for question 'p40q1'
+    And I get a summary error of 'Service configuration guidance' and an inline error of 'This question requires an answer.' for question 'p40q2'
+    And I get a summary error of 'Training' and an inline error of 'This question requires an answer.' for question 'p40q3'
+
+  @delete_service
+  Scenario: Delete the service
+    Given I am on the summary page
+    When I click 'Delete this service'
+    And I click 'Yes, delete “My IaaS service”'
+    Then I should be on the listing page
+    And My service should not be in the list

--- a/features/step_definitions/ssp_steps.rb
+++ b/features/step_definitions/ssp_steps.rb
@@ -21,6 +21,10 @@ Given /^I am at the g7 supplier dashboard page$/ do
   visit "#{dm_frontend_domain}/suppliers/frameworks/g-cloud-7"
 end
 
+Given /^I am at the g7 services page$/ do
+  visit "#{dm_frontend_domain}/suppliers/frameworks/g-cloud-7/services"
+end
+
 Given /^I am on the summary page$/ do
   visit("#{dm_frontend_domain}/suppliers/submission/services/#{store.current_listing}")
 end
@@ -33,10 +37,10 @@ Given /^The service is deleted$/ do
   delete_url = dm_api_domain + "/draft-services/#{store.current_listing}"
   token = dm_api_access_token
   headers = {:content_type => :json, :accept => :json, :authorization => "Bearer #{token}"}
-  
+
   response = RestClient::Request.execute(method: :delete, url: delete_url,
                               payload: UPDATER_JSON, headers: headers)
-  
+
   # response = RestClient.delete(url, UPDATER_JSON, headers){|response, request, result| response }  # Don't raise exceptions but return the response
   response.code.should == 200
 end
@@ -76,6 +80,10 @@ end
 
 Then /^I should be on the g7 supplier dashboard page$/ do
   URI.parse(current_url).path.should == "/suppliers/frameworks/g-cloud-7"
+end
+
+Then /^I should be on the g7 services page$/ do
+  URI.parse(current_url).path.should == "/suppliers/frameworks/g-cloud-7/services"
 end
 
 Then /^I should be on the '(.*)' page$/ do |title|

--- a/features/step_definitions/ssp_steps.rb
+++ b/features/step_definitions/ssp_steps.rb
@@ -1,0 +1,104 @@
+# encoding: utf-8
+require "ostruct"
+require "rest_client"
+
+store = OpenStruct.new
+
+UPDATER_JSON = '
+{
+    "update_details":
+      {
+          "updated_by": "Functional tests"
+      }
+}
+'
+
+Given /^I am at '(.*)'$/ do |path|
+  visit "#{dm_frontend_domain}/#{path}"
+end
+
+Given /^I am at the g7 supplier dashboard page$/ do
+  visit "#{dm_frontend_domain}/suppliers/frameworks/g-cloud-7"
+end
+
+Given /^I am on the summary page$/ do
+  visit("#{dm_frontend_domain}/suppliers/submission/services/#{store.current_listing}")
+end
+
+Given /^I am on ssp page '(.+)'$/ do |page_name|
+  visit("#{dm_frontend_domain}/suppliers/submission/services/#{store.current_listing}/edit/#{page_name}/")
+end
+
+Given /^The service is deleted$/ do
+  delete_url = dm_api_domain + "/draft-services/#{store.current_listing}"
+  token = dm_api_access_token
+  headers = {:content_type => :json, :accept => :json, :authorization => "Bearer #{token}"}
+  
+  response = RestClient::Request.execute(method: :delete, url: delete_url,
+                              payload: UPDATER_JSON, headers: headers)
+  
+  # response = RestClient.delete(url, UPDATER_JSON, headers){|response, request, result| response }  # Don't raise exceptions but return the response
+  response.code.should == 200
+end
+
+When /^I click my service$/ do
+  # Find link with the current listing in the href
+  find(:xpath, "//a[contains(@href, '/#{store.current_listing}')]").click
+end
+
+When /^I choose '(.*)'$/ do |label|
+  choose label
+end
+
+When /^I check '(.*)'$/ do |label|
+  check label
+end
+
+When /^I fill in '(.*)' with '(.*)'$/ do |label, value|
+  fill_in(label, :with => value)
+end
+
+When /^I fill in '(.*)' with:$/ do |label, value|
+  fill_in(label, :with => value)
+end
+
+When /^I select '(.*)' from '(.*)'$/ do |option, selector|
+  select(option, from: selector)
+end
+
+When /^I choose file '(.*)' for '(.*)'$/ do |file, label|
+  attach_file(label, File.join(Dir.pwd, 'fixtures', file))
+end
+
+Then /^I should be on the supplier home page$/ do
+  URI.parse(current_url).path.should == "/suppliers"
+end
+
+Then /^I should be on the g7 supplier dashboard page$/ do
+  URI.parse(current_url).path.should == "/suppliers/frameworks/g-cloud-7"
+end
+
+Then /^I should be on the '(.*)' page$/ do |title|
+  find('h1').should have_content(/#{title}/i)
+  parts = URI.parse(current_url).path.split('/')
+  while not /^\d+$/.match(parts.last)
+    parts.pop
+  end
+  store.current_listing = parts.pop
+end
+
+Then /^My service should be in the list$/ do
+  page.should have_selector(:xpath, "//a[@href='/suppliers/submission/services/#{store.current_listing}']")
+end
+
+Then /^My service should not be in the list$/ do
+  page.should have_no_selector(:xpath, "//a[@href='/suppliers/submission/services/#{store.current_listing}']")
+end
+
+Then /^The string '(.*)' should not be on the page$/ do |string|
+  page.should have_no_content(string)
+end
+
+Then /^The string '(.*)' should be on the page$/ do |string|
+  page.should have_content(string)
+end

--- a/features/step_definitions/ssp_steps.rb
+++ b/features/step_definitions/ssp_steps.rb
@@ -102,3 +102,24 @@ end
 Then /^The string '(.*)' should be on the page$/ do |string|
   page.should have_content(string)
 end
+
+Then /^Summary row '(.*)' should contain '(.*)'$/ do |question, text|
+  find(
+    :xpath,
+    "//*/span[contains(text(),'#{question}')]/../../td[@class='summary-item-field']/span"
+  ).should have_content(text)
+end
+
+Then /^Summary row '(.*)' should not contain '(.*)'$/ do |question, text|
+  find(
+    :xpath,
+    "//*/span[contains(text(),'#{question}')]/../../td[@class='summary-item-field']/span"
+  ).should have_no_content(text)
+end
+
+Then /^Summary row '(.*)' should not be empty$/ do |question|
+  find(
+    :xpath,
+    "//*/span[contains(text(),'#{question}')]/../../td[@class='summary-item-field']/span"
+  ).text.should_not == ''
+end

--- a/fixtures/test.pdf
+++ b/fixtures/test.pdf
@@ -1,0 +1,1 @@
+Not really a PDF


### PR DESCRIPTION
See: https://www.pivotaltracker.com/story/show/97631496

This adds features for all lots that create a new draft, complete all the pages (with a "happy path" - should be no errors), navigate to the summary page and delete the service to clean up.

The IaaS feature additionally checks that the correct values are displayed on the summary page - this is the same as we had for the G6 tests.  We might want to add summary page checking to the other lots too, but it would probably be overkill.

I have also copied the validations feature from the G6 tests, but have not had time to fix it to work with the new page and field names, hence the whole feature is marked as WIP.  I have only included the `ssp_steps` needed for the happy-path journeys here, so implementing the validation checking will probably require extra steps that can be found in the deleted methods here: https://github.com/alphagov/digitalmarketplace-smokey/commit/d12c2153d3f76507d1ed8a76487de7d785f4b6d1)