### PR TITLE
Extra scenarios for new supplier flow

### DIFF
--- a/features/step_definitions/brief_response_steps.rb
+++ b/features/step_definitions/brief_response_steps.rb
@@ -44,3 +44,8 @@ end
 Given 'that supplier has a completed brief-response' do
   @brief_response = create_brief_response(@service['lotSlug'], @brief_id, @supplier['id'])
 end
+
+Then /^I visit the '(.*)' question page for that brief response$/ do |question|
+  url = "/suppliers/opportunities/#{@brief_id}/responses/#{@brief_response}/#{question}"
+  step "I am on the #{url} page"
+end

--- a/features/step_definitions/brief_response_steps.rb
+++ b/features/step_definitions/brief_response_steps.rb
@@ -41,7 +41,7 @@ Given 'that supplier user is logged in' do
   }
 end
 
-Given 'that supplier has a completed brief response' do
+Given 'that supplier has filled in their application but not submitted it' do
   @brief_response = create_brief_response(@service['lotSlug'], @brief_id, @supplier['id'])
 end
 

--- a/features/step_definitions/brief_response_steps.rb
+++ b/features/step_definitions/brief_response_steps.rb
@@ -41,6 +41,6 @@ Given 'that supplier user is logged in' do
   }
 end
 
-Then /^I see '(.*)' replayed in the question advice$/ do |replayed_info|
-  page.should have_xpath("//span[@class='question-advice']/p", text: replayed_info)
+Given 'that supplier has a completed brief-response' do
+  @brief_response = create_brief_response(@service['lotSlug'], @brief_id, @supplier['id'])
 end

--- a/features/step_definitions/brief_response_steps.rb
+++ b/features/step_definitions/brief_response_steps.rb
@@ -49,3 +49,7 @@ Then /^I visit the '(.*)' question page for that brief response$/ do |question|
   url = "/suppliers/opportunities/#{@brief_id}/responses/#{@brief_response}/#{question}"
   step "I am on the #{url} page"
 end
+
+Then /^I see '(.*)' replayed in the question advice$/ do |replayed_info|
+  page.should have_xpath("//span[@class='question-advice']/p", text: replayed_info)
+end

--- a/features/step_definitions/brief_response_steps.rb
+++ b/features/step_definitions/brief_response_steps.rb
@@ -42,7 +42,7 @@ Given 'that supplier user is logged in' do
 end
 
 Given 'that supplier has filled in their application but not submitted it' do
-  @brief_response = create_brief_response(@service['lotSlug'], @brief_id, @supplier['id'])
+  @brief_response = create_brief_response(@brief['lotSlug'], @brief_id, @supplier['id'])
 end
 
 Then /^I visit the '(.*)' question page for that brief response$/ do |question|

--- a/features/step_definitions/brief_response_steps.rb
+++ b/features/step_definitions/brief_response_steps.rb
@@ -41,12 +41,16 @@ Given 'that supplier user is logged in' do
   }
 end
 
-Given 'that supplier has a completed brief-response' do
+Given 'that supplier has a completed brief response' do
   @brief_response = create_brief_response(@service['lotSlug'], @brief_id, @supplier['id'])
 end
 
 Then /^I visit the '(.*)' question page for that brief response$/ do |question|
-  url = "/suppliers/opportunities/#{@brief_id}/responses/#{@brief_response}/#{question}"
+  snaked = question.downcase.split.each_with_index do |word, index|
+    word.capitalize! if index != 0
+  end
+  question_id = snaked.join
+  url = "/suppliers/opportunities/#{@brief_id}/responses/#{@brief_response}/#{question_id}"
   step "I am on the #{url} page"
 end
 

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -184,6 +184,10 @@ Then /I see #{MAYBE_VAR} as the value of the '(.*)' field$/ do |value, field|
   end
 end
 
+Then /^I do not see the '(.*)' field$/ do |field_name|
+  page.should_not have_field(field_name)
+end
+
 Then /I see #{MAYBE_VAR} as the value of the '(.*)' JSON field$/ do |value, field|
   json = JSON.parse(@response)
   json.should include(field)
