### PR TITLE
Make smoke tests use functional test user

### DIFF
--- a/features/smoke_tests.feature
+++ b/features/smoke_tests.feature
@@ -4,7 +4,7 @@ Feature: Smoke tests
 Scenario: As supplier user I wish be able to log in and to log out of Digital Marketplace
   Given I am on the 'Supplier' login page
   When I login as a 'Supplier' user
-  Then I am presented with the 'Digital Marketplace Team' supplier dashboard page
+  Then I am presented with the 'DM Functional Test Supplier' supplier dashboard page
 
 #  When I click 'View'
 #  Then I am presented with the 'DM Functional Test Supplier' supplier service listings page


### PR DESCRIPTION
In migrating to the new jenkins machine the users used by the smoke tests and functional tests have been rationalised and both the smoke tests and the functional tests use the same supplier user now. As a consequence this test is failing because the supplier name is different.