### PR TITLE
Update scenarios for the new brief overview page

### DIFF
--- a/features/buyer/buyer_create_requirements.feature
+++ b/features/buyer/buyer_create_requirements.feature
@@ -1,4 +1,4 @@
-@not-production @functional-test
+@not-production @functional-test @write-brief
 Feature: Buyer create buyer requirements
 
 Background: Login to Digital Marketplace as the newly created buyer
@@ -14,257 +14,275 @@ Scenario: Start creating buyer requirements for an individual specialist
   Then I am taken to the buyers 'Find an individual specialist' page
 
   When I click the 'Create requirement' button
-  Then I am taken to the 'Requirements title' page
+  Then I am taken to the 'What you want to call your requirements' page
 
   When I enter 'Find an individual specialist' in the 'title' field
   And I click the 'Save and continue' button
-  Then I am taken to the 'Location' page
+  Then I am taken to the 'Find an individual specialist' requirements overview page
+
+  When I click the 'location' link
+  Then I am taken to the 'Where you want the specialist to work' page
 
   When I choose 'North East England' for 'location'
   And I click 'Save and continue'
-  Then I should be on the "Overview of work" page for the 'Find an individual specialist' buyer requirements
+  Then I am taken to the 'Find an individual specialist' requirements overview page
 
-Scenario: Newly created buyer requirements should be listed on the buyer's dashboard and the count of unanswered questions is correct
+Scenario: Newly created buyer requirements should be listed on the buyer's dashboard
   Given I navigate directly to the page '/buyers'
   Then The buyer requirements for 'Find an individual specialist' 'is' listed on the buyer's dashboard
-  And The count of unanswered questions remaining for the buyer requirement is correctly shown
 
-Scenario: Verify text on summary page for information that has been provided so far. "Ready to publish" button should not exist
-  Given I am on the "Overview of work" page for the buyer requirements
-  Then Summary row 'Requirements title' should contain 'Find an individual specialist'
-  And Summary row 'Location' should contain 'North East England'
-#  This has changed and will change again with grandparent page, fix for new flow when possible
-#  And The 'Ready to publish' button is 'not' available
+Scenario: Verify form values for information that has been provided so far
+  Given I am on the 'Find an individual specialist' requirements overview page
 
-Scenario: Complete all mandatory buyer requirements questions. "Ready to publish" is only available on completing all mandatory questions
-  Given I am on the "Overview of work" page for the buyer requirements
-  When I click the 'Choose specialist role' link for 'Specialist role'
-  Then I am taken to the 'Specialist role' page
+  When I click the 'location' link
+  Then I am taken to the 'Where you want the specialist to work' page
+  And Form field 'location' should contain 'North East England'
+
+  When I click the 'Return to overview' link
+  Then I am taken to the 'Find an individual specialist' requirements overview page
+
+  When I click the 'title' link
+  Then I am taken to the 'What you want to call your requirements' page
+  And Form field 'title' should contain 'Find an individual specialist'
+
+Scenario: Fill out requirement section question
+  Given I am on the 'Find an individual specialist' requirements overview page
+  When I click the 'description of work' link
+  Then I am taken to the 'Description of work' page
+  When I click the 'Add organisation' link
+
+  When I enter 'GDS' in the 'organisation' field
+  And I click 'Save and continue'
+  Then I am taken to the 'Description of work' page
+  Then Summary row 'Organisation the work is for' should contain 'GDS'
+
+Scenario: "Ready to publish" button should not exist yet
+  Given I am on the 'Find an individual specialist' requirements overview page
+  When I click the 'Review and publish your requirements' link
+  Then I am taken to the 'Publish your requirements and evaluation criteria' page
+  And The 'Publish Requirements' button is 'not' available
+
+Scenario: Complete all mandatory buyer requirements questions
+  Given I am on the 'Find an individual specialist' requirements overview page
+  When I click the 'specialist role' link
+  Then I am taken to the 'Type of specialist you need' page
 
   When I choose 'Quality assurance analyst' for 'specialistRole'
   And I click 'Save and continue'
-  Then I should be on the "Overview of work" page for the 'Find an individual specialist' buyer requirements
-#  This has changed and will change again with grandparent page, fix for new flow when possible
-#  And The 'Ready to publish' button is 'not' available
+  Then I am taken to the 'Find an individual specialist' requirements overview page
 
-  When I click the 'Add organisation' link for 'Your organisation'
-  Then I am taken to the 'Your organisation' page
+  When I click the 'description of work' link
+  Then I am taken to the 'Description of work' page
 
-  When I enter 'Organisation-Digital Marketplace Team' in the 'organisation' field
+  When I click the 'Add responsibilities' link
+  Then I am taken to the 'What the specialist will work on' page
+  When I enter 'Specialist will work on the Digital Marketplace' in the 'specialistWork' field
   And I click the 'Save and continue' button
-  Then I should be on the "Overview of work" page for the 'Find an individual specialist' buyer requirements
+  Then I am taken to the 'Description of work' page
 
