### PR TITLE
Update *requirements question names

### DIFF
--- a/features/buyer/buyer_create_requirements.feature
+++ b/features/buyer/buyer_create_requirements.feature
@@ -117,7 +117,7 @@ Scenario: Complete all mandatory buyer requirements questions
   Then I am taken to the 'Shortlist criteria' page
 
   When I click the 'Add essential skills or experience' link
-  Then I am taken to the 'Essential skills and experience' page
+  Then I am taken to the 'Technical competence: essential skills and experience' page
   When I enter 'Write functional tests' in the 'input-essentialRequirements-1' field
   Then I enter 'Work with ruby' in the 'input-essentialRequirements-2' field
   And I click the 'Save and continue' button
@@ -181,8 +181,8 @@ Scenario: Verify sections on the overview page are ticked
 
   When I click the 'shortlist criteria' link
   Then I am taken to the 'Shortlist criteria' page
-  And Summary row 'Essential skills and experience' should contain 'Write functional tests'
-  And Summary row 'Essential skills and experience' should contain 'Work with ruby'
+  And Summary row 'Technical competence: essential skills and experience' should contain 'Write functional tests'
+  And Summary row 'Technical competence: essential skills and experience' should contain 'Work with ruby'
   And Summary row 'How many specialists will be evaluated' should contain '5'
 
   When I click the 'Return to overview' link
@@ -237,7 +237,7 @@ Scenario: Complete all optional requirements questions
   Then I am taken to the 'Shortlist criteria' page
 
   When I click the 'Add nice-to-have skills and experience' link
-  Then I am taken to the 'Nice-to-have skills and experience' page
+  Then I am taken to the 'Technical competence: nice-to-have skills and experience' page
   When I enter 'Nice-to-have requirement' in the 'input-niceToHaveRequirements-1' field
   And I click the 'Save and continue' button
   Then I am taken to the 'Shortlist criteria' page

--- a/features/public/public_view_published_requirements.feature
+++ b/features/public/public_view_published_requirements.feature
@@ -22,10 +22,10 @@ Scenario: Public views the publish requirements. Details presented matches what 
 
     And Summary row 'Summary of the work' should contain 'Make a flappy bird clone except where the bird drives very safely'
 
-    And Summary row 'Essential skills and experience' should contain 'Can you do coding?'
-    And Summary row 'Essential skills and experience' should contain 'Can you do Python?'
-    And Summary row 'Nice-to-have skills and experience' should contain 'Do you like cats?'
-    And Summary row 'Nice-to-have skills and experience' should contain 'Is your cat named Eva?'
+    And Summary row 'Technical competence: essential skills and experience' should contain 'Can you do coding?'
+    And Summary row 'Technical competence: essential skills and experience' should contain 'Can you do Python?'
+    And Summary row 'Technical competence: nice-to-have skills and experience' should contain 'Do you like cats?'
+    And Summary row 'Technical competence: nice-to-have skills and experience' should contain 'Is your cat named Eva?'
 
     And Summary row 'Specialist role' should contain 'Developer'
     And Summary row 'Assessment methods' should contain 'Reference'


### PR DESCRIPTION
New `essentialRequirements` and `niceToHaveRequirements` questions
have been prepended with 'Technical competence: '.

Tested on preview.