### PR TITLE
Accept cucumber arguments on run_tests.sh

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,6 +1,26 @@
 #!/bin/bash
+#
+# Examples:
+#   # Run default test suite (should be the same as what preview runs)
+#   ./scripts/run_tests.sh local
+#
+#   # Run a specific feature file
+#   ./scripts/run_tests.sh local features/G-Cloud/admin_journey.feature
+#
+#   # Run features tagged as @ssp-gcloud on preview
+#   ./scripts/run_tests.sh preview --tags @ssp-gcloud
+#
+#   # ERROR first argument must be an environment
+#   ./scripts/run_tests.sh features/G-Cloud/admin_journey.feature
 
 DM_ENVIRONMENT=${1:-local}
+shift
+
+if [ "$#" -gt 0 ]; then
+  COMMAND="features --tags ~@wip  --tags ~@ssp-gcloud  --tags ~@ssp-dos  --tags @functional-test"
+else
+  COMMAND="$*"
+fi
 
 bundle install
 . "./scripts/envs/${DM_ENVIRONMENT}.sh"
@@ -15,4 +35,4 @@ fi
 mkdir -p reports
 rm -f screenshot*
 
-bundle exec cucumber -r features --tags ~@ssp --tags ~@ssp-gcloud --tags ~@wip --tags @functional-test --color --format html --out reports/index.html --format pretty
+bundle exec cucumber -r features $COMMAND --color --format html --out reports/index.html --format pretty


### PR DESCRIPTION
This allows specific tests or test tags to be run from the `run_tests.sh` and adds some examples.