### PR TITLE
Remove steps that rely on unsetting framework agreements

### DIFF
--- a/features/admin/admin_journey.feature
+++ b/features/admin/admin_journey.feature
@@ -8,8 +8,6 @@ Scenario: Setup for tests
   And Test supplier users are active
   And Test supplier users are not locked
   And The user 'DM Functional Test Supplier User 3' is locked
-  And no 'g-cloud-7' framework agreements exist
-  And no 'digital-outcomes-and-specialists' framework agreements exist
 
 Scenario: As an admin user I wish be able to log in and to log out of Digital Marketplace
   Given I am on the 'Administrator' login page
@@ -216,11 +214,6 @@ Scenario: As an admin user I want to change the supplier name of a current suppl
   When I change 'input-new_supplier_name' to 'DM Functional Test Supplier 2 name changed'
   And I click 'Save'
   Then I am presented with the 'Suppliers' page with the changed supplier name 'DM Functional Test Supplier 2 name changed' listed on the page
-
-Scenario: When there are no framework agreements the list is empty: G-Cloud 7
-  Given I have logged in to Digital Marketplace as a 'Administrator' user
-  And I click 'G-Cloud 7 agreements'
-  Then the framework agreement list is empty
 
 Scenario: Most recently uploaded agreements should be shown last: Digital Outcomes and Specialists
   Given I have logged in to Digital Marketplace as a 'Administrator' user

--- a/features/admin/admin_journey.feature
+++ b/features/admin/admin_journey.feature
@@ -221,8 +221,6 @@ Scenario: Most recently uploaded agreements should be shown last: Digital Outcom
   And a 'digital-outcomes-and-specialists' signed agreement is uploaded for supplier '11112'
   When I click 'Digital Outcomes and Specialists agreements'
   Then the last signed agreement should be for supplier 'DM Functional Test Supplier 2 name changed'
-  When I click the last download agreement link
-  Then I should get redirected to the correct 'digital-outcomes-and-specialists' S3 URL for supplier '11112'
 
 Scenario: Re-uploading an agreement brings it to the bottom of the list: G-Cloud 7
   Given I have logged in to Digital Marketplace as a 'Administrator' user
@@ -231,8 +229,6 @@ Scenario: Re-uploading an agreement brings it to the bottom of the list: G-Cloud
   And a 'g-cloud-7' signed agreement is uploaded for supplier '11111'
   When I click 'G-Cloud 7 agreements'
   Then the last signed agreement should be for supplier 'DM Functional Test Supplier'
-  When I click the last download agreement link
-  Then I should get redirected to the correct 'g-cloud-7' S3 URL for supplier '11111'
 
 Scenario: As an admin user I want to upload Digital Outcomes and Specialists communications
   Given I have logged in to Digital Marketplace as a 'Administrator' user

--- a/features/admin/ccs_sourcing_admin_journey.feature
+++ b/features/admin/ccs_sourcing_admin_journey.feature
@@ -63,8 +63,6 @@ Scenario: Most recently uploaded agreements should be shown last: G-Cloud 7
   And a 'g-cloud-7' signed agreement is uploaded for supplier '11112'
   When I click 'G-Cloud 7 agreements'
   Then the last signed agreement should be for supplier 'DM Functional Test Supplier 2'
-  When I click the last download agreement link
-  Then I should get redirected to the correct 'g-cloud-7' S3 URL for supplier '11112'
 
 Scenario: Re-uploading an agreement brings it to the bottom of the list: Digital Outcomes and Specialists
   Given I have logged in to Digital Marketplace as a 'CCS Sourcing' user
@@ -73,8 +71,6 @@ Scenario: Re-uploading an agreement brings it to the bottom of the list: Digital
   And a 'digital-outcomes-and-specialists' signed agreement is uploaded for supplier '11111'
   When I click 'Digital Outcomes and Specialists agreements'
   Then the last signed agreement should be for supplier 'DM Functional Test Supplier'
-  When I click the last download agreement link
-  Then I should get redirected to the correct 'digital-outcomes-and-specialists' S3 URL for supplier '11111'
 
 Scenario: CCS Sourcing should not have access to Administrator specific pages
   Given I have logged in to Digital Marketplace as a 'CCS Sourcing' user