-  When I click the 'Add description' link for 'Background information'
-  Then I am taken to the 'Background information' page
-
-  When I fill in 'backgroundInformation' with:
-    """
-    Background
-    information
-    for
-    Digital Marketplace Team
-    """
+  When I click the 'Describe existing team' link
+  Then I am taken to the 'Who the specialist will work with' page
+  When I enter 'Specialist will work with the Digital Marketplace team' in the 'existingTeam' field
   And I click the 'Save and continue' button
-  Then I should be on the "Overview of work" page for the 'Find an individual specialist' buyer requirements
+  Then I am taken to the 'Description of work' page
 
-  When I click the 'Set date' link for 'Start date'
-  Then I am taken to the 'Start date' page
-
-  When I enter '01/01/2020' in the 'startDate' field
+  When I click the 'Describe where the supplier will work' link
+  Then I am taken to the 'Address where the work will take place' page
+  When I enter 'Aviation House' in the 'workplaceAddress' field
   And I click the 'Save and continue' button
-  Then I should be on the "Overview of work" page for the 'Find an individual specialist' buyer requirements
+  Then I am taken to the 'Description of work' page
 
-  When I click the 'Set contract length' link for 'Contract length'
-  Then I am taken to the 'Contract length' page
-
-  When I enter '24 months' in the 'contractLength' field
+  When I click the 'Describe working arrangements' link
+  Then I am taken to the 'Working arrangements' page
+  When I enter 'Work from home' in the 'workingArrangements' field
   And I click the 'Save and continue' button
-  Then I should be on the "Overview of work" page for the 'Find an individual specialist' buyer requirements
+  Then I am taken to the 'Description of work' page
 
-  When I click the 'Add description' link for 'Important dates'
-  Then I am taken to the 'mportant dates' page
-
-  When I enter '21/05/2021' in the 'importantDates' field
+  When I click the 'Set expected start date' link
+  Then I am taken to the 'Expected start date' page
+  When I enter '25/04/2016' in the 'startDate' field
   And I click the 'Save and continue' button
-  Then I should be on the "Overview of work" page for the 'Find an individual specialist' buyer requirements
+  Then I am taken to the 'Description of work' page
 
-  When I click the 'Add essential requirements' link for 'Essential requirements'
-  Then I am taken to the 'Your requirements' page
-
-  When I enter 'First in list' in the 'input-essentialRequirements-1' field
-  Then I add 'Second essential requirement for Digital Marketplace Team' as a 'essentialRequirements'
-  And I add 'A third row for essential requirements' as a 'essentialRequirements'
-
+  When I click the 'Provide a summary of the work' link
+  Then I am taken to the 'Summary' page
+  When I enter 'Make this work' in the 'summary' field
   And I click the 'Save and continue' button
-  Then I should be on the "Overview of work" page for the 'Find an individual specialist' buyer requirements
-#  This has changed and will change again with grandparent page, fix for new flow when possible
-#  And The 'Ready to publish' button is 'not' available
+  Then I am taken to the 'Description of work' page
 
-  When I click the 'Choose evaluation types' link for 'Evaluating suppliers'
-  Then I am taken to the 'Evaluating suppliers' page
+  When I click the 'Return to overview' link
+  Then I am taken to the 'Find an individual specialist' requirements overview page
 
-  When I 'check' 'pitch' for 'evaluationType'
-  And I 'check' 'provide a written proposal' for 'evaluationType'
+  When I click the 'shortlist criteria' link
+  Then I am taken to the 'Shortlist criteria' page
+
+  When I click the 'Add essential skills or experience' link
+  Then I am taken to the 'Essential skills and experience' page
+  When I enter 'Write functional tests' in the 'input-essentialRequirements-1' field
+  Then I enter 'Work with ruby' in the 'input-essentialRequirements-2' field
   And I click the 'Save and continue' button
-  Then I should be on the "Overview of work" page for the 'Find an individual specialist' buyer requirements
-#  This has changed and will change again with grandparent page, fix for new flow when possible
-#  And The 'Ready to publish' button is 'made' available
+  Then I am taken to the 'Shortlist criteria' page
 
-Scenario: Verify all text on summary page after adding mandatory information
-  Given I am on the "Overview of work" page for the buyer requirements
-  Then Summary row 'Requirements title' should contain 'Find an individual specialist'
-  And Summary row 'Location' should contain 'North East England'
-  And Summary row 'Specialist role' should contain 'Quality assurance analyst'
-  And Summary row 'Your organisation' should contain 'Organisation-Digital Marketplace Team'
-  And Summary row 'Background information' should contain 'Background information for Digital Marketplace Team'
-  And Summary row 'Start date' should contain '01/01/2020'
-  And Summary row 'Contract length' should contain '24 months'
-  And Summary row 'Important dates' should contain '21/05/2021'
-  And Summary row 'Essential requirements' should contain 'First in list'
-  And Summary row 'Essential requirements' should contain 'Second essential requirement for Digital Marketplace Team'
-  And Summary row 'Essential requirements' should contain 'A third row for essential requirements'
-  And Summary row 'Evaluating suppliers' should contain 'pitch'
-  And Summary row 'Evaluating suppliers' should contain 'provide a written proposal'
+  When I click the 'Set number of suppliers to evaluate' link
+  Then I am taken to the 'How many specialists will be evaluated' page
+  When I enter '5' in the 'numberOfSuppliers' field
+  And I click the 'Save and continue' button
+  Then I am taken to the 'Shortlist criteria' page
 
