### PR TITLE
Fix functional tests now that suppliers can remove services

### DIFF
--- a/features/G-Cloud/admin_journey.feature
+++ b/features/G-Cloud/admin_journey.feature
@@ -127,7 +127,7 @@ Scenario: Admin changes service status to 'Removed'. The change is reflected in 
   And The message 'This service has been removed' is presented on the suppliers view of the service summary page
   And The service 'can not' be searched
   And The service details page 'can' be viewed
-  And A message stating the supplier has stopped offering this service on todays date is presented on the service listing page
+  And A message stating the supplier has stopped offering this service on todays date is presented on the 'Buyer' service summary page
 
 Scenario: Admin changes service status to 'Private'. The change is reflected in the supplier and/or buyer app
   Given I am logged in as a 'Administrator' and am on the '1123456789012346' service summary page
@@ -139,7 +139,7 @@ Scenario: Admin changes service status to 'Private'. The change is reflected in 
   And The status of the service is presented as 'Removed' on the supplier users service listings page
   And The service 'can not' be searched
   And The service details page 'can' be viewed
-  And A message stating the supplier has stopped offering this service on todays date is presented on the service listing page
+  And A message stating the supplier has stopped offering this service on todays date is presented on the 'Buyer' service summary page
 
 Scenario: Admin changes service status to 'Public'. The change is reflected in the supplier and/or buyer app
   Given I am logged in as a 'Administrator' and am on the '1123456789012346' service summary page

--- a/features/G-Cloud/admin_journey.feature
+++ b/features/G-Cloud/admin_journey.feature
@@ -124,7 +124,7 @@ Scenario: Admin changes service status to 'Removed'. The change is reflected in 
   And I am presented with the message 'Service status has been updated to: Removed'
   And There is a new row for the 'Removed' status change in the service status change page
   And The status of the service is presented as 'Removed' on the supplier users service listings page
-  And A message stating the supplier has stopped providing this service on todays date is presented on the 'Supplier' service summary page
+  And A message stating the supplier has stopped offering this service on todays date is presented on the 'Supplier' service summary page
   And The service 'can not' be searched
   And The service details page 'can' be viewed
   And A message stating the supplier has stopped offering this service on todays date is presented on the 'Buyer' service summary page
@@ -137,7 +137,7 @@ Scenario: Admin changes service status to 'Private'. The change is reflected in 
   And I am presented with the message 'Service status has been updated to: Private'
   And There is a new row for the 'Removed' status change in the service status change page
   And The status of the service is presented as 'Removed' on the supplier users service listings page
-  And A message stating the supplier has stopped providing this service on todays date is presented on the 'Supplier' service summary page
+  And A message stating the supplier has stopped offering this service on todays date is presented on the 'Supplier' service summary page
   And The service 'can not' be searched
   And The service details page 'can' be viewed
   And A message stating the supplier has stopped offering this service on todays date is presented on the 'Buyer' service summary page

--- a/features/G-Cloud/admin_journey.feature
+++ b/features/G-Cloud/admin_journey.feature
@@ -124,7 +124,7 @@ Scenario: Admin changes service status to 'Removed'. The change is reflected in 
   And I am presented with the message 'Service status has been updated to: Removed'
   And There is a new row for the 'Removed' status change in the service status change page
   And The status of the service is presented as 'Removed' on the supplier users service listings page
-  And The message 'This service has been removed' is presented on the suppliers view of the service summary page
+  And A message stating the supplier has stopped providing this service on todays date is presented on the 'Supplier' service summary page
   And The service 'can not' be searched
   And The service details page 'can' be viewed
   And A message stating the supplier has stopped offering this service on todays date is presented on the 'Buyer' service summary page

--- a/features/G-Cloud/admin_journey.feature
+++ b/features/G-Cloud/admin_journey.feature
@@ -137,6 +137,7 @@ Scenario: Admin changes service status to 'Private'. The change is reflected in 
   And I am presented with the message 'Service status has been updated to: Private'
   And There is a new row for the 'Removed' status change in the service status change page
   And The status of the service is presented as 'Removed' on the supplier users service listings page
