### PR TITLE
Small changes to repair existing functional tests

### DIFF
--- a/features/DOS/ssp_digital_specialists_service.feature
+++ b/features/DOS/ssp_digital_specialists_service.feature
@@ -145,7 +145,7 @@ Feature: Submitting a new DOS service for Digital specialists
     Given I am on the ssp page for the 'digital-specialists' service
     When I click the 'Mark as complete' button at the 'top' of the page
     Then I am taken to the 'Your Digital Outcomes and Specialists services' page
-    And I am presented with the message 'Digital specialists was marked as complete'
+    And I am presented with the message 'Digital Specialists was marked as complete'
     And There 'is a' completed 'digital specialists' service(s)
     And There 'is no' draft 'digital specialists' service(s)
 
@@ -157,6 +157,6 @@ Feature: Submitting a new DOS service for Digital specialists
 
     When I click 'Yes, delete'
     Then I am taken to the 'Your Digital Outcomes and Specialists services' page
-    And I am presented with the message 'Digital specialists was deleted'
+    And I am presented with the message 'Digital Specialists was deleted'
     And There 'is no' draft 'digital specialists' service(s)
     And There 'is no' completed 'digital specialists' service(s)

--- a/features/step_definitions/journey_test_steps.rb
+++ b/features/step_definitions/journey_test_steps.rb
@@ -1387,7 +1387,6 @@ Given /I am on the G-Cloud supplier A-Z page$/ do
   page.should have_selector(:xpath, ".//*[@id='global-atoz-navigation']//*/a[contains(@href, '/g-cloud/suppliers?prefix=other')]")
   page.should have_selector(:xpath, "//*[@id='global-breadcrumb']/nav/*[@role='breadcrumbs']/li[1]//*[contains(text(), 'Digital Marketplace')]")
   page.should have_selector(:xpath, "//*[@id='global-breadcrumb']/nav/*[@role='breadcrumbs']/li[2]//*[contains(text(), 'Cloud technology and support')]")
-  page.should have_link('Next')
 end
 
 Then /I am on the list of '(.*)' page$/ do |value|

--- a/features/step_definitions/ssp_steps.rb
+++ b/features/step_definitions/ssp_steps.rb
@@ -315,8 +315,7 @@ And /^There '(.*)' completed '(.*)' service\(s\)$/ do |availability,service|
       page.should have_no_selector(:xpath, ".//li//span[contains(text(),'#{service}')]/../../*/p[contains(text(),'You can edit it until the deadline')]")
     else
       if store.framework_name == 'digital-outcomes-and-specialists' and store.service_type == 'user-research-studios'
-        page.should have_selector(:xpath, ".//li//span[contains(text(),'#{service}')]/../../*/p[contains(text(),'#{store.completed_count} lab marked as complete')]")
-        page.should have_selector(:xpath, ".//li//span[contains(text(),'#{service}')]/../../*/p[contains(text(),' marked as complete')]")
+        page.should have_selector(:xpath, ".//li//span[contains(text(),'#{service}')]/../../*/p[contains(text(),'#{store.completed_count} lab will be submitted')]")
       elsif store.framework_name == 'g-cloud-7'
         page.should have_selector(:xpath, ".//li//span[contains(text(),'#{service}')]/../../*/p[contains(text(),'Marked as complete')]")
       end

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -8,4 +8,4 @@ bundle install
 mkdir -p reports
 rm -f screenshot*
 
-bundle exec cucumber -r features --tags ~@ssp --tags ~@wip --tags @functional-test --color --format html --out reports/index.html --format pretty
+bundle exec cucumber -r features --tags ~@ssp --tags ~@ssp-gcloud --tags ~@wip --tags @functional-test --color --format html --out reports/index.html --format pretty


### PR DESCRIPTION
Made a few small changes to the functional tests (making larger ones as we speak).

### [Changes](https://www.youtube.com/watch?v=pl3vxEudif8)

##### Capitalise 's' to find the element we're looking for

Notification messages for completed digital services now refer to
thems 'Digital Services', not 'Digital services.'

##### Remove check for next link in service A-Z listing

Checking for a 'next' link on the supplier A-Z page doesn't really tell
us anything about the A-Z page itself.  If we don't have a 'Next, we might still
on an A-Z page.
Removed it because it seemed besides the point.

##### Refactor notification-selector to actually find an element
Also remove a redundant check.

##### 	Stop testing the G7 SSP stuff
G-Cloud-7 applications are long finished, so running the suite of
unit tests (which break by the way) over the G7 SSP seems a bit pointless.