### PR TITLE
Fix a failure introduced by #156

### DIFF
--- a/features/smoke_tests.feature
+++ b/features/smoke_tests.feature
@@ -4,7 +4,7 @@ Feature: Smoke tests
 Scenario: As supplier user I wish be able to log in and to log out of Digital Marketplace
   Given I am on the 'Digital Marketplace' login page
   When I login as a 'Supplier' user
-  Then I am presented with the 'DM Functional Test Supplier' 'Supplier' dashboard page
+  Then I am presented with the 'Digital Marketplace Team' 'Supplier' dashboard page
 
   When I click 'Log out'
   Then I am logged out of Digital Marketplace as a 'Supplier' user


### PR DESCRIPTION
On the other environments the supplier name is 'Digital Marketplace Team'.

This may not be the correct fix long term but at the moment our production smoke tests are broken.