### PR TITLE
Remove paragraph tags from brief response questions

### DIFF
--- a/features/step_definitions/journey_test_steps.rb
+++ b/features/step_definitions/journey_test_steps.rb
@@ -1893,7 +1893,7 @@ And /^I see the correct title and requirements for the opportunity$/ do
 
   page.find('h1').should have_content("#{brief_title}")
   brief_requirements.each_with_index do |brief_requirement, index|
-    page.all('span.question-heading p')[index].should have_content("#{brief_requirement}")
+    page.all('span.question-heading')[index].should have_content("#{brief_requirement}")
   end
 end
 


### PR DESCRIPTION
Since new questions aren't being processed with markdown there's no paragraph tag inside a span.