### PR TITLE
Update tests to reflect new Technical Competence section

### DIFF
--- a/features/buyer/buyer_create_requirements.feature
+++ b/features/buyer/buyer_create_requirements.feature
@@ -20,7 +20,7 @@ Scenario: Start creating buyer requirements for an individual specialist
   And I click the 'Save and continue' button
   Then I am taken to the 'Find an individual specialist' requirements overview page
 
-  When I click the 'location' link
+  When I click the 'Location' link
   Then I am taken to the 'Where you want the specialist to work' page
 
   When I choose 'North East England' for 'location'
@@ -34,20 +34,20 @@ Scenario: Newly created buyer requirements should be listed on the buyer's dashb
 Scenario: Verify form values for information that has been provided so far
   Given I am on the 'Find an individual specialist' requirements overview page
 
-  When I click the 'location' link
+  When I click the 'Location' link
   Then I am taken to the 'Where you want the specialist to work' page
   And Form field 'location' should contain 'North East England'
 
   When I click the 'Return to overview' link
   Then I am taken to the 'Find an individual specialist' requirements overview page
 
-  When I click the 'title' link
+  When I click the 'Title' link
   Then I am taken to the 'What you want to call your requirements' page
   And Form field 'title' should contain 'Find an individual specialist'
 
 Scenario: Fill out requirement section question
   Given I am on the 'Find an individual specialist' requirements overview page
-  When I click the 'description of work' link
+  When I click the 'Description of work' link
   Then I am taken to the 'Description of work' page
   When I click the 'Add organisation' link
 
@@ -64,14 +64,14 @@ Scenario: "Ready to publish" button should not exist yet
 
 Scenario: Complete all mandatory buyer requirements questions
   Given I am on the 'Find an individual specialist' requirements overview page
-  When I click the 'specialist role' link
+  When I click the 'Specialist role' link
   Then I am taken to the 'Type of specialist you need' page
 
   When I choose 'Quality assurance analyst' for 'specialistRole'
   And I click 'Save and continue'
   Then I am taken to the 'Find an individual specialist' requirements overview page
 
-  When I click the 'description of work' link
+  When I click the 'Description of work' link
   Then I am taken to the 'Description of work' page
 
   When I click the 'Add responsibilities' link
@@ -113,59 +113,59 @@ Scenario: Complete all mandatory buyer requirements questions
   When I click the 'Return to overview' link
   Then I am taken to the 'Find an individual specialist' requirements overview page
 
-  When I click the 'shortlist criteria' link
-  Then I am taken to the 'Shortlist criteria' page
+  When I click the 'Shortlist and evaluation process' link
+  Then I am taken to the 'Shortlist and evaluation process' page
 
-  When I click the 'Add essential skills or experience' link
-  Then I am taken to the 'Technical competence: essential skills and experience' page
+  When I click the 'Set technical competence criteria' link
+  Then I am taken to the 'Technical competence criteria' page
   When I enter 'Write functional tests' in the 'input-essentialRequirements-1' field
   Then I enter 'Work with ruby' in the 'input-essentialRequirements-2' field
   And I click the 'Save and continue' button
-  Then I am taken to the 'Shortlist criteria' page
+  Then I am taken to the 'Shortlist and evaluation process' page
 
-  When I click the 'Set number of suppliers to evaluate' link
-  Then I am taken to the 'How many specialists will be evaluated' page
+  When I click the 'Set maximum number of specialists you’ll evaluate' link
+  Then I am taken to the 'Maximum number of specialists you’ll evaluate' page
   When I enter '5' in the 'numberOfSuppliers' field
   And I click the 'Save and continue' button
-  Then I am taken to the 'Shortlist criteria' page
+  Then I am taken to the 'Shortlist and evaluation process' page
 
-  When I click the 'Return to overview' link
-  Then I am taken to the 'Find an individual specialist' requirements overview page
+#  When I click the 'Return to overview' link
+#  Then I am taken to the 'Find an individual specialist' requirements overview page
+#
+#  When I click the 'Evaluation criteria' link
+#  Then I am taken to the 'Evaluation criteria' page
 