-Scenario: Count of unanswered questions should be updated accordingly to only indicate optional questions remain unanswered
-  Given I navigate directly to the page '/buyers'
-  Then The buyer requirements for 'Find an individual specialist' 'is' listed on the buyer's dashboard
-  And The count of unanswered questions remaining for the buyer requirement is correctly shown
+  When I click the 'Return to overview' link
+  Then I am taken to the 'Find an individual specialist' requirements overview page
+
+  When I click the 'evaluation criteria' link
+  Then I am taken to the 'Evaluation criteria' page
+
+  When I click the 'Set weighting' link
+  Then I am taken to the 'Weighting' page
+  When I enter '75' in the 'technicalWeighting' field
+  When I enter '5' in the 'culturalWeighting' field
+  When I enter '20' in the 'priceWeighting' field
+  And I click the 'Save and continue' button
+  Then I am taken to the 'Evaluation criteria' page
+
+  When I click the 'Choose cultural fit criteria' link
+  Then I am taken to the 'Cultural fit evaluation criteria' page
+  When I enter 'Main cultural fit criteria' in the 'input-culturalFitCriteria-1' field
+  When I enter 'Additional cultural fit criteria' in the 'input-culturalFitCriteria-2' field
+  And I click the 'Save and continue' button
+  Then I am taken to the 'Evaluation criteria' page
+
+  When I click the 'Choose assessment method' link
+  Then I am taken to the 'How you’ll assess the specialists' page
+  When I choose 'Interview' for 'evaluationType'
+  And I click the 'Save and continue' button
+  Then I am taken to the 'Evaluation criteria' page
+
+  When I click the 'Return to overview' link
+  Then I am taken to the 'Find an individual specialist' requirements overview page
+
+Scenario: Verify sections on the overview page are ticked
+  Given I am on the 'Find an individual specialist' requirements overview page
+  Then 'title' section is marked as complete
+  Then 'specialist role' section is marked as complete
+  Then 'location' section is marked as complete
+
+  When I click the 'description of work' link
+  Then I am taken to the 'Description of work' page
+  And Summary row 'Organisation the work is for' should contain 'GDS'
+  And Summary row 'What the specialist will work on' should contain 'Specialist will work on the Digital Marketplace'
+  And Summary row 'Who the specialist will work with' should contain 'Specialist will work with the Digital Marketplace team'
+  And Summary row 'Address where the work will take place' should contain 'Aviation House'
+  And Summary row 'Working arrangement' should contain 'Work from home'
+  And Summary row 'Expected start date' should contain '25/04/2016'
+  And Summary row 'Summary' should contain 'Make this work'
+
+  When I click the 'Return to overview' link
+  Then I am taken to the 'Find an individual specialist' requirements overview page
+  And 'description of work' section is marked as complete
+
+  When I click the 'shortlist criteria' link
+  Then I am taken to the 'Shortlist criteria' page
+  And Summary row 'Essential skills and experience' should contain 'Write functional tests'
+  And Summary row 'Essential skills and experience' should contain 'Work with ruby'
+  And Summary row 'How many specialists will be evaluated' should contain '5'
+
+  When I click the 'Return to overview' link
+  Then I am taken to the 'Find an individual specialist' requirements overview page
+  Then 'shortlist criteria' section is marked as complete
+
+  When I click the 'evaluation criteria' link
+  Then I am taken to the 'Evaluation criteria' page
+  And Summary row 'Weighting' should contain 'Technical competence 75% Cultural fit 5% Price 20%'
+  And Summary row 'Cultural fit criteria' should contain 'Main cultural fit criteria'
+  And Summary row 'Cultural fit criteria' should contain 'Additional cultural fit criteria'
+  And Summary row 'Assessment methods' should contain 'Interview'
+
+  When I click the 'Return to overview' link
+  Then I am taken to the 'Find an individual specialist' requirements overview page
+  Then 'evaluation criteria' section is marked as complete
 
 Scenario: Complete all optional requirements questions
-  Given I am on the "Overview of work" page for the buyer requirements
-  When I click the 'Add description' link for 'Current technologies'
-  Then I am taken to the 'Current technologies' page
+  Given I am on the 'Find an individual specialist' requirements overview page
 
-  When I fill in 'currentTechnologies' with:
-    """
-    Current technologies for Digital Marketplace Team:
-    Java
-    SQL
-    .net
-    """
+  When I click the 'description of work' link
+  Then I am taken to the 'Description of work' page
+
+  When I click the 'Add security clearance' link
+  Then I am taken to the 'Security clearance' page
+  When I enter 'SC' in the 'securityClearance' field
   And I click the 'Save and continue' button
-  Then I should be on the "Overview of work" page for the 'Find an individual specialist' buyer requirements
+  Then I am taken to the 'Description of work' page
 
-  When I click the 'Add description' link for 'Working arrangements'
-  Then I am taken to the 'Working arrangements' page
-
-  When I enter 'Working arrangements for Digital Marketplace Team' in the 'workingArrangements' field
+  When I click the 'Set expected contract length' link
+  Then I am taken to the 'Expected contract length' page
+  When I enter '1 year' in the 'contractLength' field
   And I click the 'Save and continue' button
