### PR TITLE
Added requirement to use rbenv to manage ruby versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,12 @@ Technology wise it is a Ruby project using:
 ## Bootstraping the project on Mac
 
 This installation assumes you're using [Homebrew](http://brew.sh/) and Ruby
-installed by Homebrew. We have seen problems installing Nokogiri with native
-Mac Ruby. Nokogiri can also cause problems if you have an old version of
-XCode. Upgrading to version 6.1.0 from 5.x has been known to resolve the issue.
-`brew doctor` will warn if your version of XCode is sufficiently out of date.
+installed by Homebrew. We expect you to have [rbenv](https://github.com/rbenv/rbenv) 
+installed and expect you to be using that to manage your Ruby versions. We have seen 
+problems installing Nokogiri with native Mac Ruby. Nokogiri can also cause problems 
+if you have an old version of XCode. Upgrading to version 6.1.0 from 5.x has been 
+known to resolve the issue. `brew doctor` will warn if your version of XCode is 
+sufficiently out of date.
 
 ```bash
 gem install bundler


### PR DESCRIPTION
Requirement added as a solution to Nokogiri installation issues that were run into when installing on Yosemite. Rbenv was needed to be installed before bundler was installed otherwise the native version of Ruby would be used for bundler rather than the rbenv version.