### PR TITLE
Improve test running

### DIFF
--- a/nginx/bootstrap.sh
+++ b/nginx/bootstrap.sh
@@ -1,11 +1,23 @@
 #!/usr/bin/env bash
 
-brew install nginx
-sudo cp "$(dirname "${BASH_SOURCE[0]}")/nginx.conf" /usr/local/etc/nginx/nginx.conf
+if [ "$(brew ls --versions nginx | wc -l)" -eq 0 ]; then
+  brew install nginx
+fi
 
-if sudo ps -xU nobody > /dev/null 2>&1; then
-  echo "Nginx running, reloading config"
-  sudo nginx -s reload
+local_config="$(dirname "$BASH_SOURCE[0]}")/nginx.conf"
+installed_config="/usr/local/etc/nginx/nginx.conf"
+config_updated=0
+if [ "$(diff "$local_config" "$installed_config" | wc -l)" -gt 0 ]; then
+  echo "Installing updated Nginx config"
+  sudo cp "$local_config" "$installed_config"
+  config_updated=1
+fi
+
+if ps -xU nobody > /dev/null 2>&1; then
+  if [ "$config_updated" -eq 1 ]; then
+    echo "Nginx running, reloading config"
+    sudo nginx -s reload
+  fi
 else
   echo "Starting Nginx"
   sudo nginx

--- a/scripts/create_users.sh
+++ b/scripts/create_users.sh
@@ -28,6 +28,7 @@ function create_user {
   }
 }
 EOF
+  echo -n "Creating admin user $email... "
   STATUS_CODE=$(curl -sL -w "%{http_code}" -o /dev/null -X POST -H 'Content-type: application/json' -H "Authorization: Bearer ${DM_API_ACCESS_TOKEN}" -d "${USER_PAYLOAD}" "${DM_API_DOMAIN}/users")
   if [ "$STATUS_CODE" == "409" ]; then
     echo "Already exists"

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -10,7 +10,6 @@ bundle install
 if [ "$DM_ENVIRONMENT" = "local" ]; then
   echo -e "\033[0;34mBootstrapping local environment\033[0m"
   ./scripts/create_users.sh "$DM_ENVIRONMENT"
-  exit
 fi
 
 mkdir -p reports

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -5,6 +5,15 @@ DM_ENVIRONMENT=${1:-local}
 bundle install
 . "./scripts/envs/${DM_ENVIRONMENT}.sh"
 
+./scripts/test_services.sh "$DM_ENVIRONMENT" || exit 1
+
+if [ "$DM_ENVIRONMENT" = "local" ]; then
+  echo -e "\033[0;34mBootstrapping local environment\033[0m"
+  ./nginx/bootstrap.sh
+  ./scripts/create_users.sh "$DM_ENVIRONMENT"
+  exit
+fi
+
 mkdir -p reports
 rm -f screenshot*
 

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -9,7 +9,6 @@ bundle install
 
 if [ "$DM_ENVIRONMENT" = "local" ]; then
   echo -e "\033[0;34mBootstrapping local environment\033[0m"
-  ./nginx/bootstrap.sh
   ./scripts/create_users.sh "$DM_ENVIRONMENT"
   exit
 fi

--- a/scripts/test_services.sh
+++ b/scripts/test_services.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Test that the data API, search API and frontends are up and accepting requests.
+
+DM_ENVIRONMENT=${1:-local}
+
+. "./scripts/envs/${DM_ENVIRONMENT}.sh"
+
+function test_url {
+  curl --output /dev/null --silent --head --fail "$1"
+}
+
+function fail {
+  >&2 echo -e "\033[1;31m$1\033[0m"
+  exit 1
+}
+
+test_url "${DM_API_DOMAIN}/_status" || fail "Data API is not up"
+test_url "${DM_SEARCH_API_DOMAIN}/_status" || fail "Search API is not up"
+test_url "${DM_FRONTEND_DOMAIN}/_status" || fail "Buyer frontend is not up"
+test_url "${DM_FRONTEND_DOMAIN}/suppliers/_status" || fail "Supplier frontend is not up"
+test_url "${DM_FRONTEND_DOMAIN}/admin/_status" || fail "Admin frontend is not up"
+
+echo -e "\033[0;32mAll services are up\033[0m"

--- a/scripts/test_services.sh
+++ b/scripts/test_services.sh
@@ -17,7 +17,7 @@ function fail {
 
 test_url "${DM_API_DOMAIN}/_status" || fail "Data API is not up"
 test_url "${DM_SEARCH_API_DOMAIN}/_status" || fail "Search API is not up"
-test_url "${DM_FRONTEND_DOMAIN}/_status" || fail "Buyer frontend is not up"
+test_url "${DM_FRONTEND_DOMAIN}/_status" || fail "Buyer frontend is not up$([ "$DM_ENVIRONMENT" = "local" ] && echo -n "; you may need to run ./nginx/bootstrap.sh")"
 test_url "${DM_FRONTEND_DOMAIN}/suppliers/_status" || fail "Supplier frontend is not up"
 test_url "${DM_FRONTEND_DOMAIN}/admin/_status" || fail "Admin frontend is not up"
 


### PR DESCRIPTION
## Add script to test services are up
It would be useful to short circuit the functional tests and tell you if some dependent services are not available rather than just showing you screens of fail.

## Add context to user bootstrapping script

## Make Nginx bootstrapping more robust
Only do actions if required to avoid sudo when not needed. These changes mean that it's less disruptive to put this on the normal test execution path.

- Check if nginx is not installed before trying to install.
- Check if installed nginx config is different before installing.
- Only reload the nginx config if it has changed.