### PR TITLE
Change to case-insensitive input label test

### DIFF
--- a/features/step_definitions/journey_test_steps.rb
+++ b/features/step_definitions/journey_test_steps.rb
@@ -314,10 +314,18 @@ And /I set '(.*)' as '(.*)'$/ do |field_to_change,new_value|
 end
 
 And /I choose '(.*)' for '(.*)'$/ do |new_value,field_to_change|
-  find(
+
+  inputs = all(
     :xpath,
-    "//*[contains(@name, '#{field_to_change}') and contains(../text(), '#{new_value}')]"
-  ).click
+    "//*[contains(@name, '#{field_to_change}')]"
+  )
+
+  input = inputs.find do |input|
+    input.find(:xpath, '..').text.downcase == new_value.downcase
+  end
+
+  input.click
+
   @changed_fields = @changed_fields || Hash.new
   @changed_fields[field_to_change] = new_value
 end


### PR DESCRIPTION
Targeting `<input>` elements in our functional tests meant looking for the `name` attribute and string-matching the text in the label.
This changes the string match to be case-insensitive because the text for the assurance questions (but not their `value`s) were all lowercased.