### PR TITLE
Update SSP routes

### DIFF
--- a/features/step_definitions/ssp_steps.rb
+++ b/features/step_definitions/ssp_steps.rb
@@ -26,11 +26,11 @@ Given /^I am at the g7 services page$/ do
 end
 
 Given /^I am on the summary page$/ do
-  visit("#{dm_frontend_domain}/suppliers/submission/services/#{store.current_listing}")
+  visit("#{dm_frontend_domain}/suppliers/frameworks/g-cloud-7/submissions/#{store.current_listing}")
 end
 
 Given /^I am on ssp page '(.+)'$/ do |page_name|
-  visit("#{dm_frontend_domain}/suppliers/submission/services/#{store.current_listing}/edit/#{page_name}/")
+  visit("#{dm_frontend_domain}/suppliers/frameworks/g-cloud-7/submissions/#{store.current_listing}/edit/#{page_name}/")
 end
 
 Given /^The service is deleted$/ do


### PR DESCRIPTION
A lot of the supplier frontend routes have been changed to include frameowrk slug.

## Depends on
- [x] https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/310