### PR TITLE
Removed unecessary check for smoke test step

### DIFF
--- a/features/step_definitions/journey_test_steps.rb
+++ b/features/step_definitions/journey_test_steps.rb
@@ -613,10 +613,6 @@ Then /I am presented with the '(.*)' supplier dashboard page$/ do |supplier_name
   page.should have_content(dm_supplier_user_email())
   current_url.should end_with("#{dm_frontend_domain}/suppliers")
   page.should have_selector(:xpath, "//*[@id='global-breadcrumb']/nav/*[@role='breadcrumbs']/li[1]//*[contains(text(), 'Digital Marketplace')]")
-
-  if supplier_name == 'Digital Marketplace Team'
-    page.should have_content('You don\'t have any services on the Digital Marketplace')
-  end
 end
 
 Given /I am logged in as a '(.*)' '(.*)' user and am on the dashboard page$/ do |supplier_name,user_type|


### PR DESCRIPTION
Test was failing because a check was made for the existence of text on the supplier dashboard page
on the supplier being logged in, which is not necessary and made the test fragile to changes when 
all it needs to do is ensure that the supplier log in was succesful.