### PR TITLE
Log out if already logged in for "Log in" step

### DIFF
--- a/features/step_definitions/journey_test_steps.rb
+++ b/features/step_definitions/journey_test_steps.rb
@@ -6,9 +6,15 @@ Given /I am on the '(.*)' login page$/ do |user_type|
   case user_type
   when 'Administrator'
     visit("#{dm_frontend_domain}/admin/login")
+    if page.has_link?("Log out")
+      page.click_link_or_button("Log out")
+    end
     page.should have_content("#{user_type} login")
   when 'Supplier'
     visit("#{dm_frontend_domain}/#{user_type.downcase}s/login")
+    if page.has_link?("Log out")
+      page.click_link_or_button("Log out")
+    end
     page.should have_content('Log in to the Digital Marketplace')
   else
     fail("Unrecognised user login page '#{user_type}'")


### PR DESCRIPTION
Now the login page will redirect to the dashboard if a user is already logged in, so the "Log in" step must log out first in order to complete.

Tested locally and all tests now pass:
![screen shot 2015-12-10 at 11 39 49](https://cloud.githubusercontent.com/assets/6525554/11714546/e2e59dd6-9f32-11e5-9dac-eb6b24803718.png)
