### PR TITLE
Supplier responds to a brief

### DIFF
--- a/features/buyer/buyer_create_briefs.feature
+++ b/features/buyer/buyer_create_briefs.feature
@@ -20,7 +20,8 @@ Scenario: Start brief creation for an individual specialist
   When I choose 'North East England' for 'location'
   And I click 'Save and continue'
   Then I should be on the "Overview of work" page for the buyer brief 'Find an individual specialist brief'
-  @wip
+
+@wip
 Scenario: Newly created brief should be listed on the buyer's dashboard and the count of unanswered questions is correct
   Given I am logged in as 'DM Functional Test Buyer User 1' 'Buyer' user and am on the dashboard page
   Then The buyer brief 'Find an individual specialist brief' 'is' listed on the buyer's dashboard

--- a/features/step_definitions/journey_test_steps.rb
+++ b/features/step_definitions/journey_test_steps.rb
@@ -1879,6 +1879,28 @@ Then /^I should be on the "Overview of work" page for the buyer brief '(.*)'$/ d
   current_url.should end_with("#{dm_frontend_domain}/buyers/frameworks/#{store.framework_name}/requirements/#{store.service_type}/#{store.current_listing}")
 end
 
+Given /^I am on the supplier response page for the brief$/ do
+  brief_id = @published_brief['id']
+  visit "#{dm_frontend_domain}/suppliers/opportunities/#{brief_id}/responses/create"
+end
+
+And /^I see correct brief title and requirements for the brief$/ do
+  brief_title = @published_brief['title']
+  brief_requirements = @published_brief['essentialRequirements'] + @published_brief['niceToHaveRequirements']
+
+  page.find('h1').should have_content("#{brief_title}")
+  brief_requirements.each_with_index do |brief_requirement, index|
+    page.all('span.question-heading p')[index].should have_content("#{brief_requirement}")
+  end
+end
+
+Then /^I choose '(.*)' for the '(.*)' requirements$/ do |value, requirements|
+  @published_brief[requirements].each_with_index do |_, index|
+    input_id = "#{requirements}-#{index}"
+    step "I choose \'#{value}\' for \'#{input_id}\'"
+  end
+end
+
 Then /^Summary row '(.*)' should contain '(.*)'$/ do |field_name, field_value|
   page.find(:xpath, "//td/span[contains(text(),'#{field_name}')]/../../td[@class='summary-item-field']/span").should have_content("#{field_value}")
 end

--- a/features/step_definitions/setup_steps.rb
+++ b/features/step_definitions/setup_steps.rb
@@ -3,9 +3,6 @@ require "rubygems"
 require "rest_client"
 require "json"
 require "test/unit"
-require "ostruct"
-
-store = OpenStruct.new
 
 # suppliers
 def create_supplier (supplier_id, supplier_name, supplier_description, supplier_contactName, supplier_email, supplier_postcode, supplier_dunsnumber)
@@ -156,7 +153,7 @@ end
 
 Given /^I have a buyer user account$/ do
   user = create_buyer_user(dm_buyer_email(),"DM Functional Test Buyer User 1", dm_buyer_password())
-  store.buyer_id = user["id"]
+  @buyer_id = user["id"]
 end
 
 And /^The test suppliers have declarations$/ do
@@ -283,20 +280,19 @@ def delete_all_draft_briefs (user_id)
 end
 
 Given /^I have a '(.*)' brief$/ do |brief_state|
-  if not store.buyer_id
+  if not @buyer_id
     fail(ArgumentError.new('No buyer user found!!'))
   end
-  brief = create_and_return_buyer_brief("Individual Specialist-Brief deletion test", "digital-outcomes-and-specialists", "digital-specialists", store.buyer_id)
+  @published_brief = create_and_return_buyer_brief("Individual Specialist-Brief deletion test", "digital-outcomes-and-specialists", "digital-specialists", @buyer_id)
 
   if brief_state == 'published'
-    brief_id = brief["id"]
-    publish_buyer_brief(brief_id)
+    publish_buyer_brief(@published_brief['id'])
   end
 end
 
 Given /^I have deleted all draft briefs$/ do
-  if not store.buyer_id
+  if not @buyer_id
     fail(ArgumentError.new('No buyer user found!!'))
   end
-  delete_all_draft_briefs(store.buyer_id)
+  delete_all_draft_briefs(@buyer_id)
 end

