### PR TITLE
Fix test as content has changed from 'Region' to 'Location'

### DIFF
--- a/features/public/public_view_published_requirements.feature
+++ b/features/public/public_view_published_requirements.feature
@@ -18,7 +18,7 @@ Scenario: Public views the publish requirements. Details presented matches what 
     And Summary row 'Organisation the work is for' should contain 'Driver and Vehicle Licensing Agency'
     And Summary row 'What the specialist will work on' should contain 'Work on the Digital Marketplace'
     And Summary row 'Who the specialist will work with' should contain 'Digital Marketplace team'
-    And Summary row 'Region' should contain 'Scotland'
+    And Summary row 'Location' should contain 'Scotland'
 
     And Summary row 'Summary of the work' should contain 'Make a flappy bird clone except where the bird drives very safely'
 


### PR DESCRIPTION
Test that was broken:
![image](https://cloud.githubusercontent.com/assets/7228605/20836455/49687a78-b897-11e6-9ab7-3fba153c5aef.png)
![image](https://cloud.githubusercontent.com/assets/7228605/20836579/ec80f19a-b897-11e6-8523-89d146711538.png)


It was broken due to content changes in the frameworks repo:
https://github.com/alphagov/digitalmarketplace-frameworks/pull/340