-  Then I should be on the "Overview of work" page for the 'Find an individual specialist' buyer requirements
+  Then I am taken to the 'Description of work' page
 
-  When I click the 'Add description' link for 'Additional terms and conditions'
-  Then I am taken to the 'Working arrangements' page
-
-  When I enter 'Addition terms and conditions for Digital Marketplace Team' in the 'additionalTerms' field
+  When I click the 'Add terms and conditions' link
+  Then I am taken to the 'Additional terms and conditions' page
+  When I enter 'Some terms and conditions' in the 'additionalTerms' field
   And I click the 'Save and continue' button
-  Then I should be on the "Overview of work" page for the 'Find an individual specialist' buyer requirements
+  Then I am taken to the 'Description of work' page
 
-  When I click the 'Add nice-to-have requirements' link for 'Nice-to-have requirements'
-  Then I am taken to the 'Your requirements' page
-
-  When I enter 'First nice-to-have requirement for Digital Marketplace Team' in the 'input-niceToHaveRequirements-1' field
-  When I enter 'Second nice-to-have requirement for Digital Marketplace Team' in the 'input-niceToHaveRequirements-2' field
+  When I click the 'Add maximum day rate' link
+  Then I am taken to the 'Maximum day rate' page
+  When I enter '10000' in the 'budgetRange' field
   And I click the 'Save and continue' button
-  Then I should be on the "Overview of work" page for the 'Find an individual specialist' buyer requirements
+  Then I am taken to the 'Description of work' page
 
-Scenario: Count of unanswered questions should be updated accordingly to only indicate no questions remain unanswered
+  When I click the 'Return to overview' link
+  Then I am taken to the 'Find an individual specialist' requirements overview page
+
+  When I click the 'shortlist criteria' link
+  Then I am taken to the 'Shortlist criteria' page
+
+  When I click the 'Add nice-to-have skills and experience' link
+  Then I am taken to the 'Nice-to-have skills and experience' page
+  When I enter 'Nice-to-have requirement' in the 'input-niceToHaveRequirements-1' field
+  And I click the 'Save and continue' button
+  Then I am taken to the 'Shortlist criteria' page
+
+  When I click the 'Return to overview' link
+  Then I am taken to the 'Find an individual specialist' requirements overview page
+
+  When I click the 'Describe question and answer session' link
+  Then I am taken to the 'Describe question and answer session' page
+
+  When I click the 'Add details' link
+  Then I am taken to the 'Question and answer session details' page
+  When I enter 'Something about a webinar' in the 'questionAndAnswerSessionDetails' field
+  And I click the 'Save and continue' button
+  Then I am taken to the 'Describe question and answer session' page
+
+  When I click the 'Return to overview' link
+  Then I am taken to the 'Find an individual specialist' requirements overview page
+
+Scenario: Check the requirement is listed on the buyer dashboard
   Given I navigate directly to the page '/buyers'
   Then The buyer requirements for 'Find an individual specialist' 'is' listed on the buyer's dashboard
-  And The count of unanswered questions remaining for the buyer requirement is correctly shown
 
-Scenario: Verify all text on summary page after adding optional information
-  Given I am on the "Overview of work" page for the buyer requirements
-  Then Summary row 'Requirements title' should contain 'Find an individual specialist'
-  And Summary row 'Location' should contain 'North East England'
-  And Summary row 'Specialist role' should contain 'Quality assurance analyst'
-  And Summary row 'Your organisation' should contain 'Organisation-Digital Marketplace Team'
-  And Summary row 'Background information' should contain 'Background information for Digital Marketplace Team'
-  And Summary row 'Start date' should contain '01/01/2020'
-  And Summary row 'Contract length' should contain '24 months'
-  And Summary row 'Important dates' should contain '21/05/2021'
-  And Summary row 'Essential requirements' should contain 'First in list'
-  And Summary row 'Essential requirements' should contain 'Second essential requirement for Digital Marketplace Team'
-  And Summary row 'Essential requirements' should contain 'A third row for essential requirements'
-  And Summary row 'Evaluating suppliers' should contain 'pitch'
-  And Summary row 'Evaluating suppliers' should contain 'provide a written proposal'
-  And Summary row 'Current technologies' should contain 'Current technologies for Digital Marketplace Team: Java SQL .net'
-  And Summary row 'Working arrangements' should contain 'Working arrangements for Digital Marketplace Team'
-  And Summary row 'Additional terms and conditions' should contain 'Addition terms and conditions for Digital Marketplace Team'
-  And Summary row 'Nice-to-have requirements' should contain 'First nice-to-have requirement for Digital Marketplace Team'
-  And Summary row 'Nice-to-have requirements' should contain 'Second nice-to-have requirement for Digital Marketplace Team'
+Scenario: Edit Requirements title and verify the change made, on the summary page (Mandatory requirement)
+  Given I am on the 'Find an individual specialist' requirements overview page
 
-Scenario: Edit Requirements title and verify the change made, on the summary page(Mandatory requirement)
-  Given I am on the "Overview of work" page for the buyer requirements
-  And I navigate to the 'Edit' 'Requirements title' page
-
+  When I click the 'title' link
+  Then I am taken to the 'What you want to call your requirements' page
   When I change 'title' to 'Find an individual specialist-edited'
   And I click 'Save and continue'
