### PR TITLE
Add admin declaration feature

### DIFF
--- a/features/admin/edit_declaration.feature
+++ b/features/admin/edit_declaration.feature
@@ -15,6 +15,9 @@ Scenario: As a CCS Sourcing user I should be able to edit a supplier declaration
     When I click the 'Edit' link for 'G-Cloud 7 essentials'
     And I choose 'No' for 'PR1'
     And I click 'Save and return to summary'
+    And I click the 'Edit' link for 'Grounds for discretionary exclusion'
+    And I change 'SQ3-1k' to 'Everything'
+    And I click 'Save and return to summary'
     Then I am presented with the updated admin G-Cloud 7 declaration page
 
 Scenario: As a normal admin user I should not be able to edit a supplier declaration

--- a/features/admin/edit_declaration.feature
+++ b/features/admin/edit_declaration.feature
@@ -1,0 +1,22 @@
+@not-production @functional-test
+Feature: CCS Sourcing can edit supplier framework declarations
+  
+  The CCS Sourcing team should be able to edit supplier framework declarations.
+  No other admin roles should be able to view or edit these declarations
+
+Background:
+    Given I have test suppliers
+    And The test suppliers have declarations
+
+Scenario: As a CCS Sourcing user I should be able to edit a supplier declaration
+    Given I am logged in as a 'CCS Sourcing' and navigated to the 'Suppliers' page by searching on suppliers by name prefix 'DM Functional Test Supplier'
+    When I click the 'G-Cloud 7 declaration' link for the supplier 'DM Functional Test Supplier'
+    Then I am presented with the admin G-Cloud 7 declaration page
+    When I click the 'Edit' link for 'G-Cloud 7 essentials'
+    And I choose 'No' for 'PR1'
+    And I click 'Save and return to summary'
+    Then I am presented with the updated admin G-Cloud 7 declaration page
+
+Scenario: As a normal admin user I should not be able to edit a supplier declaration
+    Given I am logged in as a 'Administrator' and navigated to the 'Suppliers' page by searching on suppliers by name prefix 'DM Functional Test Supplier'
+    Then there is no 'G-Cloud 7 declaration' link for any supplier

--- a/features/admin_journey.feature
+++ b/features/admin_journey.feature
@@ -64,7 +64,7 @@ Scenario: Admin user should be able to abort an edit and be returned to the serv
 
 Scenario: As an admin user I wish to edit the features and benefits of a service
   Given I am logged in as a 'Administrator' and am on the '1123456789012346' service summary page
-  When I navigate to the 'edit' 'Features and benefits' page
+  When I navigate to the 'Edit' 'Features and benefits' page
   And I change 'serviceFeatures-3' to 'Service feature changed'
   And I remove service benefit number 2
   And I add 'New service feature' as a 'serviceFeatures'
@@ -73,7 +73,7 @@ Scenario: As an admin user I wish to edit the features and benefits of a service
 
 Scenario: As an admin user I wish to edit the pricing of a service
   Given I am logged in as a 'Administrator' and am on the '1123456789012346' service summary page
-  When I navigate to the 'edit' 'Pricing' page
+  When I navigate to the 'Edit' 'Pricing' page
   And I change 'input-priceString-MinPrice' to '100'
   And I change 'input-priceString-MaxPrice' to '1234'
   And I set 'input-priceString-Unit' as 'Person'
@@ -91,14 +91,14 @@ Scenario: As an admin user I wish to change a document for a service. Service se
   Given I am logged in as a 'Administrator' and navigated to the 'Services' page by searching on supplier ID '11111'
   When I click the 'Edit' link for the service '1123456789012346'
   Then I am presented with the summary page for that service
-  When I navigate to the 'edit' 'Documents' page
+  When I navigate to the 'Edit' 'Documents' page
   And I change 'serviceDefinitionDocumentURL' file to '12345-test-new-service-definition-document.pdf'
   And I click 'Save and return to summary'
   Then I am presented with the summary page with the changes that were made to the 'Documents'
 
 Scenario: As an admin user I wish to change a document for a service
   Given I am logged in as a 'Administrator' and am on the '1123456789012346' service summary page
-  When I navigate to the 'edit' 'Documents' page
+  When I navigate to the 'Edit' 'Documents' page
   And I change 'pricingDocumentURL' file to '12345-test-new-pricing-document.pdf'
   And I click 'Save and return to summary'
   Then I am presented with the summary page with the changes that were made to the 'Documents'