+  And A message stating the supplier has stopped providing this service on todays date is presented on the 'Supplier' service summary page
   And The service 'can not' be searched
   And The service details page 'can' be viewed
   And A message stating the supplier has stopped offering this service on todays date is presented on the 'Buyer' service summary page

--- a/features/G-Cloud/supplier_journey.feature
+++ b/features/G-Cloud/supplier_journey.feature
@@ -69,6 +69,7 @@ Scenario: As a logged in supplier user, I can edit my supplier information
   And I click 'Save and return'
   Then I am presented with the dashboard page with the changes that were made to the 'Supplier information'
 
+@wip
 Scenario: As a logged in supplier user, I can edit the description of a service
   Given I am logged in as a 'Supplier' and am on the '1123456789012346' service summary page
   When I navigate to the 'Edit' 'Description' page
@@ -77,6 +78,7 @@ Scenario: As a logged in supplier user, I can edit the description of a service
   And I click 'Save and return to service'
   Then I am presented with the summary page with the changes that were made to the 'Description'
 
+@wip
 Scenario: As a logged in supplier user, I can edit the features and benefits of a service
   Given I am logged in as a 'Supplier' and am on the '1123456789012346' service summary page
   When I navigate to the 'Edit' 'Features and benefits' page

--- a/features/G-Cloud/supplier_journey.feature
+++ b/features/G-Cloud/supplier_journey.feature
@@ -86,26 +86,17 @@ Scenario: As a logged in supplier user, I can edit the features and benefits of 
   And I click 'Save and return to service'
   Then I am presented with the summary page with the changes that were made to the 'Features and benefits'
 
-Scenario: Supplier user changes service status to 'Private'. The change is reflected in the admin and/or buyer app
+Scenario: Supplier user changes service status to 'Removed'. The change is reflected in the admin and/or buyer app
   Given I am logged in as a 'Supplier' and am on the '1123456789012346' service summary page
-  When I select 'Private' as the service status
-  And I click the 'Save and return' button
-  Then The service status is set as 'Removed'
-  And I am presented with the message 'Supplier changed the service name is now private'
-  And The status of the service is presented as 'Private' on the admin users service summary page
+  When I click 'Remove service'
+  Then I am presented with the message 'Are you sure you want to remove your service?'
+  When I click 'Remove service'
+  And I am presented with the message 'Supplier changed the service name has been removed.'
+  And A message stating the supplier has stopped providing this service on todays date is presented on the 'Supplier' service summary page
   And The service 'can not' be searched
   And The service details page 'can' be viewed
   And A message stating the supplier has stopped offering this service on todays date is presented on the 'Buyer' service summary page
-
-Scenario: Supplier user changes service status to 'Public'. The change is reflected in the admin and/or buyer app
-  Given I am logged in as a 'Supplier' and am on the '1123456789012346' service summary page
-  When I select 'Public' as the service status
-  And I click the 'Save and return' button
-  Then The service status is set as 'Live'
-  And I am presented with the message 'Supplier changed the service name is now public'
-  And The status of the service is presented as 'Public' on the admin users service summary page
-  And The service 'can' be searched
-  And The service details page 'can' be viewed
+  And The status of the service is presented as 'Private' on the admin users service summary page
 
 Scenario: Supplier user has 5 failed login attempts and is locked. Login is not allowed unless admin unlocks the user
   Given The supplier user 'DM Functional Test Supplier User 3' has 5 failed login attempts

--- a/features/G-Cloud/supplier_journey.feature
+++ b/features/G-Cloud/supplier_journey.feature
@@ -92,7 +92,7 @@ Scenario: Supplier user changes service status to 'Removed'. The change is refle
   Then I am presented with the message 'Are you sure you want to remove your service?'
   When I click 'Remove service'
   And I am presented with the message 'Supplier changed the service name has been removed.'