-  Then I should be on the "Overview of work" page for the 'Find an individual specialist-edited' buyer requirements
-  And Summary row 'Requirements title' should contain 'Find an individual specialist-edited'
+  Then I am taken to the 'Find an individual specialist-edited' requirements overview page
 
-Scenario: Edit Current technologies and verify the change made, on the summary page(Optional requirement)
-  Given I am on the "Overview of work" page for the buyer requirements
-  And I navigate to the 'Edit' 'Current technologies' page
+Scenario: Publish requirements button is visible
+  Given I am on the 'Find an individual specialist' requirements overview page
+  When I click the 'Review and publish your requirements' link
 
-  When I change 'currentTechnologies' to 'Current technologies-edited'
-  And I click 'Save and continue'
-  Then I should be on the "Overview of work" page for the 'Find an individual specialist-edited' buyer requirements
-  And Summary row 'Current technologies' should contain 'Current technologies-edited'
-
-Scenario: Edit all other buyer requirements questions and verify the change made, on the summary page
-  Given I am on the "Overview of work" page for the buyer requirements
-  When I edit 'Location' by changing 'location' to 'Offsite'
-  Then Summary row 'Location' should contain 'Offsite'
-
-  When I edit 'Specialist role' by changing 'specialistRole' to 'Content designer'
-  Then Summary row 'Specialist role' should contain 'Content designer'
-
-  When I edit 'Your organisation' by changing 'organisation' to 'Organisation-Digital Marketplace Team-edited'
-  Then Summary row 'Your organisation' should contain 'Organisation-Digital Marketplace Team-edited'
-
-  When I edit 'Background information' by changing 'backgroundInformation' to 'Background information for Digital Marketplace Team-edited'
-  Then Summary row 'Background information' should contain 'Background information for Digital Marketplace Team-edited'
-
-  When I edit 'Start date' by changing 'startDate' to '12/12/2030'
-  Then Summary row 'Start date' should contain '12/12/2030'
-
-  When I edit 'Contract length' by changing 'contractLength' to '365 days'
-  Then Summary row 'Contract length' should contain '365 days'
-
-  When I edit 'Important dates' by changing 'importantDates' to '21 May 2031'
-  Then Summary row 'Important dates' should contain '21 May 2031'
-
-  When I edit 'Working arrangements' by changing 'workingArrangements' to 'Working arrangements for Digital Marketplace Team-edited'
-  Then Summary row 'Working arrangements' should contain 'Working arrangements for Digital Marketplace Team-edited'
-
-  When I edit 'Additional terms and conditions' by changing 'additionalTerms' to 'Addition terms and conditions for Digital Marketplace Team-edited'
-  Then Summary row 'Additional terms and conditions' should contain 'Addition terms and conditions for Digital Marketplace Team-edited'
-
-  When I edit 'Essential requirements' by changing 'input-essentialRequirements-1' to 'First in list-edited'
-  When I edit 'Essential requirements' by 'removing' 'A third row for essential requirements' for 'input-essentialRequirements-3'
-  Then Summary row 'Essential requirements' should contain 'First in list-edited'
-  Then Summary row 'Essential requirements' should not contain 'A third row for essential requirements'
-  Then Summary row 'Essential requirements' should contain 'Second essential requirement for Digital Marketplace Team'
-
-  When I edit 'Nice-to-have requirements' by changing 'input-niceToHaveRequirements-2' to 'Second nice-to-have requirement for Digital Marketplace Team-edited'
-  When I edit 'Nice-to-have requirements' by 'adding' 'Third requirement-added' for 'niceToHaveRequirements'
-  Then Summary row 'Nice-to-have requirements' should contain 'Second nice-to-have requirement for Digital Marketplace Team-edited'
-  Then Summary row 'Nice-to-have requirements' should contain 'First nice-to-have requirement for Digital Marketplace Team'
-  Then Summary row 'Nice-to-have requirements' should contain 'Third requirement-added'
-
-  When I edit 'Evaluating suppliers' by 'unchecking' 'pitch' for 'evaluationType'
-  And I edit 'Evaluating suppliers' by 'checking' 'provide a case study or evidence of previous work' for 'evaluationType'
-  Then Summary row 'Evaluating suppliers' should contain 'provide a case study or evidence of previous work'
-  Then Summary row 'Evaluating suppliers' should contain 'provide a written proposal'
-  And Summary row 'Evaluating suppliers' should not contain 'pitch'
+  Then I am taken to the 'Publish your requirements and evaluation criteria' page
+  And The 'Publish Requirements' button is 'made' available
 
 Scenario: Created buyer requirements can be deleted
-  Given A draft 'Find an individual specialist' buyer requirements with the name 'Individual Specialist-Buyer Requirements' exists and I am on the "Overview of work" page
+  Given A draft 'Find an individual specialist' buyer requirements with the name 'Buyer Requirements to be deleted' exists and I am on the "Overview of work" page
   When I click 'Delete'
   Then I am presented with the message 'Are you sure you want to delete these requirements?'
 
   When I click 'Yes, delete'
   Then I am presented with the 'DM Functional Test Buyer User 1' 'Buyer' dashboard page
