### PR TITLE
Add pre-flight checks for framework status

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -35,4 +35,5 @@ fi
 mkdir -p reports
 rm -f screenshot*
 
+echo -e "\033[0;34mRunning functional tests\033[0m"
 bundle exec cucumber -r features $COMMAND --color --format html --out reports/index.html --format pretty

--- a/scripts/test_dependencies.sh
+++ b/scripts/test_dependencies.sh
@@ -10,6 +10,10 @@ function test_url {
   curl --output /dev/null --silent --head --fail "$1"
 }
 
+function test_framework_status {
+  curl -H "Authorization: Bearer $DM_API_ACCESS_TOKEN" "$DM_API_DOMAIN/frameworks/$1" 2>/dev/null | grep '"status": "'$2'"' > /dev/null || fail "Framework $1 should have status '$2'"
+}
+
 function fail {
   >&2 echo -e "\033[1;31m$1\033[0m"
   exit 1
@@ -22,3 +26,11 @@ test_url "${DM_FRONTEND_DOMAIN}/suppliers/_status" || fail "Supplier frontend is
 test_url "${DM_FRONTEND_DOMAIN}/admin/_status" || fail "Admin frontend is not up"
 
 echo -e "\033[0;32mAll services are up\033[0m"
+
+test_framework_status "g-cloud-4" "expired"
+test_framework_status "g-cloud-5" "expired"
+test_framework_status "g-cloud-6" "live"
+test_framework_status "g-cloud-7" "live"
+test_framework_status "digital-outcomes-and-specialists" "pending"
+
+echo -e "\033[0;32mAll frameworks have the correct status\033[0m"


### PR DESCRIPTION
In order for the tests to run the frameworks must have particular
statuses. This change adds pre-flight checks to verify them and tell the
user which ones need to be changed.