### PR TITLE
Fixed supplier creation test caused by updating heading links

### DIFF
--- a/features/supplier/supplier_creation.feature
+++ b/features/supplier/supplier_creation.feature
@@ -3,7 +3,7 @@ Feature: Create new G-Cloud supplier account
 
 Scenario: User steps through supplier account creation process
   Given I am on the 'Digital Marketplace' landing page
-  When I click 'Create supplier account'
+  When I click 'Create a supplier account'
   Then I am on the 'Create supplier account' page
 
   When I click the 'Start' button


### PR DESCRIPTION
Due to the removal of the 'Create supplier account' link in the heading this test was failing. We have fixed it by changing the link used by this test to start the supplier creation journey using the 'Create a supplier account' link.

[Pull request in buyer app that caused this] (https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/342)