### PR TITLE
Fix service order test with new lot_id based sorting

### DIFF
--- a/features/step_definitions/journey_test_steps.rb
+++ b/features/step_definitions/journey_test_steps.rb
@@ -1136,7 +1136,7 @@ Then /I am on a page with '(.*)' in search summary text$/ do |value|
 end
 
 Then /Selected lot is that service.lot with links to the search for that service.(.*)$/ do |attr|
-  lot = full_lot(@service['lot'])
+  lot = @service['lotName']
   query = @service[attr]
   step "Selected lot is '#{lot}' with links to the search for '\"#{query}\"'"
 end
@@ -1193,7 +1193,7 @@ Then /I am on a page with that service in search results$/ do
 
   service_result.first(:xpath, "./h2[@class='search-result-title']/a").text.should == normalize_whitespace(@service['serviceName'])
   service_result.first(:xpath, "./p[@class='search-result-supplier']").text.should == normalize_whitespace(@service['supplierName'])
-  service_result.first(:xpath, ".//li[@class='search-result-metadata-item'][1]").text.should == full_lot(@service['lot'])
+  service_result.first(:xpath, ".//li[@class='search-result-metadata-item'][1]").text.should == @service['lotName']
   service_result.first(:xpath, ".//li[@class='search-result-metadata-item'][2]").text.should == @service['frameworkName']
 end
 
@@ -1216,7 +1216,7 @@ Then /Words in the search result excerpt that match the search criteria are high
 end
 
 Given /I am on the search results page with results for that service.lot displayed$/ do
-  step "Given I am on the search results page with results for '#{full_lot(@service['lot'])}' lot displayed"
+  step "Given I am on the search results page with results for '#{@service['lotName']}' lot displayed"
 end
 
 Given /I am on the search results page with results for '(.*)' lot displayed$/ do |lot_name|

--- a/features/step_definitions/journey_test_steps.rb
+++ b/features/step_definitions/journey_test_steps.rb
@@ -818,15 +818,16 @@ Then /I am presented with the 'Suppliers' page for all suppliers starting with '
 end
 
 And /I can see all listings ordered by lot name followed by listing name$/ do
-  service_listed_and_in_correct_order("1123456789012346","1")
-  service_listed_and_in_correct_order("1123456789012350","2")
-  service_listed_and_in_correct_order("1123456789012347","3")
-  service_listed_and_in_correct_order("1123456789012351","4")
-  # OS differences beween Linux and OSX mean that "SaaS" and "SCS" are ordered differently
-  # service_listed_and_in_correct_order("1123456789012348","5")
-  # service_listed_and_in_correct_order("1123456789012352","6")
-  # service_listed_and_in_correct_order("1123456789012349","7")
-  # service_listed_and_in_correct_order("1123456789012353","8")
+  services_listed([
+    "1123456789012348",
+    "1123456789012352",
+    "1123456789012347",
+    "1123456789012351",
+    "1123456789012346",
+    "1123456789012350",
+    "1123456789012349",
+    "1123456789012353",
+  ])
   page.should have_no_selector(:xpath, "*//table/tbody/tr[9][td/text()]")
 end
 
@@ -844,22 +845,24 @@ Then /I can see active users associated with '(.*)' on the dashboard$/ do |suppl
   end
 end
 
-def service_listed_and_in_correct_order (service_id,order_number)
+def services_listed(service_ids)
   url = dm_api_domain
   token = dm_api_access_token
   headers = {:content_type => :json, :accept => :json, :authorization => "Bearer #{token}"}
-  service_url = "#{url}/services/#{service_id}"
-  response = RestClient.get(service_url, headers){|response, request, result| response }
-  json = JSON.parse(response)
-  service_name = json["services"]["serviceName"]
-  service_lot = json["services"]["lot"]
-  xpath_to_check = find(:xpath, "*//table/tbody/tr[#{order_number}][td/text()]").text()
+  service_ids.each.with_index(1) do |service_id, order_number|
+    service_url = "#{url}/services/#{service_id}"
+    response = RestClient.get(service_url, headers){|response, request, result| response }
+    json = JSON.parse(response)
+    service_name = json["services"]["serviceName"]
+    service_lot = json["services"]["lotName"]
+    xpath_to_check = find(:xpath, "*//table/tbody/tr[#{order_number}][td/text()]").text()
 
-  if response.code == 404
-    puts "Service #{service_id} does not exist"
-  else
-    xpath_to_check.should have_content("#{service_name}")
-    xpath_to_check.should have_content("#{service_lot}")
+    if response.code == 404
+      puts "Service #{service_id} does not exist"
+    else
+      xpath_to_check.should have_content("#{service_name}")
+      xpath_to_check.should have_content("#{service_lot}")
+    end
   end
 end
 

