### PR TITLE
Reverse result count check to get a more useful error message

### DIFF
--- a/features/step_definitions/opportunities_steps.rb
+++ b/features/step_definitions/opportunities_steps.rb
@@ -37,7 +37,7 @@ end
 
 Then (/^I see that the stated number of results does not exceed that (\w+)$/) do |variable_name|
   var = instance_variable_get("@#{variable_name}")
-  var.should >= page.first(:css, ".search-summary-count").text.to_i
+  page.first(:css, ".search-summary-count").text.to_i.should <= var
 end
 
 Then (/^I see that the stated number of results equals that (\w+)$/) do |variable_name|


### PR DESCRIPTION
Calling `.should` on the expected value returns a confusing error
message:

    expected: >= 120
        got:    119 (RSpec::Expectations::ExpectationNotMetError)