### PR TITLE
Fix update_framework_status method to reflect the API change

### DIFF
--- a/features/support/api_helpers.rb
+++ b/features/support/api_helpers.rb
@@ -25,7 +25,7 @@ def update_framework_status(framework_slug, status)
   framework = JSON.parse(response.body)["frameworks"]
   if framework['status'] != status
     response = call_api(:post, "/frameworks/#{framework_slug}", payload: {
-      "frameworks" => {"status" => status},
+      "frameworks" => {"status" => status, "clarificationQuestionsOpen" => status == 'open'},
       "updated_by" => "functional tests",
     })
     response.code.should be(200), _error(response, "Failed to update framework status #{framework_slug} #{status}")


### PR DESCRIPTION
Update framework status endpoint now requires the clarification
questions open status to be provided with the framework status.

Adding the argument to the `update_framework_status` with quesiton
status based on framework status (questions are open for 'open'
frameworks and closed for all other framework statuses).