--- a/features/admin_journey.feature
+++ b/features/admin_journey.feature
@@ -12,7 +12,7 @@ Scenario: Setup for tests
 Scenario: As an admin user I wish be able to log in and to log out of Digital Marketplace
   Given I am on the 'Administrator' login page
   When I login as a 'Administrator' user
-  Then I am presented with the admin 'Admin' page
+  Then I am presented with the admin search page
   When I click 'Log out'
   Then I am logged out of Digital Marketplace as a 'Administrator' user
 

--- a/features/step_definitions/journey_test_steps.rb
+++ b/features/step_definitions/journey_test_steps.rb
@@ -45,8 +45,8 @@ And /The supplier user '(.*)' '(.*)' login to Digital Marketplace$/ do |user_nam
   end
 end
 
-Then /I am presented with the admin '(.*)' page$/ do |page_name|
-  page.should have_content(page_name)
+Then /I am presented with the admin search page$/ do
+  page.should have_content('Admin')
   page.should have_link('Service Updates')
   page.should have_content('Log out')
   page.should have_content('Find a service by service ID')

--- a/features/step_definitions/journey_test_steps.rb
+++ b/features/step_definitions/journey_test_steps.rb
@@ -91,6 +91,7 @@ Then /I am presented with the updated admin G-Cloud 7 declaration page$/ do
 
   declaration_answers = page.all(:xpath, "//tr[@class='summary-item-row']//td[2]")
   declaration_answers[0].text().should == "No"
+  declaration_answers[51].text().should == "Everything"
 end
 
 Then /I am presented with the admin search page$/ do

--- a/features/step_definitions/journey_test_steps.rb
+++ b/features/step_definitions/journey_test_steps.rb
@@ -54,6 +54,45 @@ And /The supplier user '(.*)' '(.*)' login to Digital Marketplace$/ do |user_nam
   end
 end
 
+Then /I am presented with the admin G-Cloud 7 declaration page$/ do
+  page.find(:css, "h1").text().should == "G-Cloud 7 declaration"
+  page.find(:css, "header p.context").text().should == @supplierName
+
+  section_headings = page.all(:css, "h2.summary-item-heading")
+  section_headings.length.should == 4
+  section_headings[0].text().should == "G-Cloud 7 essentials"
+  section_headings[1].text().should == "About you"
+  section_headings[2].text().should == "Grounds for mandatory exclusion"
+  section_headings[3].text().should == "Grounds for discretionary exclusion"
+
+  section_edit_links = page.all(:css, "a.summary-change-link")
+  section_edit_links.length.should == 4
+  section_edit_links[0][:href].should == "/admin/suppliers/#{@supplierID}/edit/declarations/g-cloud-7/g_cloud_7_essentials"
+  section_edit_links[1][:href].should == "/admin/suppliers/#{@supplierID}/edit/declarations/g-cloud-7/about_you"
+  section_edit_links[2][:href].should == "/admin/suppliers/#{@supplierID}/edit/declarations/g-cloud-7/grounds_for_mandatory_exclusion"
+  section_edit_links[3][:href].should == "/admin/suppliers/#{@supplierID}/edit/declarations/g-cloud-7/grounds_for_discretionary_exclusion"
+
+  page.all(:css, "table.summary-item-body").each do |section_table|
+    column_headings = section_table.all(:css, "thead th")
+    column_headings.length.should == 2
+    column_headings[0].text().should == "Declaration question"
+    column_headings[1].text().should == "Declaration answer"
+  end
+
+  declaration_answers = page.all(:xpath, "//tr[@class='summary-item-row']//td[2]")
+  declaration_answers[0].text().should == "Yes"
+  declaration_answers[17].text().should == "Button Moon"
+  declaration_answers[30].text().should == "small"
+end
+
+Then /I am presented with the updated admin G-Cloud 7 declaration page$/ do
+  page.find(:css, "h1").text().should == "G-Cloud 7 declaration"
+  page.find(:css, "header p.context").text().should == @supplierName
+
+  declaration_answers = page.all(:xpath, "//tr[@class='summary-item-row']//td[2]")
+  declaration_answers[0].text().should == "No"
+end
+
 Then /I am presented with the admin search page$/ do
   page.should have_content('Admin')
   page.should have_link('Service Updates')
@@ -1446,4 +1485,12 @@ Then /I am presented with the '(.*)' page with the changed supplier name '(.*)' 
   page.should have_link('Log out')
   current_url.should end_with("#{dm_frontend_domain}/admin/#{page_name.downcase}?supplier_name_prefix=#{supplier_name.split('M Functional Test Supplier').first}")
   page.should have_selector(:xpath, "//table/tbody/tr/td/span[contains(text(),'#{supplier_name}')]")
