### PR TITLE
add check for 'closed' brief status in delete brief method

### DIFF
--- a/features/step_definitions/setup_steps.rb
+++ b/features/step_definitions/setup_steps.rb
@@ -280,7 +280,7 @@ def delete_all_draft_briefs (user_id)
     brief_id = brief["id"]
     updated_by = {updated_by: "Functional tests"}
 
-    if brief["status"] != "live"
+    if !["live", "closed"].include? brief["status"]
       puts "deleting draft: #{brief_id}"
       response = call_api(:delete, "/briefs/#{brief_id}", payload: updated_by)
       response.code.should be(200), response.body


### PR DESCRIPTION
This is to stop attempted deletion of closed briefs