### PR TITLE
Add requirements length to specialist briefs

### DIFF
--- a/features/buyer/buyer_create_requirements.feature
+++ b/features/buyer/buyer_create_requirements.feature
@@ -161,6 +161,13 @@ Scenario: Complete all mandatory buyer requirements questions
   When I click the 'Return to overview' link
   Then I am taken to the 'Find an individual specialist' requirements overview page
 
+  When I click the 'Set how long your requirements will be live for' link
+  Then I am taken to the 'Set how long your requirements will be live for' page
+
+  When I choose '2 weeks' for 'requirementsLength'
+  And I click 'Save and continue'
+  Then I am taken to the 'Find an individual specialist' requirements overview page
+
 Scenario: Verify sections on the overview page are ticked
   Given I am on the 'Find an individual specialist' requirements overview page
   Then 'Title' section is marked as complete

--- a/features/step_definitions/setup_steps.rb
+++ b/features/step_definitions/setup_steps.rb
@@ -264,6 +264,7 @@ def create_and_return_buyer_brief (brief_name, framework_slug, lot, user_id)
     "userId" => user_id,
     "workingArrangements" => "Working from home",
     "workplaceAddress" => "Aviation House",
+    "requirementsLength" => "2 weeks"
   })
   brief_data["updated_by"] = "functional tests"
 


### PR DESCRIPTION
Part of [this](https://www.pivotaltracker.com/story/show/123706751) story on Pivotal.

The new required question for specialist briefs requires a couple of
small changes to the specialists briefs. One to the fixture that creates
the brief, and one to the feature test that answers brief questions to
create a brief.

Tests run locally against preview.
-----------------
<img width="1440" alt="screen shot 2016-07-29 at 15 54 42" src="https://cloud.githubusercontent.com/assets/13836290/17252513/e3e93476-55a4-11e6-9fb1-93b5bb31f3c5.png">