### PR TITLE
Find live g-cloud frameworks when requesting a random service

### DIFF
--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -20,7 +20,14 @@ Given /^I am on the (.* )?(\/.*) page$/ do |app, url|
 end
 
 Given /^I have a random g-cloud service from the API$/ do
-  params = {status: "published", framework: "g-cloud-6,g-cloud7"}
+  frameworks = call_api(:get, "/frameworks")
+  live_g_cloud = JSON.parse(frameworks.body)["frameworks"].select {|framework|
+    framework["framework"] == "g-cloud" && framework["status"] == "live"
+  }.map {|framework| framework["slug"]}.join(",")
+
+  puts "Live g-cloud frameworks: #{live_g_cloud}"
+
+  params = {status: "published", framework: live_g_cloud}
   page_one = call_api(:get, "/services", params: params)
   last_page_url = JSON.parse(page_one.body)['links']['last']
   params[:page] = if last_page_url then


### PR DESCRIPTION
There's no way to get only live G-Cloud services from the API endpoint, since the filtering is based on framework.slug, not framework.framework.

So in order to select a live G-Cloud service we need to find out which G-Cloud iterations are live on the given environment.