### PR TITLE
Update for new admin service editing

### DIFF
--- a/features/admin_journey.feature
+++ b/features/admin_journey.feature
@@ -74,10 +74,10 @@ Scenario: As an admin user I wish to edit the features and benefits of a service
 Scenario: As an admin user I wish to edit the pricing of a service
   Given I am logged in as a 'Administrator' and am on the '1123456789012346' service summary page
   When I navigate to the 'edit' 'Pricing' page
-  And I change 'priceMin' to '100'
-  And I change 'priceMax' to '1234'
-  And I set 'priceUnit' as 'Person'
-  And I set 'priceInterval' as 'Week'
+  And I change 'input-priceString-MinPrice' to '100'
+  And I change 'input-priceString-MaxPrice' to '1234'
+  And I set 'input-priceString-Unit' as 'Person'
+  And I set 'input-priceString-Interval' as 'Week'
   And I choose 'No' for 'vatIncluded'
   And I choose 'No' for 'educationPricing'
   And I choose 'Yes' for 'terminationCost'

--- a/features/step_definitions/journey_test_steps.rb
+++ b/features/step_definitions/journey_test_steps.rb
@@ -183,14 +183,14 @@ Then /I am presented with the summary page for that service$/ do
 
     pricingdocument = find(
       :xpath,
-      "//*[contains(text(), 'Pricing document')]/../../td[2]/span[text()]"
-    ).text()
+      "//*[contains(text(), 'Pricing document')]/../../td[2]/span/a"
+    )['href']
     @existing_values['pricingdocument'] = pricingdocument
 
     servicedefinitiondocument = find(
       :xpath,
-      "//*[contains(text(), 'Service definition document')]/../../td[2]/span[text()]"
-    ).text()
+      "//*[contains(text(), 'Service definition document')]/../../td[2]/span/a"
+    )['href']
     @existing_values['servicedefinitiondocument'] = servicedefinitiondocument
   end
   @existing_values['servicename'] = servicename
@@ -429,10 +429,12 @@ Then /I am presented with the summary page with the changes that were made to th
     page.should have_no_content(@changed_fields['serviceBenefits-2'])
     page.should have_content(@changed_fields['serviceFeatures'])
   elsif service_aspect == 'Pricing'
+    price_string = "£#{@changed_fields['input-priceString-MinPrice']} to £#{@changed_fields['input-priceString-MaxPrice']} " \
+                   "per #{@changed_fields['input-priceString-Unit']} per #{@changed_fields['input-priceString-Interval']}"
     find(
       :xpath,
       "//*[contains(text(), 'Service price')]/../../td[2]/span[text()]"
-    ).text().should have_content("£#{@changed_fields['priceMin']} to £#{@changed_fields['priceMax']} per #{@changed_fields['priceUnit']} per #{@changed_fields['priceInterval']}")
+    ).text().should have_content(price_string)
     find(
       :xpath,
       "//*[contains(text(), 'VAT included')]/../../td[2]/span[text()]"
@@ -507,7 +509,7 @@ When /I navigate to the '(.*)' '(.*)' page$/ do |action,service_aspect|
     page.should have_content('Service benefits')
   elsif service_aspect == 'Pricing'
     page.should have_content(service_aspect)
-    page.should have_content('Service price')
+    page.should have_content('Pricing')
     page.should have_content('VAT included')
     page.should have_content('Education pricing')
     page.should have_content('Trial option')
@@ -544,7 +546,8 @@ Then /I am presented with the summary page with no changes made to the '(.*)'$/ 
   page.should have_content(@existing_values['trialoption'])
   page.should have_content(@existing_values['freeoption'])
   page.should have_content(@existing_values['minimumcontractperiod'])
-  page.should have_content(@existing_values['pricingdocument'])
+  page.should have_selector(:xpath,
+                            "//a[@href = '#{@existing_values['pricingdocument']}']")
 end
 
 Then /I am presented with the service details page for that service$/ do


### PR DESCRIPTION
The admin frontend service editing now uses the same code as the supplier frontend. The changes here fall into a few categories:
- The pricing fields are now all called priceString so the tests must be
  updated to use the more detailed ID.
- The document URLs are no longer displayed in the page so the `href` of their links must be checked.

## Depends on
- [x] https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/173
- [x] https://github.com/alphagov/digitalmarketplace-admin-frontend/pull/132

:sparkles: This has been tested locally (rebased on top of #81) :sparkles: 