--- a/features/step_definitions/setup_steps.rb
+++ b/features/step_definitions/setup_steps.rb
@@ -260,7 +260,22 @@ def publish_buyer_brief(brief_id)
   }
   response = call_api(:put, "/briefs/#{brief_id}/status", payload: publish_brief_data)
   response.code.should be(200), response.body
-  puts response
+end
+
+
+def delete_all_draft_briefs (user_id)
+  response = call_api(:get, "/briefs", params: {user_id: user_id})
+
+  JSON.parse(response.body)["briefs"].each do |brief|
+    brief_id = brief["id"]
+    updated_by = {updated_by: "Functional tests"}
+
+    if brief["status"] != "live"
+      puts "deleting draft: #{brief_id}"
+      response = call_api(:delete, "/briefs/#{brief_id}", payload: updated_by)
+      response.code.should be(200), response.body
+    end
+  end
 end
 
 Given /^I have a '(.*)' brief$/ do |brief_state|
@@ -275,4 +290,9 @@ Given /^I have a '(.*)' brief$/ do |brief_state|
   end
 end
 
-
+Given /^I have deleted all draft briefs$/ do
+  if not store.buyer_id
+    fail(ArgumentError.new('No buyer user found!!'))
+  end
+  delete_all_draft_briefs(store.buyer_id)
+end

--- a/features/supplier/supplier_brief_response.feature
+++ b/features/supplier/supplier_brief_response.feature
@@ -1,0 +1,28 @@
+@not-production @functional-test
+Feature: Supplier respond to briefs
+
+Background: Publish a brief
+  Given I have a buyer user account
+  And I have deleted all draft briefs
+  And I have a 'published' brief
+
+Scenario: Setup for responding to a brief
+  Given I have test suppliers
+  And The test suppliers have users
+  And Test supplier users are active
+
+Scenario: Check the brief response is correct
+  Given I am logged in as 'DM Functional Test Supplier' 'Supplier' user and am on the dashboard page
+  And I am on the supplier response page for the brief
+  Then I see correct brief title and requirements for the brief
+
+Scenario: Supplier successfully responds to a brief
+  Given I am logged in as 'DM Functional Test Supplier' 'Supplier' user and am on the dashboard page
+  And I am on the supplier response page for the brief
+  And I choose 'Yes' for the 'essentialRequirements' requirements
+  And I choose 'Yes' for the 'niceToHaveRequirements' requirements
+  And I enter '23/03/2015' in the 'availability' field
+  And I enter '100' in the 'dayRate' field
+  And I enter 'Janny' in the 'specialistName' field
+  And I click the 'Save and continue' button
+  Then I am presented with the message 'Your response to ‘Individual Specialist-Brief deletion test’ has been submitted.'

--- a/features/support/api_helpers.rb
+++ b/features/support/api_helpers.rb
@@ -1,4 +1,3 @@
-
 def call_api(method, path, options={})
   domain = options.delete(:domain) || dm_api_domain
   auth_token = options.delete(:auth_token) || dm_api_access_token
@@ -12,7 +11,13 @@ def call_api(method, path, options={})
   if payload.nil?
     RestClient.send(method, url, options) {|response, request, result| response}
   else
-    RestClient.send(method, url, payload.to_json, options) {|response, request, result| response}
+    # can't send a payload as part of a DELETE request
+    # http://stackoverflow.com/questions/21104232/delete-method-with-a-payload-using-ruby-restclient
+    if method == :delete
+      RestClient::Request.execute(method: :delete, url: url, payload: payload.to_json, headers: options) {|response, request, result| response}
+    else
+      RestClient.send(method, url, payload.to_json, options) {|response, request, result| response}
+   end
   end
 end
 


### PR DESCRIPTION
**Note:**
This set of functional tests creates 3 new published briefs each time it runs.  Not sure if this is a problem or if we're happy to ignore it.
***

### Create briefs; return users
Updated the `create_and_return_buyer_brief()` function so that it can create a publishable brief and (optionally) publish it.
Returning a user from user creation because we need to be able to associate a published brief with a buyer user.

### Delete non-live briefs
Since the functional tests are constantly creating new briefs, this step deletes those that it's able to.
Live briefs can't be deleted, nor will expired briefs be able to.

### Supplier responds to a brief
- set up supplier users
- set up a buyer user
- publish a brief
- sign in as a supplier
- visit the brief response page (directly)
- check for the correct title and requirements
- answer brief response questions
- submit response
- check for success message