### PR TITLE
Fix pagination limit error

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -96,7 +96,7 @@ def dm_supplier_password()
 end
 
 def dm_pagination_limit()
-  Integer(ENV['DM_PAGINATION_LIMIT']) || 100
+  (ENV['DM_PAGINATION_LIMIT'] || 100).to_i
 end
 
 Capybara::Screenshot.prune_strategy = { keep: 100 }


### PR DESCRIPTION
If the `DM_PAGINATION_LIMIT` is not provided the function fails because
`nil` cannot be converted to an integer.