### PR TITLE
Fix for withdrawn briefs

### DIFF
--- a/features/step_definitions/setup_steps.rb
+++ b/features/step_definitions/setup_steps.rb
@@ -292,7 +292,7 @@ def delete_all_draft_briefs (user_id)
     brief_id = brief["id"]
     updated_by = {updated_by: "Functional tests"}
 
-    unless ["live", "closed"].include? brief["status"]
+    unless ["live", "closed", "withdrawn"].include? brief["status"]
       puts "deleting draft: #{brief_id}"
       response = call_api(:delete, "/briefs/#{brief_id}", payload: updated_by)
       response.code.should be(200), response.body

--- a/scripts/test_dependencies.sh
+++ b/scripts/test_dependencies.sh
@@ -31,7 +31,7 @@ test_framework_status "g-cloud-4" "expired"
 test_framework_status "g-cloud-5" "expired"
 test_framework_status "g-cloud-6" "live"
 test_framework_status "g-cloud-7" "live"
-test_framework_status "g-cloud-8" "pending"
+test_framework_status "g-cloud-8" "live"
 test_framework_status "digital-outcomes-and-specialists" "live"
 
 echo -e "\033[0;32mAll frameworks have the correct status\033[0m"


### PR DESCRIPTION
Tests are failing because they can't delete a withdrawn brief on preview.

This fixes tests by not attempting to delete withdrawn briefs.
:sparkles: :sparkles: :sparkles: :sparkles: :sparkles: :sparkles: :sparkles: :sparkles: 
![screen shot 2016-08-04 at 15 51 53](https://cloud.githubusercontent.com/assets/6525554/17406493/7c195c98-5a5b-11e6-892d-5b07fae1f33d.png)
:sparkles: :sparkles: :sparkles: :sparkles: :sparkles: :sparkles: :sparkles: :sparkles: 