### PR TITLE
Add feature for admin framework agreements view

### DIFF
--- a/features/admin/download_agreements.feature
+++ b/features/admin/download_agreements.feature
@@ -1,0 +1,29 @@
+@not-production @functional-test
+Feature: Admin users can download signed framework agreements
+
+Background:
+  Given I have test suppliers
+  And I have logged in to Digital Marketplace as a 'Administrator' user
+  And no 'g-cloud-7' framework agreements exist
+
+Scenario: When there are no framework agreements the list is empty
+  When I click 'G-Cloud 7 agreements'
+  Then the framework agreement list is empty
+
+Scenario: Most recently uploaded agreements should be shown first
+  Given a 'g-cloud-7' signed agreement is uploaded for supplier '11111'
+  And a 'g-cloud-7' signed agreement is uploaded for supplier '11112'
+  When I click 'G-Cloud 7 agreements'
+  Then the first signed agreement should be for supplier 'DM Functional Test Supplier 2'
+  When I click the first download agreement link
+  Then I should get redirected to the correct 'g-cloud-7' S3 URL for supplier '11112'
+
+Scenario: Re-uploading an agreement brings it to the top of the list
+  Given a 'g-cloud-7' signed agreement is uploaded for supplier '11111'
+  And a 'g-cloud-7' signed agreement is uploaded for supplier '11112'
+  And a 'g-cloud-7' signed agreement is uploaded for supplier '11111'
+  When I click 'G-Cloud 7 agreements'
+  Then the first signed agreement should be for supplier 'DM Functional Test Supplier'
+  When I click the first download agreement link
+  Then I should get redirected to the correct 'g-cloud-7' S3 URL for supplier '11111'
+

--- a/features/step_definitions/api_steps.rb
+++ b/features/step_definitions/api_steps.rb
@@ -24,12 +24,8 @@ Then /^The new json file has a new service name$/ do
 end
 
 Given /^I have a random service from the API$/ do
-  response = RestClient.get(
-    "#{dm_api_domain}/services",
-    params: {page: 1 + rand(dm_pagination_limit()), status: "published"},
-    authorization: "Bearer #{dm_api_access_token}"
-  )
-  @service = JSON.parse(response)['services'][rand(dm_pagination_limit())]
+  response = call_api(:get, "/services", params: {page: 1 + rand(dm_pagination_limit()), status: "published"})
+  @service = JSON.parse(response.body)['services'][rand(dm_pagination_limit())]
   puts "Service ID: #{@service['id']}"
   puts "Service name: #{@service['serviceName']}"
 end
@@ -52,22 +48,18 @@ end
 
 
 When /^I send a GET request with authorization to "([^\"]*)"$/ do |path|
-  response = RestClient.get("#{@last_domain}#{path}",
-    authorization: "Bearer #{@last_token}"){|response, request, result| response }  # Don't raise exceptions but return the response
-  @last_response = response
+  @last_response = call_api(:get, path, domain: @last_domain)
 end
 
 
 When(/^I send a GET request to the home page$/) do
-  response = RestClient.get("#{@last_domain}"){|response, request, result| response }  # Don't raise exceptions but return the response
-  @last_response = response
+  @last_response = call_api(:get, "/", domain: @last_domain)
 end
 
 # There is no version locally :/
 When(/^I send a GET request to the "([^\"]*)" status page$/) do |path|
-  response = RestClient.get("#{@last_domain}#{path}_status") { |response| response }
-  puts "Release version: " + JSON.parse(response).fetch("version")
-  @last_response = response
+  @last_response = call_api(:get, "#{path}_status", domain: @last_domain)
+  puts("Release version: #{JSON.parse(@last_response.body).fetch("version")}")
 end
 
 

--- a/features/step_definitions/journey_test_steps.rb
+++ b/features/step_definitions/journey_test_steps.rb
@@ -1137,7 +1137,7 @@ Then /Selected lot is '([^']*)'(?: with links to the search for '(.*)')?$/ do |s
     lot_link += "&lot=#{lot.to_s.downcase}" if lot != :all
     if full_lot == selected_lot
       lot_names.should include(full_lot)
-      lot_links.should_not include(lot_link)
+      lot_links.should_not include_url(lot_link)
       if query.empty?
         current_url.should end_with("/g-cloud/search?lot=#{lot.to_s.downcase}")
         find(:xpath, "//p[@class='search-summary']/em[1]").text.should == full_lot
@@ -1148,7 +1148,7 @@ Then /Selected lot is '([^']*)'(?: with links to the search for '(.*)')?$/ do |s
       page.first(:xpath, ".//ol[@role='breadcrumbs']/li[3]").text.should == full_lot if lot != :all
     else
       lot_names.should include(full_lot)
-      lot_links.should include(lot_link)
+      lot_links.should include_url(lot_link)
     end
   end
 end

