### PR TITLE
Fix smoke tests race condition on summary text check

### DIFF
--- a/features/step_definitions/journey_test_steps.rb
+++ b/features/step_definitions/journey_test_steps.rb
@@ -877,10 +877,10 @@ Then /I am on a page with that service\.(.*) in search summary text$/ do |attr_n
 end
 
 Then /I am on a page with '(.*)' in search summary text$/ do |value|
+  find(:xpath, "//*[@class='search-summary']/em[1]").text().should == normalize_whitespace(value)
+
   query_string = CGI.escape value
   current_url.should include("q=#{query_string}")
-
-  find(:xpath, "//*[@class='search-summary']/em[1]").text().should == normalize_whitespace(value)
 end
 
 Then /Selected lot is that service.lot with links to the search for that service.(.*)$/ do |attr|
@@ -936,7 +936,7 @@ Then /I am taken to the search results page with a result for the service '(.*)'
 end
 
 Then /I am on a page with that service in search results$/ do
-  search_results = all(:xpath, ".//div[@class='search-result']")
+  search_results = all(:xpath, ".//div[@class='search-result']", minimum: 1)
   service_result = search_results.find { |r| r.first(:xpath, './h2/a')[:href].include? @service['id']}
 
   service_result.first(:xpath, "./h2[@class='search-result-title']/a").text.should == normalize_whitespace(@service['serviceName'])


### PR DESCRIPTION
Capybara current_url access doesn't wait for page to load, so the
URL comparison can fail due to page load timing issues.

Using `find` blocks the step until the element is present on a page,
at which point the page was loaded and the `current_url` should be
up to date.