-  And A message stating the supplier has stopped providing this service on todays date is presented on the 'Supplier' service summary page
+  And A message stating the supplier has stopped offering this service on todays date is presented on the 'Supplier' service summary page
   And The service 'can not' be searched
   And The service details page 'can' be viewed
   And A message stating the supplier has stopped offering this service on todays date is presented on the 'Buyer' service summary page

--- a/features/G-Cloud/supplier_journey.feature
+++ b/features/G-Cloud/supplier_journey.feature
@@ -95,7 +95,7 @@ Scenario: Supplier user changes service status to 'Private'. The change is refle
   And The status of the service is presented as 'Private' on the admin users service summary page
   And The service 'can not' be searched
   And The service details page 'can' be viewed
-  And A message stating the supplier has stopped offering this service on todays date is presented on the service listing page
+  And A message stating the supplier has stopped offering this service on todays date is presented on the 'Buyer' service summary page
 
 Scenario: Supplier user changes service status to 'Public'. The change is reflected in the admin and/or buyer app
   Given I am logged in as a 'Supplier' and am on the '1123456789012346' service summary page

--- a/features/G-Cloud/supplier_journey.feature
+++ b/features/G-Cloud/supplier_journey.feature
@@ -93,7 +93,7 @@ Scenario: Supplier user changes service status to 'Removed'. The change is refle
   When I click 'Remove service'
   Then I am presented with the message 'Are you sure you want to remove your service?'
   When I click 'Remove service'
-  And I am presented with the message 'Supplier changed the service name has been removed.'
+  And I am presented with a service removal message for the '1123456789012346' service
   And A message stating the supplier has stopped offering this service on todays date is presented on the 'Supplier' service summary page
   And The service 'can not' be searched
   And The service details page 'can' be viewed

--- a/features/step_definitions/journey_test_steps.rb
+++ b/features/step_definitions/journey_test_steps.rb
@@ -950,6 +950,7 @@ And /A message stating the supplier has stopped offering this service on todays 
 
   case user_type
   when 'Supplier'
+    step "I am logged in as a 'DM Functional Test Supplier' 'Supplier' user and am on the dashboard page"
     page.visit("#{dm_frontend_domain}/suppliers/services/#{@servicesupplierID}")
     page.find(:xpath,
       "//div[@class='banner-temporary-message-without-action']/h2[contains(text(),'This service was removed on #{todays_date}')]/following-sibling::p[@class='banner-message'][contains(text(),'If you don’t know why this service was removed')]"

--- a/features/step_definitions/journey_test_steps.rb
+++ b/features/step_definitions/journey_test_steps.rb
@@ -924,6 +924,14 @@ Then /The service status is set as '(.*)'$/ do |service_status|
   end
 end
 
+And /I am presented with a service removal message for the '(.*)' service$/ do |value|
+  service_name = find(:xpath,
+    "//a[contains(@href, '/suppliers/services/#{value}')]"
+  ).text()
+
+  step "And I am presented with the message '#{service_name} has been removed.'"
+end
+
 And /I am presented with the message '(.*)'$/ do |message_text|
   page.should have_content(message_text)
 end

--- a/features/step_definitions/journey_test_steps.rb
+++ b/features/step_definitions/journey_test_steps.rb
@@ -179,11 +179,16 @@ Then /I am presented with the summary page for that service$/ do
   @existing_values['serviceid'] = serviceid
 
   if current_url.include?('suppliers')
-    servicestatus = find(
+    # if the remove button exists
+    remove_button = first(
       :xpath,
-      "//*[@class='selection-button selection-button-inline selection-button-selected']"
-    ).text()
-    @existing_values['servicestatus'] = servicestatus
+      "//input[@class='button-destructive' and @value='Remove service']"
+    )
+    if remove_button
+      @existing_values['servicestatus'] = 'Live'
+    else
+      @existing_values['servicestatus'] = 'Removed'
+    end
 
     servicename = find(
       :xpath,

--- a/features/step_definitions/journey_test_steps.rb
+++ b/features/step_definitions/journey_test_steps.rb
@@ -957,7 +957,7 @@ And /A message stating the supplier has stopped offering this service on todays 
     )
   when 'Buyer'
     page.find(:xpath,
-      "//div[@class='banner-temporary-message-without-action']/h2[contains(text(),'DM Functional Test Supplier stopped providing this service on #{todays_date}.')]/following-sibling::p[@class='banner-message'][contains(text(),'Any existing contracts for this service are still valid')]"
+      "//div[@class='banner-temporary-message-without-action']/h2[contains(text(),'DM Functional Test Supplier stopped offering this service on #{todays_date}.')]/following-sibling::p[@class='banner-message'][contains(text(),'Any existing contracts for this service are still valid')]"
     )
   else
     fail("Unrecognised user type: '#{user_type}'")

--- a/features/step_definitions/journey_test_steps.rb
+++ b/features/step_definitions/journey_test_steps.rb
@@ -939,17 +939,23 @@ Then /The status of the service is presented as '(.*)' on the admin users servic
   ).text().should have_content("#{service_status}")
 end
 