--- a/features/support/api_helpers.rb
+++ b/features/support/api_helpers.rb
@@ -1,0 +1,66 @@
+
+def call_api(method, path, payload=nil)
+  headers = {
+    :content_type => :json,
+    :accept => :json,
+    :authorization => "Bearer #{dm_api_access_token}"
+  }
+  url = "#{dm_api_domain}#{path}"
+  if payload.nil?
+    return RestClient.send(method, url, headers) {|response, request, result| response}
+  else
+    return RestClient.send(method, url, payload.to_json, headers) {|response, request, result| response}
+  end
+end
+
+def update_framework_status(framework_slug, status)
+  response = call_api(:get, "/frameworks/#{framework_slug}")
+  framework = JSON.parse(response.body)["frameworks"]
+  if framework['status'] != status
+    response = call_api(:post, "/frameworks/#{framework_slug}", {
+      "frameworks" => {"status" => status},
+      "updated_by" => "functional tests",
+    })
+    response.code.should == 200
+  end
+  return framework['status']
+end
+
+def ensure_no_framework_agreements_exist(framework_slug)
+  response = call_api(:get, "/frameworks/#{framework_slug}/suppliers")
+  response.code.should == 200
+  supplier_frameworks = JSON.parse(response.body)["supplierFrameworks"]
+  supplier_frameworks.each do |supplier_framework|
+    update_framework_agreement_status(framework_slug, supplier_framework["supplierId"], false)
+  end
+end
+
+def update_framework_agreement_status(framework_slug, supplier_id, status)
+  response = call_api(:post, "/suppliers/#{supplier_id}/frameworks/#{framework_slug}", {
+    "frameworkInterest" => {"agreementReturned" => status},
+    "update_details" => {"updated_by" => "functional tests"},
+  })
+  response.code.should == 200
+end
+
+def register_interest_in_framework(framework_slug, supplier_id)
+  path = "/suppliers/#{supplier_id}/frameworks/#{framework_slug}"
+  response = call_api(:get, path)
+  if response.code == 404
+    response = call_api(:put, path, {
+      "update_details" => {"updated_by" => "functional tests"}
+    })
+    if response.code == 400
+      puts(response.body)
+    end
+  end
+end
+
+def submit_supplier_declaration(framework_slug, supplier_id, declaration)
+  path = "/suppliers/#{supplier_id}/frameworks/#{framework_slug}/declaration"
+  response = call_api(:put, path, {
+    "declaration" => declaration,
+    "updated_by" => "functional tests",
+  })
+  [200, 201].should include(response.code)
+end

--- a/features/support/helpers.rb
+++ b/features/support/helpers.rb
@@ -1,4 +1,5 @@
 require 'capybara/helpers'
+require 'rspec/expectations'
 
 LOTS = {
   all: 'All categories',
@@ -14,4 +15,45 @@ end
 
 def normalize_whitespace(text)
   Capybara::Helpers.normalize_whitespace(text)
+end
+
+def urls_are_equal(url1, url2)
+  # horrible hack, if it's a relative href stick a fake scheme and prefix on
+  if url1.start_with? "/"
+    if !url2.start_with? "/"
+      return false
+    end
+    url1 = "http://localhost#{url1}"
+    url2 = "http://localhost#{url2}"
+  end
+  url1 = URI::parse(url1)
+  url2 = URI::parse(url2)
+  [:scheme, :host, :path].each do |key|
+    if url1.send(key) != url2.send(key)
+      return false
+    end
+  end
+  # query and fragment parameters can appear in any order
+  [:query, :fragment].each do |key|
+    if url1.send(key)
+      if !url2.send(key)
+        return false
+      elsif CGI::parse(url1.send(key)) != CGI::parse(url2.send(key))
+        return false
+      end
+    end
+  end
+  return true
+end
+
+RSpec::Matchers.define :match_url do |expected|
+  match do |actual|
+    urls_are_equal(expected, actual)
+  end
+end
+
+RSpec::Matchers.define :include_url do |expected|
+  match do |actual_list|
+    actual_list.map {|actual| urls_are_equal(actual, expected)}.include?(true)
+  end
 end


### PR DESCRIPTION
## Add feature for admin framework agreements view
This tests the view in the admin app for listing signed framework agreements.

I have tried to keep the step definitions small and put most of the logic into helper functions so that they can be easily reused.

## Match URLs ignoring parameter order
For our applications the order of URL parameters does not matter. Also, because the URLs are generated from dictionaries the order of URL parameters is non-deterministic. This change introduces a couple of new RSpec matchers that compare two URLs based on their component parts, ignoring the order of query or fragment parameters. I have tried to keep the step definitions small and put most of the logic into helper functions so that they can be easily reused.

## Refactor API steps to use call_api
Refacotr existing uses of RestClient to use the recently introduced wrapper call_api. As part of this change call_api was changed so that it can accept a custom domain and parameters.