### PR TITLE
new scenarios for checking count of unanswered questions

### DIFF
--- a/features/buyer/buyer_create_requirements.feature
+++ b/features/buyer/buyer_create_requirements.feature
@@ -24,10 +24,10 @@ Scenario: Start creating buyer requirements for an individual specialist
   And I click 'Save and continue'
   Then I should be on the "Overview of work" page for the 'Find an individual specialist' buyer requirements
 
-@wip
 Scenario: Newly created buyer requirements should be listed on the buyer's dashboard and the count of unanswered questions is correct
-  Given I am logged in as 'DM Functional Test Buyer User 1' 'Buyer' user and am on the dashboard page
+  Given I navigate directly to the 'buyers' dasboard page
   Then The buyer requirements for 'Find an individual specialist' 'is' listed on the buyer's dashboard
+  And The count of unanswered questions remaining for the buyer requirement is correctly shown
 
 Scenario: Verify text on summary page for information that has been provided so far. "Ready to publish" button should not exist
   Given I am on the "Overview of work" page for the buyer requirements
@@ -122,10 +122,10 @@ Scenario: Verify all text on summary page after adding mandatory information
   And Summary row 'Evaluating suppliers' 'should' contain 'pitch'
   And Summary row 'Evaluating suppliers' 'should' contain 'provide a written proposal'
 
-@wip
-Scenario: Count of unanswered questions should be updated accordingly
-  Given I am logged in as 'DM Functional Test Buyer User 1' 'Buyer' user and am on the dashboard page
+Scenario: Count of unanswered questions should be updated accordingly to only indicate optional questions remain unanswered
+  Given I navigate directly to the 'buyers' dasboard page
   Then The buyer requirements for 'Find an individual specialist' 'is' listed on the buyer's dashboard
+  And The count of unanswered questions remaining for the buyer requirement is correctly shown
 
 Scenario: Complete all optional requirements questions
   Given I am on the "Overview of work" page for the buyer requirements
@@ -163,6 +163,11 @@ Scenario: Complete all optional requirements questions
   When I enter 'Second nice-to-have requirement for Digital Marketplace Team' in the 'input-niceToHaveRequirements-2' field
   And I click the 'Save and continue' button
   Then I should be on the "Overview of work" page for the 'Find an individual specialist' buyer requirements
+
+Scenario: Count of unanswered questions should be updated accordingly to only indicate no questions remain unanswered
+  Given I navigate directly to the 'buyers' dasboard page
+  Then The buyer requirements for 'Find an individual specialist' 'is' listed on the buyer's dashboard
+  And The count of unanswered questions remaining for the buyer requirement is correctly shown
 
 Scenario: Verify all text on summary page after adding optional information
   Given I am on the "Overview of work" page for the buyer requirements

--- a/features/buyer/buyer_create_requirements.feature
+++ b/features/buyer/buyer_create_requirements.feature
@@ -25,7 +25,7 @@ Scenario: Start creating buyer requirements for an individual specialist
   Then I should be on the "Overview of work" page for the 'Find an individual specialist' buyer requirements
 
 Scenario: Newly created buyer requirements should be listed on the buyer's dashboard and the count of unanswered questions is correct
-  Given I navigate directly to the 'buyers' dasboard page
+  Given I navigate directly to the page '/buyers'
   Then The buyer requirements for 'Find an individual specialist' 'is' listed on the buyer's dashboard
   And The count of unanswered questions remaining for the buyer requirement is correctly shown
 
@@ -123,7 +123,7 @@ Scenario: Verify all text on summary page after adding mandatory information
   And Summary row 'Evaluating suppliers' 'should' contain 'provide a written proposal'
 
 Scenario: Count of unanswered questions should be updated accordingly to only indicate optional questions remain unanswered
-  Given I navigate directly to the 'buyers' dasboard page
+  Given I navigate directly to the page '/buyers'
   Then The buyer requirements for 'Find an individual specialist' 'is' listed on the buyer's dashboard
   And The count of unanswered questions remaining for the buyer requirement is correctly shown
 
@@ -165,7 +165,7 @@ Scenario: Complete all optional requirements questions
   Then I should be on the "Overview of work" page for the 'Find an individual specialist' buyer requirements
 
 Scenario: Count of unanswered questions should be updated accordingly to only indicate no questions remain unanswered
-  Given I navigate directly to the 'buyers' dasboard page
+  Given I navigate directly to the page '/buyers'
   Then The buyer requirements for 'Find an individual specialist' 'is' listed on the buyer's dashboard
   And The count of unanswered questions remaining for the buyer requirement is correctly shown
 

--- a/features/step_definitions/journey_test_steps.rb
+++ b/features/step_definitions/journey_test_steps.rb
@@ -1820,7 +1820,7 @@ And /There is no agreement available on the page$/ do
 end
 
 Given /^I navigate directly to the page '(.*)'$/ do |url|
-  page.visit("#{dm_frontend_domain}/#{url}")
+  page.visit("#{dm_frontend_domain}#{url}")
 end
 
 Then /I am on the '(.*)' page$/ do |page_name|
@@ -2070,8 +2070,4 @@ And /^The count of unanswered questions remaining for the buyer requirement is c
   else
     page.should have_no_selector(:xpath, "//a[contains(@href, '#{store.current_brief_id}')]/../../../td[3]/span[text()]")
   end
-end
-
-Given /^I navigate directly to the '(.*)' dasboard page$/ do |user_type|
-  step "I navigate directly to the page \'#{user_type}\'"
 end

--- a/features/step_definitions/setup_steps.rb
+++ b/features/step_definitions/setup_steps.rb
@@ -280,7 +280,7 @@ def delete_all_draft_briefs (user_id)
     brief_id = brief["id"]
     updated_by = {updated_by: "Functional tests"}
 
-    if brief["status"] != "live"
+    if !["live", "closed"].include? brief["status"]
       puts "deleting draft: #{brief_id}"
       response = call_api(:delete, "/briefs/#{brief_id}", payload: updated_by)
       response.code.should be(200), response.body

--- a/features/step_definitions/setup_steps.rb
+++ b/features/step_definitions/setup_steps.rb
@@ -280,7 +280,7 @@ def delete_all_draft_briefs (user_id)
     brief_id = brief["id"]
     updated_by = {updated_by: "Functional tests"}
 
-    if !["live", "closed"].include? brief["status"]
+    unless ["live", "closed"].include? brief["status"]
       puts "deleting draft: #{brief_id}"
       response = call_api(:delete, "/briefs/#{brief_id}", payload: updated_by)
       response.code.should be(200), response.body


### PR DESCRIPTION
Check count of required and optional questions left to be completed as presented on the buyer dashboard for the newly created brief