### PR TITLE
[#103486222] Fix test failures for service names with brackets

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.3.7)
+    addressable (2.3.8)
     builder (3.2.2)
     capybara (2.1.0)
       mime-types (>= 1.16)
@@ -30,9 +30,9 @@ GEM
     json (1.8.2)
     launchy (2.4.2)
       addressable (~> 2.3)
-    mime-types (2.4.3)
+    mime-types (2.6.2)
     mini_portile (0.5.3)
-    multi_json (1.11.0)
+    multi_json (1.11.2)
     multi_test (0.1.2)
     nokogiri (1.6.1)
       mini_portile (~> 0.5.0)
@@ -42,8 +42,8 @@ GEM
       cliver (~> 0.3.1)
       multi_json (~> 1.0)
       websocket-driver (>= 0.2.0)
-    power_assert (0.2.3)
-    rack (1.6.0)
+    power_assert (0.2.4)
+    rack (1.6.4)
     rack-test (0.6.3)
       rack (>= 1.0)
     rake (10.1.1)
@@ -89,3 +89,6 @@ DEPENDENCIES
   rspec (= 2.14.1)
   selenium-webdriver (= 2.47.1)
   test-unit (= 3.0.9)
+
+BUNDLED WITH
+   1.10.6

--- a/features/step_definitions/journey_test_steps.rb
+++ b/features/step_definitions/journey_test_steps.rb
@@ -1014,9 +1014,6 @@ Then /I am on a page with that service\.(.*) in search summary text$/ do |attr_n
 end
 
 Then /I am on a page with '(.*)' in search summary text$/ do |value|
-  query_string = CGI.escape value
-  current_url.should include("q=#{query_string}")
-
   find(:xpath, "//*[@class='search-summary']/em[1]").text().should == normalize_whitespace(value)
 end
 


### PR DESCRIPTION
Fixes this bug: https://www.pivotaltracker.com/story/show/103486222 - the solution proposed here may be controversial and I'm open to other suggestions if you don't like it.

The step definition for `Then I am on a page with that <service name> in search summary text` currently includes a check that the service name is in the `q` parameter in the URL of the page. This query string check is failing for searches including service names with brackets.

The CGI encoder encodes brackets as `%28` and `%29` but our app doesn't, so matches fail.
Using a URI encoder is worse because as well as encoding the brackets it encodes spaces as `%20` instead of `+`, which our apps do.

Doing ad-hoc replacement of `%28` and `%29` in CGI-escaped strings feels too hacky, and who knows what other characters might cause the same problem in future.

So I propose to not check the query parameter at all, and just stick with the check of the content on the page. The scenario description is just that the submitted query appears in the search summary on the page - it doesn't mention anything about the query parameter, so I think removing that check from this test is OK.  It still does what the scenario demands.

An alternative would be to change the way the buyer app and search API encode and decode query strings, but as they are all working nicely as they are I don't see the point in changing them just so we can run this test.

I also have a question: should `Gemfile.lock` really be included in this repository? Or should it be removed and git ignored, as it seems to me like a file that is specific to what the local bundler has done, rather than something that should be shared and updated?