### PR TITLE
Update admin tests for new improved search-by-email flow

### DIFF
--- a/features/admin/admin_journey.feature
+++ b/features/admin/admin_journey.feature
@@ -66,7 +66,7 @@ Scenario: As an admin user who has logged in to Digital Marketplace, I wish to s
   Then The page for the 'DM Functional Test Supplier User 3' user is presented
 
   When I click the 'DM Functional Test Supplier' link
-  Then I am presented with the 'Users' page for the supplier 'DM Functional Test Supplier'
+  Then I am presented with the overview page for the supplier 'DM Functional Test Supplier'
 
 Scenario: Admin user should be able to abort an edit and be returned to the service summary page
   Given I am logged in as 'Administrator' and am on the '1123456789012346' service summary page

--- a/features/step_definitions/journey_test_steps.rb
+++ b/features/step_definitions/journey_test_steps.rb
@@ -832,6 +832,18 @@ Then /I am presented with the '(.*)' page for the supplier '(.*)'$/ do |page_nam
   page.should have_selector(:xpath, ".//*[@id='global-breadcrumb']/nav/*[@role='breadcrumbs']/li[2][contains(text(), '#{supplier_name}')]")
 end
 
+Then /I am presented with the overview page for the supplier '(.*)'$/ do |supplier_name|
+  if dm_supplier_user_emails().include?(@servicesupplierID) or @servicesupplierID == "DM Functional Test Supplier" or supplier_name == "DM Functional Test Supplier"
+    @servicesupplierID = '11111'
+  end
+  page.should have_selector(:xpath, "*//header/h1[contains(text(), 'Suppliers')]")
+  page.should have_selector(:xpath, "*//td[@class='summary-item-field-first']/span[contains(text(), supplier_name)]")
+  page.should have_link('Change name')
+  page.should have_link('Users')
+  page.should have_link('Services')
+  current_url.should end_with("#{dm_frontend_domain}/admin/suppliers?supplier_id=#{@servicesupplierID}")
+end
+
 Then /I am presented with the 'Suppliers' page for all suppliers starting with '(.*)'$/ do |name_prefix|
   page.should have_content('Suppliers')
   page.should have_link('Log out')


### PR DESCRIPTION
This should fix the preview functional tests.

Running locally at the moment, will add sparkles here once they pass...

:sparkles: :sparkles: :sparkles: :sparkles: :sparkles: :sparkles: :sparkles: 
~~Still going, but the failing scenario on Preview has now passed locally.~~
Everything passes locally.
:sparkles: :sparkles: :sparkles: :sparkles: :sparkles: :sparkles: :sparkles: 