### PR TITLE
Stop mentioning "briefs" in Scenarios

### DIFF
--- a/features/step_definitions/journey_test_steps.rb
+++ b/features/step_definitions/journey_test_steps.rb
@@ -1908,12 +1908,12 @@ Then /^I should be on the "Overview of work" page for the '(.*)' buyer requireme
   current_url.should end_with("#{dm_frontend_domain}/buyers/frameworks/#{store.framework}/requirements/#{store.lot}/#{store.current_brief_id}")
 end
 
-Given /^I am on the supplier response page for the brief$/ do
+Given /^I am on the supplier response page for the opportunity$/ do
   brief_id = @published_brief['id']
   visit "#{dm_frontend_domain}/suppliers/opportunities/#{brief_id}/responses/create"
 end
 
-And /^I see correct brief title and requirements for the brief$/ do
+And /^I see the correct title and requirements for the opportunity$/ do
   brief_title = @published_brief['title']
   brief_requirements = @published_brief['essentialRequirements'] + @published_brief['niceToHaveRequirements']
 

--- a/features/step_definitions/setup_steps.rb
+++ b/features/step_definitions/setup_steps.rb
@@ -288,7 +288,7 @@ def delete_all_draft_briefs (user_id)
   end
 end
 
-Given /^I have a '(.*)' brief$/ do |brief_state|
+Given /^I have a '(.*)' set of requirements$/ do |brief_state|
   if not @buyer_id
     fail(ArgumentError.new('No buyer user found!!'))
   end

--- a/features/supplier/supplier_brief_response.feature
+++ b/features/supplier/supplier_brief_response.feature
@@ -1,25 +1,25 @@
-@not-production @functional-test @brief-responses
-Feature: Supplier respond to briefs
+@not-production @functional-test
+Feature: Supplier respond to opportunities
 
-Background: Publish a brief
+Background: Buyer publishes requirements
   Given I have a buyer user account
   And I have deleted all draft buyer requirements
-  And I have a 'published' brief
+  And I have a 'published' set of requirements
 
-Scenario: Setup for responding to a brief
+Scenario: Setup for responding to an opportunity
   Given I have test suppliers
   And Test suppliers are eligible to respond to a brief
   And The test suppliers have users
   And Test supplier users are active
 
-Scenario: Check the brief response is correct
+Scenario: Supplier sees the correct opportunity
   Given I am logged in as 'DM Functional Test Supplier' 'Supplier' user and am on the dashboard page
-  And I am on the supplier response page for the brief
-  Then I see correct brief title and requirements for the brief
+  And I am on the supplier response page for the opportunity
+  Then I see the correct title and requirements for the opportunity
 
-Scenario: Supplier successfully responds to a brief
+Scenario: Supplier successfully responds to an opportunity
   Given I am logged in as 'DM Functional Test Supplier' 'Supplier' user and am on the dashboard page
-  And I am on the supplier response page for the brief
+  And I am on the supplier response page for the opportunity
   And I choose 'Yes' for the 'essentialRequirements' requirements
   And I choose 'Yes' for the 'niceToHaveRequirements' requirements
   And I enter '23/03/2015' in the 'availability' field

--- a/features/support/api_helpers.rb
+++ b/features/support/api_helpers.rb
@@ -11,7 +11,7 @@ def call_api(method, path, options={})
   if payload.nil?
     RestClient.send(method, url, options) {|response, request, result| response}
   else
-    # can't send a payload as part of a DELETE request
+    # can't send a payload as part of a DELETE request using the ruby rest client
     # http://stackoverflow.com/questions/21104232/delete-method-with-a-payload-using-ruby-restclient
     if method == :delete
       RestClient::Request.execute(method: :delete, url: url, payload: payload.to_json, headers: options) {|response, request, result| response}


### PR DESCRIPTION
We don't refer to our briefs as "briefs" anywhere in the frontend, so neither should we in our frontend scenarios.