### PR TITLE
Fix the tests around service status

### DIFF
--- a/features/G-Cloud/admin_journey.feature
+++ b/features/G-Cloud/admin_journey.feature
@@ -126,7 +126,7 @@ Scenario: Admin changes service status to 'Private'. The change is reflected in 
   And I click the 'Update status' button
   Then The service status is set as 'Private'
   And I am presented with the message 'Service status has been updated to: Private'
-  And The status of the service is presented as 'Private' on the supplier users service listings page
+  And The status of the service is presented as 'Removed' on the supplier users service listings page
   And The service 'can not' be searched
   And The service details page 'can' be viewed
   And A message stating the supplier has stopped providing this service on todays date is presented on the service listing page
@@ -137,7 +137,7 @@ Scenario: Admin changes service status to 'Public'. The change is reflected in t
   And I click the 'Update status' button
   Then The service status is set as 'Public'
   And I am presented with the message 'Service status has been updated to: Public'
-  And The status of the service is presented as 'Public' on the supplier users service listings page
+  And The status of the service is presented as 'Live' on the supplier users service listings page
   And The service 'can' be searched
   And The service details page 'can' be viewed
 

--- a/features/G-Cloud/supplier_journey.feature
+++ b/features/G-Cloud/supplier_journey.feature
@@ -26,7 +26,8 @@ Scenario: As a logged in supplier user, I can navigate to the service listings p
 
 Scenario: As a logged in supplier user, I can view the listings page of a specific service
   Given I am logged in as a 'DM Functional Test Supplier' 'Supplier' user and am on the service listings page
-  When I select 'view service for the' second listing on the page
+  When I select 'the' second listing on the page
+  And I click 'View service'
   Then I am presented with the service page for that specific listing
 
 Scenario: As a logged in supplier user, I can see my active contributors on the dashboard
@@ -89,7 +90,7 @@ Scenario: Supplier user changes service status to 'Private'. The change is refle
   Given I am logged in as a 'Supplier' and am on the '1123456789012346' service summary page
   When I select 'Private' as the service status
   And I click the 'Save and return' button
-  Then The service status is set as 'Private'
+  Then The service status is set as 'Removed'
   And I am presented with the message 'Supplier changed the service name is now private'
   And The status of the service is presented as 'Private' on the admin users service summary page
   And The service 'can not' be searched
@@ -100,7 +101,7 @@ Scenario: Supplier user changes service status to 'Public'. The change is reflec
   Given I am logged in as a 'Supplier' and am on the '1123456789012346' service summary page
   When I select 'Public' as the service status
   And I click the 'Save and return' button
-  Then The service status is set as 'Public'
+  Then The service status is set as 'Live'
   And I am presented with the message 'Supplier changed the service name is now public'
   And The status of the service is presented as 'Public' on the admin users service summary page
   And The service 'can' be searched

--- a/features/step_definitions/journey_test_steps.rb
+++ b/features/step_definitions/journey_test_steps.rb
@@ -906,16 +906,10 @@ end
 
 Then /The service status is set as '(.*)'$/ do |service_status|
   if current_url.include?('suppliers')
-    if service_status == 'Public'
-      find(:xpath,
-        "//a[contains(@href, '/services/#{@servicesupplierID}')]/../../../td[4]/span/a[text()]"
-      ).text().should have_content('View service')
-    else
-      find(
-        :xpath,
-        "//a[contains(text(), '#{@existing_values['servicename']}')]/../../..//td/*/span"
-      ).text().should have_content(service_status)
-    end
+    find(
+      :xpath,
+      "//a[contains(text(), '#{@existing_values['servicename']}')]/../../..//td[4]/span"
+    ).text().should have_content(service_status)
   elsif current_url.include?('admin')
     find(
       :xpath,
@@ -931,15 +925,9 @@ end
 Then /The status of the service is presented as '(.*)' on the supplier users service listings page$/ do |service_status|
   step "I am logged in as a 'DM Functional Test Supplier' 'Supplier' user and am on the service listings page"
 
-  if service_status == 'Public'
-    find(:xpath,
-      "//a[contains(@href, '/suppliers/services/#{@servicesupplierID}')]/../../../td[4]/span/a[text()]"
-    ).text().should have_content('View service')
-  else
-    find(:xpath,
-      "//a[contains(@href, '/suppliers/services/#{@servicesupplierID}')]/../../../td[contains(@class, 'summary-item-field')]/span/span[contains(@class, 'service-status-')][text()]"
-    ).text().should have_content("#{service_status}")
-  end
+  find(:xpath,
+    "//a[contains(@href, '/suppliers/services/#{@servicesupplierID}')]/../../../td[4]/span"
+  ).text().should have_content("#{service_status}")
 end
 
 Then /The status of the service is presented as '(.*)' on the admin users service summary page$/ do |service_status|


### PR DESCRIPTION
The wording and markup around service statuses has changed.

https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/403

:sparkles: :sparkles: these have been tested locally against preview :sparkles: :sparkles: 