@@ -210,5 +214,15 @@ Then /^I see the '(.*)' summary table filled with:$/ do |table_heading, table|
     result_items = result_table_rows[index].all('td')
     result_items[0].text.should == row[0]
     result_items[1].text.should == row[1]
+  end
+end
+
+Then /^I see the '(.*)' radio button is checked(?: for the '(.*)' question)?$/ do |radio_button_name, question|
+  if question
+    within(:xpath, "//span[normalize-space(text())='#{question}']/../..") do
+      page.find_field("#{radio_button_name}").should be_checked
+    end
+  else
+    page.find_field("#{radio_button_name}").should be_checked
   end
 end

--- a/features/supplier/brief_response.feature
+++ b/features/supplier/brief_response.feature
@@ -151,8 +151,8 @@ Scenario: Supplier applies for a user-research-participants brief
 Scenario: Previous page links are used during response flow
   Given that supplier has a service on the digital-specialists lot
     And I have a live digital-specialists brief
-    And that supplier has a completed brief-response
-  When I visit the 'respondToEmailAddress' question page for that brief response
+    And that supplier has a completed brief response
+  When I visit the 'Respond to email address' question page for that brief response
     And I click 'Back to previous page' link
   Then I am on 'Do you have any of the nice-to-have skills or experience?' page
     And I see the 'Yes' radio button is checked for the 'Talk snobbishly about water quality' question

--- a/features/supplier/brief_response.feature
+++ b/features/supplier/brief_response.feature
@@ -148,7 +148,7 @@ Scenario: Supplier applies for a user-research-participants brief
       | Being good at jumping over fences  | No jump is too high. |
       | Saying "Neigh"                     | NEIGH                |
 
-Scenario: Previous page links are used during response flow
+Scenario: Previous page links are used during response flow and existing data is replayed
   Given that supplier has a service on the digital-specialists lot
     And I have a live digital-specialists brief
     And that supplier has filled in their application but not submitted it

--- a/features/supplier/brief_response.feature
+++ b/features/supplier/brief_response.feature
@@ -147,3 +147,33 @@ Scenario: Supplier applies for a user-research-participants brief
       | Liking sugar lumps                 |                      |
       | Being good at jumping over fences  | No jump is too high. |
       | Saying "Neigh"                     | NEIGH                |
+
+Scenario: Previous page links are used during response flow
+  Given that supplier has a service on the digital-specialists lot
+    And I have a live digital-specialists brief
+    And that supplier has a completed brief-response
+  When I visit the 'respondToEmailAddress' question page for that brief response
+    And I click 'Back to previous page' link
+  Then I am on 'Do you have any of the nice-to-have skills or experience?' page
+    And I see the 'Yes' radio button is checked for the 'Talk snobbishly about water quality' question
+    And I see 'First nice to have evidence' as the value of the 'Evidence of Talk snobbishly about water quality' field
+    And I see the 'Yes' radio button is checked for the 'Sip quietly' question
+    And I see 'Second nice to have evidence' as the value of the 'Evidence of Sip quietly' field
+    And I see the 'No' radio button is checked for the 'Provide biscuits' question
+    And I do not see the 'Evidence of Provide biscuits' field
+  When I click 'Back to previous page' link
+  Then I am on 'Give evidence of the essential skills and experience' page
+    And I see 'first evidence' as the value of the 'Boil kettle' field
+    And I see 'second evidence' as the value of the 'Taste tea' field
+    And I see 'third evidence' as the value of the 'Wash mug' field
+    And I see 'fourth evidence' as the value of the 'Dry mug' field
+  When I click 'Back to previous page' link
+  Then I am on 'Do you have all the essential skills and experience?' page
+    And I see the 'Yes' radio button is checked
+  When I click 'Back to previous page' link
+  Then I am on 'What’s the specialist’s day rate?' page
+    And I see '200' as the value of the 'dayRate' field
+  When I click 'Back to previous page' link
+  Then I am on 'When is the earliest the specialist can start work?' page
+    And I see '27/12/17' as the value of the 'availability' field
+    And I don't see the 'Back to previous page' link

