### PR TITLE
Update for new link text on "Ask a question" page

### DIFF
--- a/features/supplier/supplier_submits_clarification_question.feature
+++ b/features/supplier/supplier_submits_clarification_question.feature
@@ -15,7 +15,7 @@ Scenario: Supplier asks a question
     Given I am on the 'Digital Marketplace' login page
     And I login as a 'Supplier' user
     And I am on the public view of the opportunity
-    When I click 'Log in to ask a question'
+    When I click 'Ask a question'
     Then I am taken to the 'Ask a question' page
     When I enter 'How do I ask a question?' in the 'clarification-question' field
     And I click the 'Ask question' button


### PR DESCRIPTION
If a user is already logged in then they now see the link text "Ask a question" rather than "Log in to ask a question", which is only shown when no user is logged in.