--- a/features/admin/ccs_sourcing_admin_journey.feature
+++ b/features/admin/ccs_sourcing_admin_journey.feature
@@ -4,7 +4,6 @@ Feature: CCS admin user journey through Digital Marketplace
 Scenario: Setup for tests
   Given I have test suppliers
   And The test suppliers have declarations
-  And no 'digital-outcomes-and-specialists' framework agreements exist
 
 Scenario: As a CCS Sourcing user, I wish to search for supplier(s) by supplier name prefix
   Given I have logged in to Digital Marketplace as a 'CCS Sourcing' user
@@ -57,11 +56,6 @@ Scenario: As a CCS Sourcing user I want to view G-Cloud 8 statistics
   Given I have logged in to Digital Marketplace as a 'CCS Sourcing' user
   When I click 'G-Cloud 8 statistics'
   Then I am presented with the 'G-Cloud 8' statistics page
-
-Scenario: When there are no framework agreements the list is empty: Digital Outcomes and Specialists
-  Given I have logged in to Digital Marketplace as a 'CCS Sourcing' user
-  And I click 'Digital Outcomes and Specialists agreements'
-  Then the framework agreement list is empty
 
 Scenario: Most recently uploaded agreements should be shown last: G-Cloud 7
   Given I have logged in to Digital Marketplace as a 'CCS Sourcing' user

--- a/features/step_definitions/journey_test_steps.rb
+++ b/features/step_definitions/journey_test_steps.rb
@@ -1743,11 +1743,6 @@ When /^I click the last download agreement link$/ do
   @response = RestClient.get(url, headers){|response, request, result| response}
 end
 
-Then /^I should get redirected to the correct '(.+)' S3 URL for supplier '(\d+)'$/ do |framework_slug, supplier_id|
-  @response.code.should == 302
-  @response.headers[:location].should match(%r"/#{framework_slug}/agreements/#{supplier_id}/.*signed-framework-agreement.pdf")
-end
-
 Then /^I am presented with the \/"(.*?)" page\/$/ do |page_name|
   current_url.should end_with("#{dm_frontend_domain}/reset-password")
   page.should have_content(page_name)

--- a/features/step_definitions/journey_test_steps.rb
+++ b/features/step_definitions/journey_test_steps.rb
@@ -1721,22 +1721,15 @@ Then /^there is no '(.*)' link for any supplier$/ do |link_text|
   end
 end
 
-Given /^no '(.*)' framework agreements exist$/ do |framework_slug|
-  ensure_no_framework_agreements_exist(framework_slug)
-end
-
 Given /^a '(.*)' signed agreement is uploaded for supplier '(\d+)'$/ do |framework_slug, supplier_id|
   original_framework_status = update_framework_status(framework_slug, "open")
   register_interest_in_framework(framework_slug, supplier_id)
   submit_supplier_declaration(framework_slug, supplier_id, {
     "status" => "complete", "SQ1-1a" => "company name"
   })
-  update_framework_agreement_status(framework_slug, supplier_id, true)
   update_framework_status(framework_slug, original_framework_status)
-end
-
-Then /^the framework agreement list is empty$/ do
-  page.all(:css, ".summary-item-row").length.should == 0
+  update_supplier_on_framework(framework_slug, supplier_id, true)
+  create_and_sign_framework_agreement(framework_slug, supplier_id)
 end
 
 Then /^the last signed agreement should be for supplier '(.*)'$/ do |supplier_name|


### PR DESCRIPTION
Now we're using the new FrameworkAgreement routes we have no way to unset a framework agreement as having been returned, and agreements can no longer be set with a single API call.

This pull request: 
 1. Removes the steps that attempt to unset framework agreements and test the "empty list" of agreements as this is no longer possible. 

 2. Updates the setting of framework agreements to use the new API routes, replacing the old `update_framework_agreement_status` API call with `create_and_sign_framework_agreement` that performs the three API calls now needed to return a signed agreement.

 3. Removes steps that check the existence of agreement files in S3 - the tests don't upload any files, so they shouldn't be testing that they can download one.  These tests previously worked because of the standard S3 file path we used to have for agreement files, and the (coincidental) existence of these files in S3 for the preview test supplier accounts.
