### PR TITLE
Add an option to quote the value in MAYBE_VAR

### DIFF
--- a/features/buyer/catalogue.feature
+++ b/features/buyer/catalogue.feature
@@ -50,10 +50,10 @@ Scenario: User is able to search by service id and have result returned.
 Scenario: User is able to search by service name and have result returned.
   Given I am on the /g-cloud page
   And I have a random g-cloud service from the API
-  When I enter that service.serviceName in the 'q' field
+  When I enter that quoted service.serviceName in the 'q' field
   And I click 'Show services'
-  Then I see that service.serviceName in the search summary text
-  And I see that service.serviceName as the value of the 'q' field
+  Then I see that quoted service.serviceName in the search summary text
+  And I see that quoted service.serviceName as the value of the 'q' field
   And I see that service in the search results
 
 Scenario: User is able to navigate to service detail page via selecting the service from the search results

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -125,7 +125,6 @@ When /^I enter #{MAYBE_VAR} in the '(.*)' field( and click its associated '(.*)'
     form_element = field_element.find(:xpath, "ancestor::form")
     form_element.click_button(click_button_name)
   end
-  sleep 1
 end
 
 When(/^I choose a random uppercase letter$/) do

--- a/features/support/transforms.rb
+++ b/features/support/transforms.rb
@@ -1,23 +1,26 @@
 # Captures a literal value or a variable reference that gets resolved by a
 # transform step into a value before being passed to the step definition
-MAYBE_VAR = '((?:the )?(?:\'(?:.*)\')|(?:that (?:\w+)(?:(?:\.\w+)*)))'
+
+MAYBE_VAR_RE = '((?:the )?(?:\'(?<value>.*)\')|(?:that (?<quoted>quoted )?(?<variable>\w+)(?<attributes>(?:\.\w+)*)))'
+MAYBE_VAR = MAYBE_VAR_RE.gsub(/<[a-z]+>/, ':')
 
 Transform /^#{MAYBE_VAR}$/ do |whole_match|
   # to access the inner regex groups we have to perform the regex again with the groups captured. from what i can tell
   # Transforms don't work very well with multiple arguments, so we implement the transform itself as a single-argument
   # Transform and suck out the innards ourselves in this secondary regex matching...
-  match = /^#{MAYBE_VAR.gsub("(?:", "(")}$/.match whole_match
-  if match[4] # literal string
-    match[4]
+  match = /^#{MAYBE_VAR_RE}$/.match whole_match
+  if match[:value] # literal string
+    match[:value]
   else
     # get base variable name
-    term = instance_variable_get("@#{match[6]}")
+    term = instance_variable_get("@#{match[:variable]}")
     # now iterate along the chain of hash keys (if any)
-    (match[7]||'').split('.').each do |key|
+    (match[:attributes]||'').split('.').each do |key|
       unless key.empty?
         term = term[key]
       end
     end
+    term = "\"#{term}\"" if match[:quoted]
     term
   end
 end


### PR DESCRIPTION
When searching for service names we need to enter the value in quotes
since individual words can match multiple services. Also special characters
like "&" and ":" are treated as separate terms that don't match anything
since the original field is analyzed by Elasticsearch. Quoting special
characters with other parts of the query solves the issue.

Adding an optional "quoted" match to the MAYBE_VAR allows us to
return a quoted value. This also changes MAYBE_VAR regexp to use
named groups since the transform only cares about certain matches.

Another approach we've considered was adding a separate step for
quoting a stored value:

    And I have a random g-cloud service from the API
    And I wrap that service.serviceName with quotes
    When I enter that service.serviceName in the 'q' field

The problem with this approach is that MAYBE_VAR transform doesn't
return the name of the instance variable or the attributed, only
the value, so the step can't replace the attributed value with a
quoted one. We could return a custom object that contains that
information from the transform, but the current approach seems
simpler.

### Remove `sleep 1` after button click
We should wait for pages to load based on content, not time delays, so following the page transition step with a "I am on a page" step shouldn't require any waiting.