-  When I click the 'evaluation criteria' link
-  Then I am taken to the 'Evaluation criteria' page
-
-  When I click the 'Set weighting' link
+  When I click the 'Set evaluation weighting' link
   Then I am taken to the 'Weighting' page
   When I enter '75' in the 'technicalWeighting' field
   When I enter '5' in the 'culturalWeighting' field
   When I enter '20' in the 'priceWeighting' field
   And I click the 'Save and continue' button
-  Then I am taken to the 'Evaluation criteria' page
+  Then I am taken to the 'Shortlist and evaluation process' page
 
   When I click the 'Choose cultural fit criteria' link
   Then I am taken to the 'Cultural fit criteria' page
   When I enter 'Main cultural fit criteria' in the 'input-culturalFitCriteria-1' field
   When I enter 'Additional cultural fit criteria' in the 'input-culturalFitCriteria-2' field
   And I click the 'Save and continue' button
-  Then I am taken to the 'Evaluation criteria' page
+  Then I am taken to the 'Shortlist and evaluation process' page
 
   When I click the 'Edit' link for 'Assessment methods'
   Then I am taken to the 'How you’ll assess specialists' page
   When I choose 'Interview' for 'evaluationType'
   And I click the 'Save and continue' button
-  Then I am taken to the 'Evaluation criteria' page
+  Then I am taken to the 'Shortlist and evaluation process' page
 
   When I click the 'Return to overview' link
   Then I am taken to the 'Find an individual specialist' requirements overview page
 
 Scenario: Verify sections on the overview page are ticked
   Given I am on the 'Find an individual specialist' requirements overview page
-  Then 'title' section is marked as complete
-  Then 'specialist role' section is marked as complete
-  Then 'location' section is marked as complete
+  Then 'Title' section is marked as complete
+  Then 'Specialist role' section is marked as complete
+  Then 'Location' section is marked as complete
 
-  When I click the 'description of work' link
+  When I click the 'Description of work' link
   Then I am taken to the 'Description of work' page
   And Summary row 'Organisation the work is for' should contain 'GDS'
   And Summary row 'What the specialist will work on' should contain 'Specialist will work on the Digital Marketplace'
@@ -177,33 +177,26 @@ Scenario: Verify sections on the overview page are ticked
 
   When I click the 'Return to overview' link
   Then I am taken to the 'Find an individual specialist' requirements overview page
-  And 'description of work' section is marked as complete
+  And 'Description of work' section is marked as complete
 
-  When I click the 'shortlist criteria' link
-  Then I am taken to the 'Shortlist criteria' page
-  And Summary row 'Technical competence: essential skills and experience' should contain 'Write functional tests'
-  And Summary row 'Technical competence: essential skills and experience' should contain 'Work with ruby'
-  And Summary row 'How many specialists will be evaluated' should contain '5'
-
-  When I click the 'Return to overview' link
-  Then I am taken to the 'Find an individual specialist' requirements overview page
-  Then 'shortlist criteria' section is marked as complete
-
-  When I click the 'evaluation criteria' link
-  Then I am taken to the 'Evaluation criteria' page
-  And Summary row 'Weighting' should contain 'Technical competence 75% Cultural fit 5% Price 20%'
+  When I click the 'Shortlist and evaluation process' link
+  Then I am taken to the 'Shortlist and evaluation process' page
+  And Summary row 'Technical competence criteria' should contain 'Write functional tests'
+  And Summary row 'Technical competence criteria' should contain 'Work with ruby'
+  And Summary row 'Maximum number of specialists that will be evaluated' should contain '5'
+  And Summary row 'Evaluation weighting' should contain 'Technical competence 75% Cultural fit 5% Price 20%'
   And Summary row 'Cultural fit criteria' should contain 'Main cultural fit criteria'
   And Summary row 'Cultural fit criteria' should contain 'Additional cultural fit criteria'
   And Summary row 'Assessment methods' should contain 'Interview'
 
   When I click the 'Return to overview' link
   Then I am taken to the 'Find an individual specialist' requirements overview page
