### PR TITLE
Add a check for Q&A session being ticked once complete

### DIFF
--- a/features/buyer/buyer_create_requirements.feature
+++ b/features/buyer/buyer_create_requirements.feature
@@ -249,6 +249,7 @@ Scenario: Complete all optional requirements questions
 
   When I click the 'Return to overview' link
   Then I am taken to the 'Find an individual specialist' requirements overview page
+  And 'Describe question and answer session' section is marked as complete
 
 Scenario: Check the requirement is listed on the buyer dashboard
   Given I navigate directly to the page '/buyers'


### PR DESCRIPTION
New logic ticks this if Q&A session details are added, so nice to have a test for it.

Step passes OK against preview:
![screen shot 2016-06-13 at 13 13 52](https://cloud.githubusercontent.com/assets/6525554/16007162/c3beae7a-3168-11e6-8837-2a2853b60b2e.png)
