### PR TITLE
Changed test step to fix failing functional tests

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,6 +89,3 @@ DEPENDENCIES
   rspec (= 2.14.1)
   selenium-webdriver (= 2.47.1)
   test-unit (= 3.0.9)
-
-BUNDLED WITH
-   1.10.6

--- a/features/buyer_journey.feature
+++ b/features/buyer_journey.feature
@@ -119,7 +119,7 @@ Scenario: Specific supplier is not listed on G-Cloud supplier A-Z when status of
   Then The supplier 'DM Functional Test Supplier 2' is 'not listed' on the page
 
 Scenario: There is pagination on the list of suppliers page if there are more than 100 results
-  Given I navigate to the list of 'Suppliers starting with C' page
+  Given I navigate to the list of 'Suppliers starting with T' page
   When I click the 'Next page' link
   Then I am taken to page '2' of results
 


### PR DESCRIPTION
Supplier A-Z list for suppliers starting with C prior to G7 live had <200 records
G7 live changes this and so the test has been changed to select a supplier(suppliers starting with "T") with <200 records
to fix the failing test