### PR TITLE
Supplier websites are now linked

### DIFF
--- a/features/step_definitions/journey_test_steps.rb
+++ b/features/step_definitions/journey_test_steps.rb
@@ -696,7 +696,7 @@ Then /I can see my supplier details on the dashboard$/ do
   page.should have_selector(:xpath, "//*[@class='summary-item-field-first']/span[contains(text(), 'Contact name')]")
   page.should have_selector(:xpath, "//*[@class='summary-item-field']/span[contains(text(), 'Testing Supplier Name')]")
   page.should have_selector(:xpath, "//*[@class='summary-item-field-first']/span[contains(text(), 'Website')]")
-  page.should have_selector(:xpath, "//*[@class='summary-item-field']/span[contains(text(), 'www.dmfunctionaltestsupplier.com')]")
+  page.should have_selector(:xpath, "//*[@class='summary-item-field']/span/a[contains(text(), 'www.dmfunctionaltestsupplier.com')]")
   page.should have_selector(:xpath, "//*[@class='summary-item-field-first']/span[contains(text(), 'Email address')]")
   page.should have_selector(:xpath, "//*[@class='summary-item-field']/span[contains(text(), 'Testing.supplier.NaMe@DMtestemail.com')]")
   page.should have_selector(:xpath, "//*[@class='summary-item-field-first']/span[contains(text(), 'Phone number')]")


### PR DESCRIPTION
Update to the supplier app adds hyperlinks to supplier's website fields, so the test need to look inside the anchor tag to find the required text.