### PR TITLE
Add priceMax to service fixtures

### DIFF
--- a/fixtures/11111-g6-iaas-test-service.json
+++ b/fixtures/11111-g6-iaas-test-service.json
@@ -180,6 +180,7 @@
     },
     "priceInterval": "Month",
     "priceMin": "9.75",
+    "priceMax": "",
     "priceString": "\u00a39.75 per licence per month",
     "priceUnit": "Licence",
     "pricingDocument": "Pricing template V1.0.pdf",

--- a/fixtures/11111-g6-paas-test-service.json
+++ b/fixtures/11111-g6-paas-test-service.json
@@ -173,6 +173,7 @@
     },
     "priceInterval": "Month",
     "priceMin": "2000",
+    "priceMax": "",
     "priceString": "\u00a32000 per unit per month",
     "priceUnit": "Unit",
     "pricingDocument": "Pricing Document.pdf",

--- a/fixtures/11111-g6-saas-test-service.json
+++ b/fixtures/11111-g6-saas-test-service.json
@@ -133,6 +133,7 @@
     },
     "priceInterval": "",
     "priceMin": "5800",
+    "priceMax": "",
     "priceString": "\u00a35800 per licence",
     "priceUnit": "Licence",
     "pricingDocument": "Pricing Document.pdf",

--- a/fixtures/11112-g6-iaas-test-service.json
+++ b/fixtures/11112-g6-iaas-test-service.json
@@ -180,6 +180,7 @@
     },
     "priceInterval": "Month",
     "priceMin": "9.75",
+    "priceMax": "",
     "priceString": "\u00a39.75 per licence per month",
     "priceUnit": "Licence",
     "pricingDocument": "Pricing template V1.0.pdf",


### PR DESCRIPTION
Because the JSON schema has recently changed to require numeric strings
rather than numbers and because the services in the database have
numeric values for priceMax and fields only get overwritten when they're
provided; provide the priceMax to override the value in the database.