### PR TITLE
Skip suppliers without DUNS number

### DIFF
--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -58,7 +58,11 @@ Given /^I have a random (?:([a-z-]+) )?supplier from the API$/ do |metaframework
                     1
                   end
   random_page = call_api(:get, "/suppliers", params: params)
-  suppliers = JSON.parse(random_page.body)['suppliers']
+  # Remove suppliers without a DUNS number - these are old imported accounts
+  # and it's easier to skip them than to handle the empty DUNS search case
+  suppliers = JSON.parse(random_page.body)['suppliers'].select { |supplier|
+    supplier['dunsNumber']
+  }
   @supplier = suppliers[rand(suppliers.length)]
   puts "Supplier ID: #{@supplier['id']}"
   puts "Supplier name: #{ERB::Util.h @supplier['name']}"


### PR DESCRIPTION
Some of the suppliers in the preview, staging and production DBs were imported from the old database and don't have a DUNS number.

When tests select a supplier without a DUNS number and run the admin scenario with DUNS search the scenario fails since search returns >100 results. There's no reason for us to handle this case (since it's essentially searching for an empty string), so it seems that the simplest solution is to remove these suppliers from the random pool.