### PR TITLE
Revise tests for "Update links in header" story

### DIFF
--- a/features/buyer/buyer_create_requirements.feature
+++ b/features/buyer/buyer_create_requirements.feature
@@ -28,7 +28,9 @@ Scenario: Start creating buyer requirements for an individual specialist
   Then I am taken to the 'Find an individual specialist' requirements overview page
 
 Scenario: Newly created buyer requirements should be listed on the buyer's dashboard
-  Given I navigate directly to the page '/buyers'
+  Given I am on the 'Digital Marketplace' landing page
+  When I click the 'View your account' link
+  Then I am presented with the 'DM Functional Test Buyer User 1' 'Buyer' dashboard page
   Then The buyer requirements for 'Find an individual specialist' 'is' listed on the buyer's dashboard
 
 Scenario: Verify form values for information that has been provided so far
@@ -252,7 +254,9 @@ Scenario: Complete all optional requirements questions
   And 'Describe question and answer session' section is marked as complete
 
 Scenario: Check the requirement is listed on the buyer dashboard
-  Given I navigate directly to the page '/buyers'
+  Given I am on the 'Digital Marketplace' landing page
+  When I click the 'View your account' link
+  Then I am presented with the 'DM Functional Test Buyer User 1' 'Buyer' dashboard page
   Then The buyer requirements for 'Find an individual specialist' 'is' listed on the buyer's dashboard
 
 Scenario: Edit Requirements title and verify the change made, on the summary page (Mandatory requirement)

--- a/features/buyer/buyer_creation.feature
+++ b/features/buyer/buyer_creation.feature
@@ -1,9 +1,17 @@
-@not-production @functional-test
-Feature: Create buyer account. WIP-The flow to get to the creation page is as yet not nailed down. This test starts directly on the buyer creation page itself rather than navigating to it as a user would on the frontend app
+@not-production @functional-test @buyer-creation
+Feature: Create buyer account. We're assuming a user journey where someone tries to find a specialist, eventually hits the login page, and then clicks 'Create a buyer account' from the login page
 
 Scenario: User steps through buyer account creation process
-  Given I navigate directly to the page '/buyers/create'
-  When I am on the 'Create a buyer account' page
+  Given I am on the 'Digital Marketplace' landing page
+  When I click the 'Find an individual specialist' link
+  Then I am taken to the buyers 'Find an individual specialist' page
+
+  When I click the 'Create requirement' button
+  Then I am taken to the 'Log in to the Digital Marketplace' page
+
+  When I click the 'Create a buyer account' link
+  Then I am on the 'Create a buyer account' page
+
   And I enter 'test.buyer.email@test.gov.uk' in the 'email_address' field
   And I click 'Create account'
   Then I am taken to the 'Activate your account' page

--- a/features/step_definitions/journey_test_steps.rb
+++ b/features/step_definitions/journey_test_steps.rb
@@ -1823,10 +1823,6 @@ And /There is no agreement available on the page$/ do
   page.should have_no_selector(:xpath, "//tbody/tr[@class='summary-item-row']/*/span[contains(text(), 'G-Cloud 7 countersigned agreement')]")
 end
 
-Given /^I navigate directly to the page '(.*)'$/ do |url|
-  page.visit("#{dm_frontend_domain}#{url}")
-end
-
 Then /I am on the '(.*)' page$/ do |page_name|
   if page_name == 'Create supplier account'
     page.should have_content("#{page_name}")


### PR DESCRIPTION
The functional tests for logged-in buyers were previously navigating directly to (a) the buyer dashboard and (b) the create buyer account page.  At the point these tests were written, there was probably no other way to visit these pages, but now that there are real user flows the tests can now reflect this.

Was able to remove the `I navigate directly to the page '(.*)'` step completely after revising the above-mentioned tests. 😄 😄 😄 

Needs the following PRs to go in before this can be merged:

- [ ]  https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/494
- [x] https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/343