--- a/features/supplier/brief_response.feature
+++ b/features/supplier/brief_response.feature
@@ -151,7 +151,7 @@ Scenario: Supplier applies for a user-research-participants brief
 Scenario: Previous page links are used during response flow
   Given that supplier has a service on the digital-specialists lot
     And I have a live digital-specialists brief
-    And that supplier has a completed brief response
+    And that supplier has filled in their application but not submitted it
   When I visit the 'Respond to email address' question page for that brief response
     And I click 'Back to previous page' link
   Then I am on 'Do you have any of the nice-to-have skills or experience?' page
@@ -181,7 +181,7 @@ Scenario: Previous page links are used during response flow
 Scenario: Supplier changes their answers before submission
   Given that supplier has a service on the digital-specialists lot
     And I have a live digital-specialists brief
-    And that supplier has a completed brief response
+    And that supplier has filled in their application but not submitted it
     And I go to that brief page
     And I click 'Apply'
   Then I am on 'Apply for ‘Tea drinker’' page

--- a/features/supplier/brief_response.feature
+++ b/features/supplier/brief_response.feature
@@ -177,3 +177,64 @@ Scenario: Previous page links are used during response flow
   Then I am on 'When is the earliest the specialist can start work?' page
     And I see '27/12/17' as the value of the 'availability' field
     And I don't see the 'Back to previous page' link
+
+Scenario: Supplier changes their answers before submission
+  Given that supplier has a service on the digital-specialists lot
+    And I have a live digital-specialists brief
+    And that supplier has a completed brief response
+    And I go to that brief page
+    And I click 'Apply'
+  Then I am on 'Apply for ‘Tea drinker’' page
+  When I click 'Continue application'
+  Then I am on 'When is the earliest the specialist can start work?' page
+    And I see 'The buyer needs the specialist to start: 31/12/2016' replayed in the question advice
+    And I see '27/12/17' as the value of the 'availability' field
+  When I enter '28/09/17' in the 'availability' field
+    And I click 'Continue'
+  Then I am on the 'What’s the specialist’s day rate?' page
+    And I see '£200' replayed in the question advice
+    And I see '200' as the value of the 'dayRate' field
+  When I enter '100' in the 'dayRate' field
+    And I click 'Continue'
+  Then I am on the 'Do you have all the essential skills and experience?' page
+  When I click 'Continue'
+  Then I am on the 'Give evidence of the essential skills and experience' page
+    And I see 'first evidence' as the value of the 'Boil kettle' field
+    And I see 'second evidence' as the value of the 'Taste tea' field
+    And I see 'third evidence' as the value of the 'Wash mug' field
+    And I see 'fourth evidence' as the value of the 'Dry mug' field
+  When I enter 'Flick the switch' in the 'Boil kettle' field
+    And I enter 'Drink the tea' in the 'Taste tea' field
+    And I enter 'Use soap' in the 'Wash mug' field
+    And I click 'Continue'
+  Then I am on the 'Do you have any of the nice-to-have skills or experience?' page
+    And I see the 'Yes' radio button is checked for the 'Talk snobbishly about water quality' question
+    And I see 'First nice to have evidence' as the value of the 'Evidence of Talk snobbishly about water quality' field
+    And I see the 'Yes' radio button is checked for the 'Sip quietly' question
+    And I see 'Second nice to have evidence' as the value of the 'Evidence of Sip quietly' field
+    And I see the 'No' radio button is checked for the 'Provide biscuits' question
+    And I do not see the 'Evidence of Provide biscuits' field
+  When I choose 'No' radio button for the 'Sip quietly' question
+    And I choose 'Yes' radio button for the 'Provide biscuits' question
+    And I enter 'Only the finest' in the 'Evidence of Provide biscuits' field
+    And I click 'Continue'
+  Then I am on the 'Email address the buyer should use to contact you' page
+  When I enter 'example-email@gov.uk' in the 'respondToEmailAddress' field
+    And I click 'Submit application'
+  Then I am on the 'Your application for ‘Tea drinker’' page
+    And I see the 'Your details' summary table filled with:
+      | field               | value                |
+      | Day rate            | £100                 |
+      | Earliest start date | 28/09/17             |
+      | Email address       | example-email@gov.uk |
+    And I see the 'Your essential skills and experience' summary table filled with:
+      | field       | value            |
+      | Boil kettle | Flick the switch |
+      | Taste tea   | Drink the tea    |
+      | Wash mug    | Use soap         |
+      | Dry mug     | fourth evidence  |
+    And I see the 'Your nice-to-have skills and experience' summary table filled with:
+      | field                               | value |
+      | Talk snobbishly about water quality | First nice to have evidence |
+      | Sip quietly                         |                             |
+      | Provide biscuits                    |  Only the finest            |