-  And I am presented with the message 'Your requirements ‘Individual Specialist-Buyer Requirements’ were deleted'
-  And The buyer requirements for 'Individual Specialist-Buyer Requirements' 'is not' listed on the buyer's dashboard
+  And I am presented with the message 'Your requirements ‘Buyer Requirements to be deleted’ were deleted'
+  And The buyer requirements for 'Buyer Requirements to be deleted' 'is not' listed on the buyer's dashboard

--- a/features/buyer/buyer_create_requirements.feature
+++ b/features/buyer/buyer_create_requirements.feature
@@ -98,8 +98,8 @@ Scenario: Complete all mandatory buyer requirements questions
   And I click the 'Save and continue' button
   Then I am taken to the 'Description of work' page
 
-  When I click the 'Set expected start date' link
-  Then I am taken to the 'Expected start date' page
+  When I click the 'Set latest start date' link
+  Then I am taken to the 'Latest start date' page
   When I enter '25/04/2016' in the 'startDate' field
   And I click the 'Save and continue' button
   Then I am taken to the 'Description of work' page
@@ -172,7 +172,7 @@ Scenario: Verify sections on the overview page are ticked
   And Summary row 'Who the specialist will work with' should contain 'Specialist will work with the Digital Marketplace team'
   And Summary row 'Address where the work will take place' should contain 'Aviation House'
   And Summary row 'Working arrangement' should contain 'Work from home'
-  And Summary row 'Expected start date' should contain '25/04/2016'
+  And Summary row 'Latest start date' should contain '25/04/2016'
   And Summary row 'Summary' should contain 'Make this work'
 
   When I click the 'Return to overview' link

--- a/features/buyer/buyer_publish_question_and_answer.feature
+++ b/features/buyer/buyer_publish_question_and_answer.feature
@@ -1,4 +1,4 @@
-@not-production @functional-test
+@not-production @functional-test @brief-questions
 Feature: Buyer publishes question and answer
 
 Background: Create buyer user account and login to DM
@@ -13,21 +13,27 @@ Scenario: Test setup
 Scenario: Buyer answers a couple of clarification questions and publishes each one in turn
   Given I have logged in to Digital Marketplace as a 'Buyer' user
   And A published 'Find an individual specialist' buyer requirements with the name 'Individual Specialist-Buyer Requirements' exists and I am on the "Overview of work" page
-  When I click the 'Answer a clarification question' link
-  Then I am taken to the 'Answer a clarification question' page
+  When I click the 'Publish questions and answers' link
+  Then I am taken to the 'Supplier questions' page
+
+  When I click the 'Answer a supplier question' link
+  Then I am taken to the 'Publish questions and answers' page
 
   When I enter 'This is the first clarification question. What else can I put in here?' in the 'question' field
   Then I enter 'You can put any queries about this opportunity here and we will answer it the best we can.' in the 'answer' field
-  And I click the 'Publish clarification question' button
-  Then I am taken back to the "Overview of work" page with the first question and answer listed under "Clarification questions"
+  And I click the 'Save and continue' button
+  Then I am taken to the 'Supplier questions' page
 
-  When I click the 'Answer a clarification question' link
-  Then I am taken to the 'Answer a clarification question' page
+  When I click the 'Answer a supplier question' link
+  Then I am taken to the 'Publish questions and answers' page
 
   When I enter 'This is the second clarification question. What is the cost?' in the 'question' field
   Then I enter 'The price is as stated in the brief, which is £123/hr' in the 'answer' field
-  And I click the 'Publish clarification question' button
-  Then I am taken back to the "Overview of work" page with the second question and answer listed under "Clarification questions"
+  And I click the 'Save and continue' button
+  Then I am taken to the 'Supplier questions' page
+
+  When I click the 'Return to overview' link
+  Then I am taken to the 'Individual Specialist-Buyer Requirements' requirements overview page
 
 Scenario: Supplier/Public can view questions and answers to an opportunity
   Given I have logged in to Digital Marketplace as a 'Supplier' user
@@ -37,4 +43,5 @@ Scenario: Supplier/Public can view questions and answers to an opportunity
 
   When I click on the link to the opportunity I have posted a question for
   Then I am on the details page for the selected opportunity
-  And I can see all questions and answers related to the opportunity
+  And Summary row 'This is the first clarification question. What else can I put in here?' should contain 'You can put any queries about this opportunity here and we will answer it the best we can.'
+  And Summary row 'This is the second clarification question. What is the cost?' should contain 'The price is as stated in the brief, which is £123/hr'

--- a/features/public/public_view_published_requirements.feature
+++ b/features/public/public_view_published_requirements.feature
@@ -12,7 +12,7 @@ Scenario: Public views the publish requirements. Details presented matches what 
     Then Summary row 'Published' should contain 'the published at date of the opportunity'
     And The Requirements title 'Individual Specialist-Buyer Requirements' is presented on the page
 
-    And Summary row 'Expected start date' should contain '31/12/2016'
+    And Summary row 'Latest start date' should contain '31/12/2016'
     And Summary row 'Expected contract length' should contain '1 day'
 
     And Summary row 'Organisation the work is for' should contain 'Driver and Vehicle Licensing Agency'

