### PR TITLE
Fix bug in run_tests

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -25,7 +25,7 @@ fi
 bundle install
 . "./scripts/envs/${DM_ENVIRONMENT}.sh"
 
-./scripts/test_services.sh "$DM_ENVIRONMENT" || exit 1
+./scripts/test_dependencies.sh "$DM_ENVIRONMENT" || exit 1
 
 if [ "$DM_ENVIRONMENT" = "local" ]; then
   echo -e "\033[0;34mBootstrapping local environment\033[0m"

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -17,9 +17,9 @@ DM_ENVIRONMENT=${1:-local}
 shift
 
 if [ "$#" -gt 0 ]; then
-  COMMAND="features --tags ~@wip  --tags ~@ssp-gcloud  --tags ~@ssp-dos  --tags @functional-test"
-else
   COMMAND="$*"
+else
+  COMMAND="features --tags ~@wip  --tags ~@ssp-gcloud  --tags ~@ssp-dos  --tags @functional-test"
 fi
 
 bundle install


### PR DESCRIPTION
The `test_services.sh` script was renamed to `test_dependencies.sh` as it was confusing.