### PR TITLE
Rerun and random failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,9 @@ smoke-tests: setup
 run: setup
 	. config/${DM_ENVIRONMENT}.sh && bundle exec cucumber ${ARGS}
 
+rerun:
+	. config/${DM_ENVIRONMENT}.sh && bundle exec cucumber -p rerun
+
 setup: install clean
 	@echo "Environment:" ${DM_ENVIRONMENT}
 	mkdir -p reports/
@@ -19,4 +22,4 @@ config/local.sh:
 clean:
 	rm -rf reports/
 
-.PHONY: smoke-tests run setup install clean
+.PHONY: smoke-tests run rerun setup install clean

--- a/config/cucumber.yml
+++ b/config/cucumber.yml
@@ -1,1 +1,2 @@
-default: --format html --out reports/index.html --format pretty features/apps_status.feature features
+default: --format html --out reports/index.html --format rerun --out reports/rerun --format pretty features/apps_status.feature features
+rerun: --format html --out reports/rerun.html --format pretty @reports/rerun

--- a/features/step_definitions/catalogue_steps.rb
+++ b/features/step_definitions/catalogue_steps.rb
@@ -6,10 +6,10 @@ When(/^I click a random result in the list of service results returned$/) do
 
   a_elem = selected_result.first(:xpath, ".//h2[@class='search-result-title']/a")
   @result['title'] = a_elem.text
-  puts "Result name: #{@result['title']}"
+  puts "Result name: #{ERB::Util.h @result['title']}"
 
   @result['supplier_name'] = selected_result.first(:xpath, ".//*[@class='search-result-supplier']").text
-  puts "Result supplier_name: #{@result['supplier_name']}"
+  puts "Result supplier_name: #{ERB::Util.h @result['supplier_name']}"
 
   a_elem.click
 end

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -29,6 +29,7 @@ Given /^I have a random g-cloud service from the API$/ do
 
   params = {status: "published", framework: live_g_cloud}
   page_one = call_api(:get, "/services", params: params)
+  page_one.code.should == 200
   last_page_url = JSON.parse(page_one.body)['links']['last']
   params[:page] = if last_page_url then
                     1 + rand(CGI.parse(URI.parse(last_page_url).query)['page'][0].to_i)
@@ -36,6 +37,7 @@ Given /^I have a random g-cloud service from the API$/ do
                     1
                   end
   random_page = call_api(:get, "/services", params: params)
+  random_page.code.should == 200
   services = JSON.parse(random_page.body)['services']
   @service = services[rand(services.length)]
   puts "Service ID: #{@service['id']}"

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -41,7 +41,7 @@ Given /^I have a random g-cloud service from the API$/ do
   services = JSON.parse(random_page.body)['services']
   @service = services[rand(services.length)]
   puts "Service ID: #{@service['id']}"
-  puts "Service name: #{@service['serviceName']}"
+  puts "Service name: #{ERB::Util.h @service['serviceName']}"
 end
 
 # TODO merge with above step
@@ -61,7 +61,7 @@ Given /^I have a random (?:([a-z-]+) )?supplier from the API$/ do |metaframework
   suppliers = JSON.parse(random_page.body)['suppliers']
   @supplier = suppliers[rand(suppliers.length)]
   puts "Supplier ID: #{@supplier['id']}"
-  puts "Supplier name: #{@supplier['name']}"
+  puts "Supplier name: #{ERB::Util.h @supplier['name']}"
 end
 
 # TODO merge with above step
@@ -85,7 +85,7 @@ Given /^I have a random dos brief from the API$/ do
   }[@brief['status']]
 
   puts "Brief ID: #{@brief['id']}"
-  puts "Brief name: #{@brief['title']}"
+  puts "Brief name: #{ERB::Util.h @brief['title']}"
 end
 
 When /I click #{MAYBE_VAR} ?(button|link)?$/ do |button_link_name, elem_type|

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -145,7 +145,7 @@ Then /^I see the '(.*)' link$/ do |link_text|
 end
 
 Then /^I am on #{MAYBE_VAR} page$/ do |page_name|
-  find('h1').text.should == normalize_whitespace(page_name)
+  page.should have_selector('h1', text: normalize_whitespace(page_name))
 end
 
 Then /^I see #{MAYBE_VAR} in the page's h1$/ do |page_name_fragment|

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,3 +1,4 @@
+require 'erb'
 require 'rspec'
 require 'nokogiri'
 require 'capybara/cucumber'


### PR DESCRIPTION
### Check API status code before parsing the response
Gives a more useful error message than 'JSON must have at least two octets'.

### Store failed cucumber scenarios and add a make step to rerun them
Adding an additional output to the default cucumber profile allows us to store the failed scenario names and to rerun them using `make rerun` step. Rerun will overwrite the failed scenarios file, so it can be run repeatedly to only execute scenarios that keep failing.

### Replace generic h1 find with have_selector with text filter
`find('h1')` causes a race condition since it can succeed on any page without waiting for the new response to be displayed. Rewriting it with have_selector and `text:` filter should force Capybara to wait until an h1 element with the correct text is present on the page.

### Escape HTML when printing messages with user input
Cucumber HTML formatter doesn't escape HTML tags in printed messages, so if there are any (and there are since we've created quite a few when testing the apps for XSS) in the random brief/service titles they get injected into the report page.

I've made a PR to the cucumber-ruby, but for now I'm adding the manual escaping. This affects the CLI output, since it will go through the same escaping as well.