### PR TITLE
Fix "supplier name changed" test to match new redirect location

### DIFF
--- a/features/step_definitions/journey_test_steps.rb
+++ b/features/step_definitions/journey_test_steps.rb
@@ -1709,7 +1709,7 @@ end
 Then /I am presented with the '(.*)' page with the changed supplier name '(.*)' listed on the page$/ do |page_name,supplier_name|
   page.should have_content("#{page_name}")
   page.should have_link('Log out')
-  current_url.should end_with("#{dm_frontend_domain}/admin/#{page_name.downcase}?supplier_name_prefix=#{supplier_name.split('M Functional Test Supplier').first}")
+  current_url.should end_with("#{dm_frontend_domain}/admin/#{page_name.downcase}?supplier_id=#{@supplierID}")
   page.should have_selector(:xpath, "//table/tbody/tr/td/span[contains(text(),'#{supplier_name}')]")
 end
 


### PR DESCRIPTION
Change reflects recent admin frontend redirect change.

Tested against preview and runs green:
![screen shot 2016-10-28 at 12 17 48](https://cloud.githubusercontent.com/assets/6525554/19806676/52f1edde-9d14-11e6-88dd-bf0354ae1d46.png)