-  Then 'evaluation criteria' section is marked as complete
+  Then 'Shortlist and evaluation process' section is marked as complete
 
 Scenario: Complete all optional requirements questions
   Given I am on the 'Find an individual specialist' requirements overview page
 
-  When I click the 'description of work' link
+  When I click the 'Description of work' link
   Then I am taken to the 'Description of work' page
 
   When I click the 'Add security clearance' link
@@ -233,14 +226,14 @@ Scenario: Complete all optional requirements questions
   When I click the 'Return to overview' link
   Then I am taken to the 'Find an individual specialist' requirements overview page
 
-  When I click the 'shortlist criteria' link
-  Then I am taken to the 'Shortlist criteria' page
+  When I click the 'Shortlist and evaluation process' link
+  Then I am taken to the 'Shortlist and evaluation process' page
 
-  When I click the 'Add nice-to-have skills and experience' link
-  Then I am taken to the 'Technical competence: nice-to-have skills and experience' page
+  When I click the 'Edit' link for 'Technical competence criteria'
+  Then I am taken to the 'Technical competence criteria' page
   When I enter 'Nice-to-have requirement' in the 'input-niceToHaveRequirements-1' field
   And I click the 'Save and continue' button
-  Then I am taken to the 'Shortlist criteria' page
+  Then I am taken to the 'Shortlist and evaluation process' page
 
   When I click the 'Return to overview' link
   Then I am taken to the 'Find an individual specialist' requirements overview page
@@ -264,7 +257,7 @@ Scenario: Check the requirement is listed on the buyer dashboard
 Scenario: Edit Requirements title and verify the change made, on the summary page (Mandatory requirement)
   Given I am on the 'Find an individual specialist' requirements overview page
 
-  When I click the 'title' link
+  When I click the 'Title' link
   Then I am taken to the 'What you want to call your requirements' page
   When I change 'title' to 'Find an individual specialist-edited'
   And I click 'Save and continue'

--- a/features/public/public_view_published_requirements.feature
+++ b/features/public/public_view_published_requirements.feature
@@ -22,10 +22,10 @@ Scenario: Public views the publish requirements. Details presented matches what 
 
     And Summary row 'Summary of the work' should contain 'Make a flappy bird clone except where the bird drives very safely'
 
-    And Summary row 'Technical competence: essential skills and experience' should contain 'Can you do coding?'
-    And Summary row 'Technical competence: essential skills and experience' should contain 'Can you do Python?'
-    And Summary row 'Technical competence: nice-to-have skills and experience' should contain 'Do you like cats?'
-    And Summary row 'Technical competence: nice-to-have skills and experience' should contain 'Is your cat named Eva?'
+    And Summary row 'Essential skills and experience' should contain 'Can you do coding?'
+    And Summary row 'Essential skills and experience' should contain 'Can you do Python?'
+    And Summary row 'Nice-to-have skills and experience' should contain 'Do you like cats?'
+    And Summary row 'Nice-to-have skills and experience' should contain 'Is your cat named Eva?'
 
     And Summary row 'Specialist role' should contain 'Developer'
     And Summary row 'Assessment methods' should contain 'Reference'


### PR DESCRIPTION
The ordering of sections and questions for buyers writing a set of requirements has changed.
The changes here reflect the new flow, and also capitalisation of all links on the requirements overview page.

I have run these against current preview and all tests pass EXCEPT the checking that all sections are ticked, which fails because of a genuine application bug that is currently being fixed.

![screen shot 2016-06-13 at 10 54 19](https://cloud.githubusercontent.com/assets/6525554/16003808/78212b1c-3156-11e6-9de9-7381f38fb084.png)