+end
+
+Then /^there is no '(.*)' link for any supplier$/ do |link_text|
+  page.all(:css, "tr.summary-item-row").each do |row|
+    row.all(:css, "td a").each do |link|
+      link.text().should_not == link_text
+    end
+  end
 end

--- a/features/step_definitions/setup_steps.rb
+++ b/features/step_definitions/setup_steps.rb
@@ -110,6 +110,20 @@ And /^The test suppliers have users$/ do
   create_supplier_user(11112,dm_supplier2_user_email(),"DM Functional Test Supplier 2 User 1", dm_supplier_password())
 end
 
+And /^The test suppliers have declarations$/ do
+  declaration = JSON.parse(File.read("./fixtures/11111-g7-declaration.json"))
+  payload = {
+    "declaration" => declaration,
+    "updated_by" => "Test User",
+  }
+
+  url = "#{dm_api_domain}/suppliers/11111/frameworks/g-cloud-7/declaration"
+  headers = {:content_type => :json, :accept => :json, :authorization => "Bearer #{dm_api_access_token}"}
+
+  response = RestClient.put(url, payload.to_json, headers){|response, request, result| response}
+  response.code.should == 200
+end
+
 And /^I have an admin user$/ do
   create_admin_user(dm_admin_email(),"DM Functional Test Admin User 1", dm_admin_password())
 end

--- a/features/step_definitions/setup_steps.rb
+++ b/features/step_definitions/setup_steps.rb
@@ -124,7 +124,7 @@ end
 And /^Test supplier users are active$/ do
   steps %Q{
     Given I have logged in to Digital Marketplace as a 'Administrator' user
-    Then I am presented with the admin 'Admin' page
+    Then I am presented with the admin search page
   }
   page.visit("#{dm_frontend_domain}/admin/suppliers/users?supplier_id=11111")
   activate_users("DM Functional Test Supplier User 3")
@@ -142,7 +142,7 @@ end
 And /^Test supplier users are not locked$/ do
   steps %Q{
     Given I have logged in to Digital Marketplace as a 'Administrator' user
-    Then I am presented with the admin 'Admin' page
+    Then I am presented with the admin search page
   }
   page.visit("#{dm_frontend_domain}/admin/suppliers/users?supplier_id=11111")
   unlock_users("DM Functional Test Supplier User 3")

--- a/features/supplier_journey.feature
+++ b/features/supplier_journey.feature
@@ -52,7 +52,7 @@ Scenario: As a logged in supplier user, I can navigate to the service summary pa
 
 Scenario: As a logged in supplier user, I can edit my supplier information
   Given I am logged in as a 'DM Functional Test Supplier' 'Supplier' user and am on the dashboard page
-  When I navigate to the 'edit' 'Supplier information' page
+  When I navigate to the 'Edit' 'Supplier information' page
   And I change 'description' to 'Supplier changed the service description'
   And I change 'clients-3' to 'Supplier changed the third client'
   And I remove client number 2
@@ -70,7 +70,7 @@ Scenario: As a logged in supplier user, I can edit my supplier information
 
 Scenario: As a logged in supplier user, I can edit the description of a service
   Given I am logged in as a 'Supplier' and am on the '1123456789012346' service summary page
-  When I navigate to the 'edit' 'Description' page
+  When I navigate to the 'Edit' 'Description' page
   And I change 'serviceName' to 'Supplier changed the service name'
   And I change 'serviceSummary' to 'Supplier changed the service summary'
   And I click 'Save and return to service'
@@ -78,7 +78,7 @@ Scenario: As a logged in supplier user, I can edit the description of a service
 
 Scenario: As a logged in supplier user, I can edit the features and benefits of a service
   Given I am logged in as a 'Supplier' and am on the '1123456789012346' service summary page
-  When I navigate to the 'edit' 'Features and benefits' page
+  When I navigate to the 'Edit' 'Features and benefits' page
   And I change 'serviceFeatures-3' to 'Supplier changed this service feature'
   And I remove service benefit number 2
   And I add 'This is a new service feature' as a 'serviceFeatures'

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -71,6 +71,10 @@ def dm_admin_email()
   ENV['DM_ADMINISTRATORNAME'] || ENV['DM_ADMIN_EMAIL']
 end
 
+def dm_admin_ccs_sourcing_email()
+  ENV['DM_ADMIN_CCS_SOURCING_EMAIL']
+end
+
 def dm_admin_password()
   ENV['DM_ADMINISTRATORPASSWORD'] || ENV['DM_ADMIN_PASSWORD']
 end