--- a/features/public/public_view_published_requirements.feature
+++ b/features/public/public_view_published_requirements.feature
@@ -1,4 +1,4 @@
-@not-production @functional-test
+@not-production @functional-test @view-brief
 Feature: Published requirements can be viewed by the public
 
 Background: Publish requirements
@@ -10,21 +10,22 @@ Scenario: Public views the publish requirements. Details presented matches what 
     Given I am on the 'Digital Marketplace' landing page
     When I am on the public view of the opportunity
     Then Summary row 'Published' should contain 'the published at date of the opportunity'
-    Then The Organisation name 'Driver and Vehicle Licensing Agency' is presented on the page
     And The Requirements title 'Individual Specialist-Buyer Requirements' is presented on the page
 
-    And Summary row 'Start date' should contain '31/12/2016'
-    And Summary row 'Contract length' should contain '1 day'
-    #Public view currently displays 'Location' twice. Reinstate after issue resolved.
-    #And Summary row 'Location' should contain 'Scotland'
+    And Summary row 'Expected start date' should contain '31/12/2016'
+    And Summary row 'Expected contract length' should contain '1 day'
 
-    And Summary row 'Background information' should contain 'Make a flappy bird clone except where the bird drives very safely'
-    And Summary row 'Important dates' should contain 'Yesterday'
+    And Summary row 'Organisation the work is for' should contain 'Driver and Vehicle Licensing Agency'
+    And Summary row 'What the specialist will work on' should contain 'Work on the Digital Marketplace'
+    And Summary row 'Who the specialist will work with' should contain 'Digital Marketplace team'
+    And Summary row 'Region' should contain 'Scotland'
 
-    And Summary row 'Essential requirements' should contain 'Can you do coding?'
-    And Summary row 'Essential requirements' should contain 'Can you do Python?'
-    And Summary row 'Nice-to-have requirements' should contain 'Do you like cats?'
-    And Summary row 'Nice-to-have requirements' should contain 'Is your cat named Eva?'
+    And Summary row 'Summary of the work' should contain 'Make a flappy bird clone except where the bird drives very safely'
+
+    And Summary row 'Essential skills and experience' should contain 'Can you do coding?'
+    And Summary row 'Essential skills and experience' should contain 'Can you do Python?'
+    And Summary row 'Nice-to-have skills and experience' should contain 'Do you like cats?'
+    And Summary row 'Nice-to-have skills and experience' should contain 'Is your cat named Eva?'
 
     And Summary row 'Specialist role' should contain 'Developer'
-    And Summary row 'Evaluating suppliers' should contain 'pitch'
+    And Summary row 'Assessment methods' should contain 'Reference'

--- a/features/step_definitions/requirements_steps.rb
+++ b/features/step_definitions/requirements_steps.rb
@@ -1,0 +1,50 @@
+store = OpenStruct.new
+
+Given /^I am on the '(.*)' requirements overview page$/ do |brief_name|
+  visit "#{dm_frontend_domain}/buyers/frameworks/#{store.framework}/requirements/#{store.lot}/#{store.current_brief_id}"
+  page.find('h1').should have_content("#{brief_name}")
+  current_url.should end_with("#{dm_frontend_domain}/buyers/frameworks/#{store.framework}/requirements/#{store.lot}/#{store.current_brief_id}")
+end
+
+Given /^I am on the details page for the selected opportunity$/ do
+  current_url.should end_with("#{dm_frontend_domain}/#{store.framework}/opportunities/#{store.current_brief_id}")
+end
+
+Then /^I am taken to the '(.*)' requirements overview page$/ do |brief_name|
+  page.find('h1').should have_content(brief_name)
+  page.all(:css, '.instruction-list h2').map {|e| e.text }.should == [
+    "1. Write requirements",
+    "2. Set how you’ll evaluate suppliers",
+    "3. Publish requirements",
+    "4. Answer supplier questions",
+    "5. Shortlist",
+    "6. Evaluate",
+    "7. Award a contract"
+  ]
+  parts = URI.parse(current_url).path.split('/')
+  store.current_brief_id = (parts.select {|v| v =~ /^\d+$/}).last
+  store.framework = URI.parse(current_url).path.split('frameworks/').last.split('/').first
+  store.lot = URI.parse(current_url).path.split('requirements/').last.split('/').first
+  current_url.should end_with("#{dm_frontend_domain}/buyers/frameworks/#{store.framework}/requirements/#{store.lot}/#{store.current_brief_id}")
+end
+
+Then /^'(.*)' section is marked as complete$/ do |section|
+  page.all(:xpath, '//span[@class="tick"]/following-sibling::a').map {|e| e.text }.should include(section)
+end
+
+Given /^A (.*) '(.*)' buyer requirements with the name '(.*)' exists and I am on the "Overview of work" page$/ do |brief_state, brief_type, brief_name|
+  steps %Q{
+    Given I have a '#{brief_state}' set of requirements named '#{brief_name}'
+    And I am on the "Overview of work" page for the newly created buyer requirements
+  }
+  page.find('h1').should have_content(brief_name)
+  parts = URI.parse(current_url).path.split('/')
+  store.current_brief_id = (parts.select {|v| v =~ /^\d+$/}).last
+  store.framework = URI.parse(current_url).path.split('frameworks/').last.split('/').first
+  store.lot = URI.parse(current_url).path.split('requirements/').last.split('/').first
+  current_url.should end_with("#{dm_frontend_domain}/buyers/frameworks/#{store.framework}/requirements/#{store.lot}/#{store.current_brief_id}")
+end
+
+When /^I click on the link to the opportunity I have posted a question for$/ do
+  page.find(:xpath, "//h2/a[contains(@href, '/#{store.framework}/opportunities/#{store.current_brief_id}')]").click
+end

