### PR TITLE
Fix smoke test supplier name

### DIFF
--- a/features/smoke_tests.feature
+++ b/features/smoke_tests.feature
@@ -4,7 +4,7 @@ Feature: Smoke tests
 Scenario: As supplier user I wish be able to log in and to log out of Digital Marketplace
   Given I am on the 'Supplier' login page
   When I login as a 'Supplier' user
-  Then I am presented with the 'DM Functional Test Supplier' supplier dashboard page
+  Then I am presented with the 'Digital Marketplace Team' supplier dashboard page
 
 #  When I click 'View'
 #  Then I am presented with the 'DM Functional Test Supplier' supplier service listings page


### PR DESCRIPTION
This changed in 21a807 but has not been changed on the environments.
Until this is managed by the functional tests I'm reverting this change.