### PR TITLE
Fix brief response requirements check

### DIFF
--- a/features/step_definitions/journey_test_steps.rb
+++ b/features/step_definitions/journey_test_steps.rb
@@ -1893,7 +1893,7 @@ And /^I see the correct title and requirements for the opportunity$/ do
 
   page.find('h1').should have_content("#{brief_title}")
   brief_requirements.each_with_index do |brief_requirement, index|
-    page.all('span.question-heading')[index].should have_content("#{brief_requirement}")
+    page.all('legend span.question-heading')[index].should have_content("#{brief_requirement}")
   end
 end
 


### PR DESCRIPTION
Without a paragraph tag requirements selector matches both
individual requirements and "Do you have the essential skills and
experience?" section titles, which breaks the index-based iteration.

Making the selector more specific should fix the issue.