--- a/features/step_definitions/setup_steps.rb
+++ b/features/step_definitions/setup_steps.rb
@@ -242,23 +242,28 @@ def create_and_return_buyer_brief (brief_name, framework_slug, lot, user_id)
   file = File.read("./fixtures/briefs-DOS.json")
   brief_data = JSON.parse(file)
   brief_data["briefs"] = brief_data["briefs"].merge({
-    "title" => brief_name,
-    "location" => "Scotland",
-    "frameworkSlug" => framework_slug,
-    "lot" => lot,
-    "userId" => user_id,
-    "startDate" => '31/12/2016',
-    "specialistRole" => 'developer',
-    "organisation" => 'Driver and Vehicle Licensing Agency',
-    "importantDates" => 'Yesterday',
-    "evaluationType" => ['pitch'],
     "contractLength" => '1 day',
-    "backgroundInformation" => 'Make a flappy bird clone except where the bird drives very safely',
-    "essentialRequirements" => ['Can you do coding?', 'Can you do Python?'],
-    "niceToHaveRequirements" => ['Do you like cats?', 'Is your cat named Eva?'],
+    "culturalFitCriteria" => ["Cultural fit criteria 1", "Cultural fit criteria 2"],
     "culturalWeighting" => 10,
+    "essentialRequirements" => ['Can you do coding?', 'Can you do Python?'],
+    "evaluationType" => ['Reference'],
+    "existingTeam" => "Digital Marketplace team",
+    "frameworkSlug" => framework_slug,
+    "location" => "Scotland",
+    "lot" => lot,
+    "niceToHaveRequirements" => ['Do you like cats?', 'Is your cat named Eva?'],
+    "numberOfSuppliers" => "5",
+    "organisation" => 'Driver and Vehicle Licensing Agency',
     "priceWeighting" => 20,
+    "specialistRole" => 'developer',
+    "specialistWork" => "Work on the Digital Marketplace",
+    "startDate" => '31/12/2016',
+    "summary" => "Make a flappy bird clone except where the bird drives very safely",
     "technicalWeighting" => 70,
+    "title" => brief_name,
+    "userId" => user_id,
+    "workingArrangements" => "Working from home",
+    "workplaceAddress" => "Aviation House",
   })
   brief_data["updated_by"] = "functional tests"
 
@@ -294,11 +299,11 @@ def delete_all_draft_briefs (user_id)
   end
 end
 
-Given /^I have a '(.*)' (?:opportunity|set of requirements)$/ do |brief_state|
+Given /^I have a '(.*)' (?:opportunity|set of requirements)(?: named '(.*)')?$/ do |brief_state, brief_name|
   if not @buyer_id
     fail(ArgumentError.new('No buyer user found!!'))
   end
-  @created_brief = create_and_return_buyer_brief("Individual Specialist-Buyer Requirements", "digital-outcomes-and-specialists", "digital-specialists", @buyer_id)
+  @created_brief = create_and_return_buyer_brief(brief_name || "Individual Specialist-Buyer Requirements", "digital-outcomes-and-specialists", "digital-specialists", @buyer_id)
   store.framework = @created_brief["frameworkSlug"]
   store.lot = @created_brief["lotSlug"]
   store.current_brief = @created_brief["id"]

--- a/features/supplier/supplier_opportunity_response.feature
+++ b/features/supplier/supplier_opportunity_response.feature
@@ -1,4 +1,4 @@
-@not-production @functional-test
+@not-production @functional-test @brief-response
 Feature: Supplier respond to opportunities
 
 Background: Buyer publishes requirements
@@ -25,6 +25,5 @@ Scenario: Supplier successfully responds to an opportunity
   And I choose 'Yes' for the 'niceToHaveRequirements' requirements
   And I enter '23/03/2015' in the 'availability' field
   And I enter '100' in the 'dayRate' field
-  And I enter 'Janny' in the 'specialistName' field
   And I click the 'Save and continue' button
   Then I am presented with the message 'Your response to ‘Individual Specialist-Buyer Requirements’ has been submitted.'


### PR DESCRIPTION
Rewrites brief creation to use the new brief overview page.
There are a lot of changes that went in in the last few days, so
it's likely I've missed something, but the major changes are:

* There's no brief unanswered question count checks since the
  counters aren't displayed on the overview page anymore and
  it's hard to count questions without a single summary view.

* Removed steps that edited all brief fields. Only brief title is
  changed to check that editing works, other steps don't add that
  much compared to filling brief fields for the first time.

* Moved some step definitions to `requirements_steps.rb`. This is
  complicated by the use of a file-wide global `store` in the
  journey steps.

This will need some clean up in the future, since I've probably left
some unused step definitions behind.