--- a/fixtures/11111-g7-declaration.json
+++ b/fixtures/11111-g7-declaration.json
@@ -1,0 +1,47 @@
+{
+  "AQA3": true,
+  "PR1": true,
+  "PR2": false,
+  "PR3": true,
+  "PR4": true,
+  "PR5": false,
+  "SQ1-1a": "Example",
+  "SQ1-1b": "Button Moon",
+  "SQ1-1ci": "public limited company",
+  "SQ1-1cii": "",
+  "SQ1-1d-i": "",
+  "SQ1-1d-ii": "",
+  "SQ1-1e": "",
+  "SQ1-1h": "",
+  "SQ1-1i-i": true,
+  "SQ1-1i-ii": "",
+  "SQ1-1j-i": [
+    "licensed",
+    "a member of a relevant organisation"
+  ],
+  "SQ1-1j-ii": "",
+  "SQ1-1k": "",
+  "SQ1-1m": "small",
+  "SQ1-1n": "",
+  "SQ1-1o": "",
+  "SQ1-2a": "Example",
+  "SQ1-2b": "example@example.com",
+  "SQ1-3": [
+    "on-demand self-service. Your cloud services, eg server time or network storage, must be automatically available without interaction between the supplier and the contracting body.",
+    "broad network access. Your cloud services must be easily accessible over the network and across a wide range of platforms (eg mobile phones, tablets, laptops and workstations) and a mix of applications that are both thin (the bulk of data processing occurs on the server) and thick (most processing occurs on the local platform)."
+  ],
+  "SQ5-1a": "Yes \u2013 your organisation has, or will have in place, employer\u2019s liability insurance of at least \u00a35 million and you will provide certification prior to framework award.",
+  "SQ5-2a": false,
+  "SQA2": false,
+  "SQA3": true,
+  "SQA4": true,
+  "SQA5": true,
+  "SQC2": true,
+  "SQC3": [
+    "race",
+    "sexual orientation"
+  ],
+  "SQE2a": [
+    "as a prime contractor, using third parties (subcontractors) to provide some services"
+  ]
+}

--- a/scripts/create_users.sh
+++ b/scripts/create_users.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+#
+# Create admin users for use in functional tests
+#
+# Usage:
+# ./scripts/create_users.sh <environment>
+#
+# Example:
+# ./scripts/create_users.sh local
+
+DM_ENVIRONMENT=${1:-local}
+
+. "./scripts/envs/${DM_ENVIRONMENT}.sh"
+
+function create_user {
+  local email=$1;
+  local name=$2;
+  local role=$3;
+  local password=$4;
+
+  read -r -d '' USER_PAYLOAD <<EOF
+{
+  "users": {
+    "emailAddress": "$email",
+    "name": "$name",
+    "role": "$role",
+    "password": "$password"
+  }
+}
+EOF
+  STATUS_CODE=$(curl -sL -w "%{http_code}" -o /dev/null -X POST -H 'Content-type: application/json' -H "Authorization: Bearer ${DM_API_ACCESS_TOKEN}" -d "${USER_PAYLOAD}" "${DM_API_DOMAIN}/users")
+  if [ "$STATUS_CODE" == "409" ]; then
+    echo "Already exists"
+  elif [ "$STATUS_CODE" == "201" ]; then
+    echo "Created"
+  else
+    echo "ERROR: $STATUS_CODE"
+  fi
+}
+
+create_user "$DM_ADMIN_EMAIL" "Admin" "admin" "$DM_ADMIN_PASSWORD"
+create_user "$DM_ADMIN_CCS_SOURCING_EMAIL" "Admin" "admin-ccs-sourcing" "$DM_ADMIN_PASSWORD"

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -8,4 +8,4 @@ bundle install
 mkdir -p reports
 rm -f screenshot*
 
-bundle exec cucumber --tags ~@ssp --tags ~@wip --tags @functional-test --color --format html --out reports/index.html --format pretty
+bundle exec cucumber -r features --tags ~@ssp --tags ~@wip --tags @functional-test --color --format html --out reports/index.html --format pretty


### PR DESCRIPTION
Add a feature testing supplier declaration editing from within the admin app.

This pull request also includes a few refactoring changes that are described in each of the commits.


## Relates to
- [#103091058](https://www.pivotaltracker.com/story/show/103091058)

## Depends on
- [x] https://github.com/alphagov/digitalmarketplace-admin-frontend/pull/135