### PR TITLE
Fix SSP service description tests

### DIFF
--- a/features/ssp_iaas_service.feature
+++ b/features/ssp_iaas_service.feature
@@ -10,18 +10,22 @@ Feature: Submitting a new service for IaaS
 
   Scenario: Select lot
     Given I am at '/suppliers'
-    When I click 'Apply to become a G-Cloud 7 supplier and add services'
+    When I click 'Continue your G-Cloud 7 application'
     And I click 'Add services'
     And I click 'Add a service'
     When I choose 'Infrastructure as a Service (IaaS)' for 'lot'
     And I click 'Save and continue'
-    Then I should be on the 'Service description' page
+    Then I should be on the 'Service name' page
 
+  Scenario: Provide a service name
+    Given I am on ssp page 'service_name'
+    When I fill in 'serviceName' with 'My IaaS service'
+    And I click 'Save and continue'
+    Then I should be on the 'Service description' page
 
   Scenario: Provide a service description
     Given I am on ssp page 'service_description'
-    When I fill in 'serviceName' with 'My IaaS service'
-    And I fill in 'serviceSummary' with:
+    When I fill in 'serviceSummary' with:
       """
       My IaaS service that does stuff with stuff.
       """

--- a/features/ssp_paas_service.feature
+++ b/features/ssp_paas_service.feature
@@ -10,17 +10,22 @@ Feature: Submitting a new service for PaaS
 
   Scenario: Select lot
     Given I am at '/suppliers'
-    When I click 'Apply to become a G-Cloud 7 supplier and add services'
+    When I click 'Continue your G-Cloud 7 application'
     And I click 'Add services'
     And I click 'Add a service'
     When I choose 'Platform as a Service (PaaS)' for 'lot'
+    And I click 'Save and continue'
+    Then I should be on the 'Service name' page
+
+  Scenario: Provide a service name
+    Given I am on ssp page 'service_name'
+    When I fill in 'serviceName' with 'My PaaS service'
     And I click 'Save and continue'
     Then I should be on the 'Service description' page
 
   Scenario: Provide a service description
     Given I am on ssp page 'service_description'
-    When I fill in 'serviceName' with 'My PaaS service'
-    And I fill in 'serviceSummary' with:
+    When I fill in 'serviceSummary' with:
       """
       Platform as a service (PaaS) is a category of cloud computing services that provides a computing platform and a solution stack as a service.
       """

--- a/features/ssp_saas_service.feature
+++ b/features/ssp_saas_service.feature
@@ -10,17 +10,22 @@ Feature: Submitting a new service for SaaS
 
   Scenario: Select lot
     Given I am at '/suppliers'
-    When I click 'Apply to become a G-Cloud 7 supplier and add services'
+    When I click 'Continue your G-Cloud 7 application'
     And I click 'Add services'
     And I click 'Add a service'
     When I choose 'Software as a Service (SaaS)' for 'lot'
+    And I click 'Save and continue'
+    Then I should be on the 'Service name' page
+
+  Scenario: Provide a service name
+    Given I am on ssp page 'service_name'
+    When I fill in 'serviceName' with 'My SaaS service'
     And I click 'Save and continue'
     Then I should be on the 'Service description' page
 
   Scenario: Provide a service description
     Given I am on ssp page 'service_description'
-    When I fill in 'serviceName' with 'My SaaS service'
-    And I fill in 'serviceSummary' with:
+    When I fill in 'serviceSummary' with:
       """
       It's very SaaSy.
       """

--- a/features/ssp_scs_service.feature
+++ b/features/ssp_scs_service.feature
@@ -10,17 +10,22 @@ Feature: Submitting a new service for SCS
 
   Scenario: Select lot
     Given I am at '/suppliers'
-    When I click 'Apply to become a G-Cloud 7 supplier and add services'
+    When I click 'Continue your G-Cloud 7 application'
     And I click 'Add services'
     And I click 'Add a service'
     When I choose 'Specialist Cloud Services (SCS)' for 'lot'
+    And I click 'Save and continue'
+    Then I should be on the 'Service name' page
+
+  Scenario: Provide a service name
+    Given I am on ssp page 'service_name'
+    When I fill in 'serviceName' with 'My SCS service name'
     And I click 'Save and continue'
     Then I should be on the 'Service description' page
 
   Scenario: Provide a service description
     Given I am on ssp page 'service_description'
-    When I fill in 'serviceName' with 'My SCS service name'
-    And I fill in 'serviceSummary' with:
+    When I fill in 'serviceSummary' with:
       """
       Service summary for my SCS service that does stuff with stuff.
       """


### PR DESCRIPTION
The service description has been split over two pages. One for service name and one for the description.