--- a/features/support/api_helpers.rb
+++ b/features/support/api_helpers.rb
@@ -140,6 +140,25 @@ def create_brief(lot_slug, user_id)
   JSON.parse(response.body)['briefs']['id']
 end
 
+def create_brief_response(lot_slug, brief_id, supplier_id)
+  brief_response_data = {
+    updated_by: "functional tests"
+  }
+  case lot_slug
+  when 'digital-specialists'
+    brief_response_data['briefResponses'] = Fixtures::DIGITAL_SPECIALISTS_BRIEF_RESPONSE
+  else
+    puts 'Lot slug not recognised'
+  end
+
+  brief_response_data['briefResponses']['briefId'] = brief_id
+  brief_response_data['briefResponses']['supplierId'] = supplier_id
+
+  response = call_api(:post, '/brief-responses', payload: brief_response_data)
+  response.code.should be(201), _error(response, "Failed to create brief response for #{lot_slug}, #{brief_id}")
+  JSON.parse(response.body)['briefResponses']['id']
+end
+
 def publish_brief(brief_id)
   path = "/briefs/#{brief_id}/publish"
   response = call_api(:post, path, payload: {

--- a/features/support/api_helpers.rb
+++ b/features/support/api_helpers.rb
@@ -165,6 +165,7 @@ def publish_brief(brief_id)
     updated_by: "functional tests"
   })
   response.code.should be(200), _error(response, "Failed to publish brief #{brief_id}")
+  JSON.parse(response.body)['briefs']
 end
 
 def create_supplier

--- a/features/support/fixtures.rb
+++ b/features/support/fixtures.rb
@@ -166,4 +166,25 @@ module Fixtures
     technicalWeighting: 60,
     title: "I need horses."
   }
+
+  DIGITAL_SPECIALISTS_BRIEF_RESPONSE = {
+    # ID's should be updated within the step this fixture is used in.
+    briefId: nil,
+    supplierId: nil,
+    availability: "27/12/17",
+    dayRate: "200",
+    essentialRequirements: [
+      { "evidence": "first evidence" },
+      { "evidence": "second evidence" },
+      { "evidence": "third evidence" },
+      { "evidence": "fourth evidence" },
+    ],
+    essentialRequirementsMet: true,
+    niceToHaveRequirements: [
+      { "yesNo": true, "evidence": "First nice to have evidence" },
+      { "yesNo": true, "evidence": "Second nice to have evidence" },
+      { "yesNo": false },
+    ],
+    respondToEmailAddress: "example-email@gov.uk",
+  }
 end


### PR DESCRIPTION
This PR is an addition to this story [https://www.pivotaltracker.com/story/show/137359721](https://www.pivotaltracker.com/story/show/137359721)

The original PR to add the tests didn't check the functionality of the 'Back to previous page' link.

This scenario effectively goes through the flow in reverse for an already completed specialist response, and checks that the correct data is pre-filled in the correct fields.

UPDATE:
It now also checks that a supplier can change there answers (if they haven't already submitted their response). It runs through a already completed specialist response and updates key fields, then checks the summary table at the end.