### PR TITLE
Change buyer frontend framework slug

### DIFF
--- a/features/step_definitions/journey_test_steps.rb
+++ b/features/step_definitions/journey_test_steps.rb
@@ -1347,7 +1347,7 @@ Then /I am taken to page '(.*)' of results$/ do |page_number|
     current_url.should include("#{dm_frontend_domain}/g-cloud/suppliers?")
     current_url.should include("prefix=#{@data_store['supplier_alphabet']}")
     current_url.should include("page=#{page_number}")
-    current_url.should include("framework=gcloud")
+    current_url.should include("framework=g-cloud")
     if page_number >= '2'
       page.should have_no_selector(:xpath, "//a[contains(text(), 'Next')]//following-sibling::span[contains(text(),'page')]")
       page.should have_selector(:xpath, "//a[contains(text(), 'Previous')]//following-sibling::span[contains(text(),'page')]")


### PR DESCRIPTION
It has changed from gcloud to g-cloud to better match how it is used
elsewhere.