--- a/features/step_definitions/setup_steps.rb
+++ b/features/step_definitions/setup_steps.rb
@@ -54,7 +54,7 @@ def create_service (supplier_id, service_id, lot)
   response = RestClient.get(service_url, headers){|response, request, result| response }
   if response.code == 404
     response = RestClient.put(service_url, service_data.to_json, headers){|response, request, result| response }
-    response.code.should == 201
+    response.code.should be(201), response.body
   else
     response = RestClient.post(service_url, service_data.to_json, headers){|response, request, result| response }
     response.code.should == 200

--- a/fixtures/11111-g6-iaas-test-service.json
+++ b/fixtures/11111-g6-iaas-test-service.json
@@ -96,7 +96,7 @@
       "assurance": "Independent validation of assertion",
       "value": true
     },
-    "frameworkName": "G-Cloud 6",
+    "frameworkSlug": "g-cloud-6",
     "freeOption": true,
     "governanceFramework": {
       "assurance": "Independent validation of assertion",
@@ -147,7 +147,7 @@
     "links": {
       "self": "https://api.beta.digitalmarketplace.service.gov.uk/services/1234567890000000"
     },
-    "lot": "IaaS",
+    "lot": "iaas",
     "managementInterfaceProtection": {
       "assurance": "Independent validation of assertion",
       "value": true

--- a/fixtures/11111-g6-paas-test-service.json
+++ b/fixtures/11111-g6-paas-test-service.json
@@ -96,7 +96,7 @@
       "assurance": "Independent validation of assertion",
       "value": true
     },
-    "frameworkName": "G-Cloud 6",
+    "frameworkSlug": "g-cloud-6",
     "freeOption": false,
     "governanceFramework": {
       "assurance": "Independent validation of assertion",
@@ -142,7 +142,7 @@
     "links": {
       "self": "https://api.beta.digitalmarketplace.service.gov.uk/services/1234567890000001"
     },
-    "lot": "PaaS",
+    "lot": "paas",
     "managementInterfaceProtection": {
       "assurance": "Service provider assertion",
       "value": true

--- a/fixtures/11111-g6-saas-test-service.json
+++ b/fixtures/11111-g6-saas-test-service.json
@@ -71,7 +71,7 @@
       "assurance": "Service provider assertion",
       "value": true
     },
-    "frameworkName": "G-Cloud 6",
+    "frameworkSlug": "g-cloud-6",
     "freeOption": false,
     "governanceFramework": {
       "assurance": "Service provider assertion",
@@ -109,7 +109,7 @@
     "links": {
       "self": "https://api.beta.digitalmarketplace.service.gov.uk/services/1234567890000002"
     },
-    "lot": "SaaS",
+    "lot": "saas",
     "minimumContractPeriod": "Year",
     "networksConnected": [
       "Internet",

--- a/fixtures/11111-g6-scs-test-service.json
+++ b/fixtures/11111-g6-scs-test-service.json
@@ -4,14 +4,14 @@
       "update_reason": "For testing"},
   "services": {
     "educationPricing": false,
-    "frameworkName": "G-Cloud 6",
+    "frameworkSlug": "g-cloud-6",
     "id": "1234567890000001",
     "incidentEscalation": false,
     "createdAt": "2014-12-08T20:54:39Z",
     "links": {
       "self": "https://api.beta.digitalmarketplace.service.gov.uk/services/1234567890000001"
     },
-    "lot": "SCS",
+    "lot": "scs",
     "minimumContractPeriod": "Day",
     "priceInterval": "Day",
     "priceMax": "960",

--- a/fixtures/11112-g6-iaas-test-service.json
+++ b/fixtures/11112-g6-iaas-test-service.json
@@ -96,7 +96,7 @@
       "assurance": "Independent validation of assertion",
       "value": true
     },
-    "frameworkName": "G-Cloud 6",
+    "frameworkSlug": "g-cloud-6",
     "freeOption": true,
     "governanceFramework": {
       "assurance": "Independent validation of assertion",
@@ -147,7 +147,7 @@
     "links": {
       "self": "https://api.beta.digitalmarketplace.service.gov.uk/services/1234567890000000"
     },
-    "lot": "IaaS",
+    "lot": "iaas",
     "managementInterfaceProtection": {
       "assurance": "Independent validation of assertion",
       "value": true


### PR DESCRIPTION
Related to and should be merged after https://github.com/alphagov/digitalmarketplace-api/pull/273

#### Fix service order test with new lot_id based sorting
Services returned by the API are sorted based on internal lot order.
Full lot name is returned in service.lotName and is now displayed
in service list tables.

#### Update service fixtures with frameworkSlug and lowercase lot
frameworkSlug is required for service creation, while frameworkName
field is always ignored.