-And /The message 'This service has been removed' is presented on the suppliers view of the service summary page$/ do
-  page.visit("#{dm_frontend_domain}/suppliers/services/#{@servicesupplierID}")
-  page.find(:xpath, "//h2[@class='question-heading service-status-removed']").text().should have_content('This service has been removed')
-end
-
-And /A message stating the supplier has stopped offering this service on todays date is presented on the service listing page$/ do
+And /A message stating the supplier has stopped offering this service on todays date is presented on the '(.*)' service summary page$/ do |user_type|
   time = Time.new
   todays_date = time.strftime("%A %d %B %Y")
-  page.find(:xpath,
-    "//div[@class='banner-temporary-message-without-action']/h2[contains(text(),'DM Functional Test Supplier stopped offering this service on #{todays_date}.')]/following-sibling::p[@class='banner-message'][contains(text(),'Any existing contracts for this service are still valid.')]"
-  )
+
+  case user_type
+  when 'Supplier'
+    page.visit("#{dm_frontend_domain}/suppliers/services/#{@servicesupplierID}")
+    page.find(:xpath,
+      "//div[@class='banner-temporary-message-without-action']/h2[contains(text(),'This service was removed on #{todays_date}')]/following-sibling::p[@class='banner-message'][contains(text(),'If you don’t know why this service was removed')]"
+    )
+  when 'Buyer'
+    page.find(:xpath,
+      "//div[@class='banner-temporary-message-without-action']/h2[contains(text(),'DM Functional Test Supplier stopped providing this service on #{todays_date}.')]/following-sibling::p[@class='banner-message'][contains(text(),'Any existing contracts for this service are still valid')]"
+    )
+  else
+    fail("Unrecognised user type: '#{user_type}'")
+  end
 end
 
 And /The service '(.*)' be searched$/ do |ability|

--- a/features/step_definitions/ssp_steps.rb
+++ b/features/step_definitions/ssp_steps.rb
@@ -342,7 +342,7 @@ When /^I click the '(.*)' button at the '(.*)' of the page$/ do |button,location
     when 'top'
       page.first(:xpath, "//input[contains(@class,'button-save') and contains(@value,'#{button}')]").click
     else 'bottom'
-      page.find(:xpath, "//div[3]//input[contains(@class,'button-save') and contains(@value,'#{button}')]").click
+      page.all(:xpath, "//input[contains(@class,'button-save') and contains(@value,'#{button}')]").last.click
     end
 end
 


### PR DESCRIPTION
Suppliers removing their services has changed pretty substantially, both visually and functionally.  As a result, the functional tests need some updates to the content they're looking for and a few new tests.

- Removed the tests about changing a service from 'Public' to 'Private'
- Added a test for a supplier changing a service to 'Removed'
- Relevant tests look for the removed service notification banners where they exist
- Added a new tag to stop the supplier service edit tests from being run (not sure if Jenkins needs updating)
 - In our preview environment, suppliers can remove their services but not edit them

My supplier and admin journeys are working whether on my local environment or on preview.