### PR TITLE
Remove tests that rely on g6 services

### DIFF
--- a/features/admin/admin_journey.feature
+++ b/features/admin/admin_journey.feature
@@ -22,20 +22,6 @@ Scenario: As an admin user who has logged in to Digital Marketplace, I wish to s
   And I click the search button for 'service_id'
   Then I am presented with the summary page for that service
 
-Scenario: As an admin user who has logged in to Digital Marketplace, I wish to search for services by DUNS number
-  Given I have logged in to Digital Marketplace as a 'Administrator' user
-  When I enter '930123456789' in the 'supplier_duns_number' field
-  And I click the search button for 'supplier_duns_number'
-  And I am taken to the 'Suppliers' page
-  And I click the 'Services' link
-  Then  I am presented with the 'Services' page for the supplier 'DM Functional Test Supplier'
-  And I can see all listings ordered by lot name followed by listing name
-
-Scenario: As an admin user who has logged in to Digital Marketplace, I wish to search for services by supplier name prefix and view a specific service
-  Given I am logged in as 'Administrator' and navigated to the 'Services' page by searching on suppliers by name prefix 'DM Functional Test Supplier'
-  When I click the service name link for the second listing on the page
-  Then I am presented with the service page for that specific listing
-
 Scenario: As an admin user who has logged in to Digital Marketplace, I wish to search for supplier(s) by supplier name prefix
   Given I have logged in to Digital Marketplace as a 'Administrator' user
   When I enter 'DM Functional Test Supplier' in the 'supplier_name_prefix' field
@@ -46,12 +32,6 @@ Scenario: As an admin user who has logged in to Digital Marketplace, I wish to n
   Given I am logged in as 'Administrator' and navigated to the 'Suppliers' page by searching on suppliers by name prefix 'DM Functional Test Supplier'
   When I click the 'Users' link for the supplier 'DM Functional Test Supplier'
   Then I am presented with the 'Users' page for the supplier 'DM Functional Test Supplier'
-
-Scenario: As an admin user who has logged in to Digital Marketplace, I wish to navigate to the Supplier Services page via the supplier(s) by supplier name prefix page
-  Given I am logged in as 'Administrator' and navigated to the 'Suppliers' page by searching on suppliers by name prefix 'DM Functional Test Supplier'
-  When I click the 'Services' link for the supplier 'DM Functional Test Supplier'
-  Then I am presented with the 'Services' page for the supplier 'DM Functional Test Supplier'
-  And I can see all listings ordered by lot name followed by listing name
 
 Scenario: As an admin user who has logged in to Digital Marketplace, I wish to search for users by email address
   Given I have logged in to Digital Marketplace as a 'Administrator' user
@@ -116,43 +96,6 @@ Scenario: As an admin user I want to view Service status changes
 
   When I navigate to the Service status changes page for changes made yesterday
   Then I am presented with the Service status changes page for changes made 'yesterday'
-
-Scenario: Admin changes service status to 'Removed'. The change is reflected in the supplier and/or buyer app
-  Given I am logged in as 'Administrator' and am on the '1123456789012346' service summary page
-  When I select 'Removed' as the service status
-  And I click the 'Update status' button
-  Then The service status is set as 'Removed'
-  And I am presented with the message 'Service status has been updated to: Removed'
-  And There is a new row for the 'Removed' status change in the service status change page
-  And The status of the service is presented as 'Removed' on the supplier users service listings page
-  And A message stating the supplier has stopped offering this service on todays date is presented on the 'Supplier' service summary page
-  And The service 'can not' be searched
-  And The service details page 'can' be viewed
-  And A message stating the supplier has stopped offering this service on todays date is presented on the 'Buyer' service summary page
-
-Scenario: Admin changes service status to 'Private'. The change is reflected in the supplier and/or buyer app
-  Given I am logged in as 'Administrator' and am on the '1123456789012346' service summary page
-  When I select 'Private' as the service status
-  And I click the 'Update status' button
-  Then The service status is set as 'Private'
-  And I am presented with the message 'Service status has been updated to: Private'
-  And There is a new row for the 'Removed' status change in the service status change page
-  And The status of the service is presented as 'Removed' on the supplier users service listings page
-  And A message stating the supplier has stopped offering this service on todays date is presented on the 'Supplier' service summary page
-  And The service 'can not' be searched
-  And The service details page 'can' be viewed
-  And A message stating the supplier has stopped offering this service on todays date is presented on the 'Buyer' service summary page
-
-Scenario: Admin changes service status to 'Public'. The change is reflected in the supplier and/or buyer app
-  Given I am logged in as 'Administrator' and am on the '1123456789012346' service summary page
-  When I select 'Public' as the service status
-  And I click the 'Update status' button
-  Then The service status is set as 'Public'
-  And I am presented with the message 'Service status has been updated to: Public'
-  And There is a new row for the 'Live' status change in the service status change page
-  And The status of the service is presented as 'Live' on the supplier users service listings page
-  And The service 'can' be searched
-  And The service details page 'can' be viewed
 
 Scenario: As an admin user who has logged in to Digital Marketplace, I wish to deactivate a supplier user
   Given I am logged in as 'Administrator' and navigated to the 'Users' page for supplier 'DM Functional Test Supplier'

--- a/features/admin/ccs_category_admin_journey.feature
+++ b/features/admin/ccs_category_admin_journey.feature
@@ -16,11 +16,6 @@ Scenario: As a CCS Category user who has logged in to Digital Marketplace, I wis
   And I click the search button for 'service_id'
   Then I am presented with the summary page for that service
 
-Scenario: As an admin user who has logged in to Digital Marketplace, I wish to search for services by supplier name prefix and view a specific service
-  Given I am logged in as 'CCS Category' and navigated to the 'Services' page by searching on suppliers by name prefix 'DM Functional Test Supplier'
-  When I click the service name link for the second listing on the page
-  Then I am presented with the service page for that specific listing
-
 Scenario: As a CCS Category user who has logged in to Digital Marketplace, I wish to search for supplier(s) by supplier name prefix
   Given I have logged in to Digital Marketplace as a 'CCS Category' user
   When I enter 'DM Functional Test Supplier' in the 'supplier_name_prefix' field
@@ -31,12 +26,6 @@ Scenario: As a CCS Category user who has logged in to Digital Marketplace, I wis
   Given I am logged in as 'CCS Category' and navigated to the 'Suppliers' page by searching on suppliers by name prefix 'DM Functional Test Supplier'
   When I click the 'Users' link for the supplier 'DM Functional Test Supplier'
   Then I am presented with the 'Users' page for the supplier 'DM Functional Test Supplier'
-
-Scenario: As a CCS Category user who has logged in to Digital Marketplace, I wish to navigate to the Supplier Services page via the supplier(s) by supplier name prefix page
-  Given I am logged in as 'CCS Category' and navigated to the 'Suppliers' page by searching on suppliers by name prefix 'DM Functional Test Supplier'
-  When I click the 'Services' link for the supplier 'DM Functional Test Supplier'
-  Then I am presented with the 'Services' page for the supplier 'DM Functional Test Supplier'
-  And I can see all listings ordered by lot name followed by listing name
 
 Scenario: CCS Category should not have access to certain admin pages
   Given I have logged in to Digital Marketplace as a 'CCS Category' user

--- a/features/buyer/buyer_journey.feature
+++ b/features/buyer/buyer_journey.feature
@@ -51,28 +51,6 @@ Scenario: There is no pagination on the results page if there is less than or eq
   When There is 'less' than the pagination limit results returned
   Then Pagination is 'not available'
 
-Scenario: User able to search by service ID and have result returned
-  Given I am on the 'Cloud technology and support' landing page
-  When I enter '1123456789012346' in the 'q' field
-  And I click 'Show services'
-  Then I am taken to the search results page with a result for the service '1123456789012346'
-
-Scenario: User is able to search by service name and have result returned.
-  Given I am on the 'Cloud technology and support' landing page
-  When I enter '1123456789012346 DM Functional Test N3 Secure Remote Access' in the 'q' field
-  And I click 'Show services'
-  Then I am taken to the search results page with a result for the service '1123456789012346 DM Functional Test N3 Secure Remote Access'
-
-Scenario: Words in service description matching the search criteria are highlighted
-  Given I am on the search results page for the searched value of '1123456789012346 DM Functional Test N3 Secure Remote Access'
-  Then Words in the search result excerpt that match the search criteria are highlighted
-
-Scenario: User able to search by keywords field on the search results page to narrow down the results returned
-  Given I am on the search results page with results for 'Infrastructure as a Service' lot displayed
-  When I enter '1123456789012346' in the 'q' field
-  And I click 'Filter'
-  Then The search results is filtered returning just one result for the service '1123456789012346'
-
 Scenario: User is able to use filter to narrow down results set
   Given I am on the search results page with results for 'Specialist Cloud Services' lot displayed
   When I select 'Training' as the filter value under the 'Categories' filter
@@ -95,28 +73,6 @@ Scenario: User is able to navigate to service listing page via selecting the ser
   Given I am on the search results page with results for 'Platform as a Service' lot displayed
   When I click the first record in the list of results returned
   Then I am taken to the service listing page of that specific record selected
-
-Scenario: User is able to find a specific supplier via G-Cloud supplier A-Z when status of all services for that supplier are PUBLIC
-  Given I am on the G-Cloud supplier A-Z page
-  When I click the 'D' link
-  Then I am on the list of 'Suppliers starting with D' page
-  And The supplier 'DM Functional Test Supplier 2' is 'listed' on the page
-
-Scenario: User is able to navigate to the supplier information page of a specific supplier
-  Given I navigate to the list of 'Suppliers starting with D' page
-  When The supplier 'DM Functional Test Supplier 2' is 'listed' on the page
-  Then I click the 'DM Functional Test Supplier 2' link
-  And I am taken to the 'DM Functional Test Supplier 2' supplier information page
-
-Scenario: Specific supplier is not listed on G-Cloud supplier A-Z when status of all services for that supplier are REMOVED
-  Given All services associated with supplier with name 'DM Functional Test Supplier 2' have a status of 'Removed'
-  When I navigate to the list of 'Suppliers starting with D' page
-  Then The supplier 'DM Functional Test Supplier 2' is 'not listed' on the page
-
-Scenario: Specific supplier is not listed on G-Cloud supplier A-Z when status of all services for that supplier are PRIVATE
-  Given All services associated with supplier with name 'DM Functional Test Supplier 2' have a status of 'Private'
-  When I navigate to the list of 'Suppliers starting with D' page
-  Then The supplier 'DM Functional Test Supplier 2' is 'not listed' on the page
 
 Scenario: There is pagination on the list of suppliers page if there are more than 100 results
   Given I navigate to the list of 'Suppliers starting with S' page

--- a/features/step_definitions/journey_test_steps.rb
+++ b/features/step_definitions/journey_test_steps.rb
@@ -730,43 +730,6 @@ Given /^I am logged in as '(.*)' '(.*)' user and am on the service listings page
   }
 end
 
-Then /I can see my supplier details on the dashboard$/ do
-  page.should have_selector(:xpath, "//*[@class='summary-item-heading'][contains(text(), 'Current services')]")
-  page.should have_selector(:xpath, "//*[@class='summary-item-heading'][contains(text(), 'Supplier information')]")
-  page.should have_selector(:xpath, "//*[@class='summary-item-heading'][contains(text(), 'Account information')]")
-  page.should have_selector(:xpath, "//*[@class='summary-item-heading'][contains(text(), 'Contributors')]")
-  page.should have_selector(:xpath, "//*[@class='summary-item-field-first']/span[contains(text(), 'G-Cloud 6')]")
-  page.should have_selector(:xpath, "//*[@class='summary-item-field']/span/p[contains(text(), '8 services')]")
-  page.should have_selector(:xpath, "//*[@class='summary-item-field-first']/span[contains(text(), 'Supplier summary')]")
-  page.should have_selector(:xpath, "//*[@class='summary-item-field']/span[contains(text(), 'This is a test supplier, which will be used solely for the purpose of running functional test.')]")
-  page.should have_selector(:xpath, "//*[@class='summary-item-field-first']/span[contains(text(), 'Clients')]")
-  page.should have_selector(:xpath, "//*[@class='summary-item-field']//li[contains(text(), 'First client')]")
-  page.should have_selector(:xpath, "//*[@class='summary-item-field']//li[contains(text(), 'Second client')]")
-  page.should have_selector(:xpath, "//*[@class='summary-item-field']//li[contains(text(), '3rd client')]")
-  page.should have_selector(:xpath, "//*[@class='summary-item-field']//li[contains(text(), 'Client 4')]")
-  page.should have_selector(:xpath, "//*[@class='summary-item-field-first']/span[contains(text(), 'Contact name')]")
-  page.should have_selector(:xpath, "//*[@class='summary-item-field']/span[contains(text(), 'Testing Supplier Name')]")
-  page.should have_selector(:xpath, "//*[@class='summary-item-field-first']/span[contains(text(), 'Website')]")
-  page.should have_selector(:xpath, "//*[@class='summary-item-field']/span/a[contains(text(), 'www.dmfunctionaltestsupplier.com')]")
-  page.should have_selector(:xpath, "//*[@class='summary-item-field-first']/span[contains(text(), 'Email address')]")
-  page.should have_selector(:xpath, "//*[@class='summary-item-field']/span[contains(text(), 'Testing.supplier.NaMe@DMtestemail.com')]")
-  page.should have_selector(:xpath, "//*[@class='summary-item-field-first']/span[contains(text(), 'Phone number')]")
-  page.should have_selector(:xpath, "//*[@class='summary-item-field']/span[contains(text(), '+44 (0) 123456789')]")
-  page.should have_selector(:xpath, "//*[@class='summary-item-field-first']/span[contains(text(), 'Address')]")
-  page.should have_selector(:xpath, "//*[@class='summary-item-field']//*/span[@itemprop][text()][contains(text(), '125 Kingsway')]")
-  page.should have_selector(:xpath, "//*[@class='summary-item-field']//*/span[@itemprop][text()][contains(text(), 'London')]")
-  page.should have_selector(:xpath, "//*[@class='summary-item-field']//*/span[@itemprop][text()][contains(text(), 'United Kingdom')]")
-  page.should have_selector(:xpath, "//*[@class='summary-item-field']//*/span[@itemprop][text()][contains(text(), 'WC2B 6NH')]")
-  page.should have_selector(:xpath, "//*[@class='summary-item-field-first']/span[contains(text(), 'DM Functional Test Supplier User 1')]")
-  page.should have_selector(:xpath, "//*[@class='summary-item-field']/span[contains(text(), '#{dm_supplier_user_email()}')]")
-  page.should have_selector(:xpath, "//*[@class='summary-item-field-first']/span[contains(text(), 'DM Functional Test Supplier User 2')]")
-  page.should have_selector(:xpath, "//*[@class='summary-item-field']/span[contains(text(), '#{dm_supplier_user2_email()}')]")
-  page.should have_selector(:xpath, "//*[@class='summary-item-field-first']/span[contains(text(), 'DM Functional Test Supplier User 3')]")
-  page.should have_selector(:xpath, "//*[@class='summary-item-field']/span[contains(text(), '#{dm_supplier_user3_email()}')]")
-  page.should have_selector(:xpath, "//*[@class='summary-item-body']/caption[contains(text(), 'Account information')]/following-sibling::*[2]//*[@class='summary-item-field-first']/span[contains(text(), 'Email address')]")
-  page.should have_selector(:xpath, "//*[@class='summary-item-field']/span[contains(text(), '#{dm_supplier_user_email()}')]")
-end
-
 Then /I am presented with the supplier '(.*)' '(.*)' page$/ do |supplier_name, page_name|
   page.should have_selector(:xpath, ".//*[@id='global-breadcrumb']/nav/*[@role='breadcrumbs']/li[1]//*[contains(text(), 'Digital Marketplace')]")
   page.should have_selector(:xpath, ".//*[@id='global-breadcrumb']/nav/*[@role='breadcrumbs']/li[2]//*[contains(text(), 'Your account')]")
@@ -899,19 +862,6 @@ Then /I am presented with the 'Suppliers' page for all suppliers starting with '
   end
 end
 
-And /I can see all listings ordered by lot name followed by listing name$/ do
-  services_listed([
-    "1123456789012348",
-    "1123456789012352",
-    "1123456789012347",
-    "1123456789012351",
-    "1123456789012346",
-    "1123456789012350",
-    "1123456789012349",
-    "1123456789012353",
-  ])
-end
-
 Then /I can see active users associated with '(.*)' on the dashboard$/ do |supplier_name|
   page.should have_selector(:xpath, "//*[@class='summary-item-heading'][contains(text(), 'Contributors')]")
   ['Name', 'Email address'].each do |header|
@@ -947,39 +897,6 @@ def services_listed(service_ids)
   end
 end
 
-When /I click the service name link for the second listing on the page$/ do
-  @data_store = @data_store || Hash.new
-
-  servicename = find(
-    :xpath,
-    "//*/table/tbody/tr[2]/td[1]/span/a"
-  ).text()
-  @data_store['servicename'] = servicename
-
-  page.click_link_or_button(@data_store['servicename'])
-  serviceid = URI.parse(current_url).to_s.split('services/').last
-  @data_store['serviceid'] = serviceid
-end
-
-Then /I am presented with the service page for that specific listing$/ do
-  page.should have_content(@data_store['servicename'])
-  current_url.should end_with("#{dm_frontend_domain}/g-cloud/services/#{@data_store['serviceid']}")
-end
-
-When /I select '(.*)' as the service status$/ do |service_status|
-  if current_url.include?('suppliers')
-    find(
-      :xpath,
-      "//*[contains(@name, 'status') and contains(@value, '#{service_status}')]"
-    ).click
-  elsif current_url.include?('admin')
-    find(
-      :xpath,
-      "//*[contains(@name, 'status') and contains(@value, '#{service_status.downcase}')]"
-    ).click
-  end
-end
-
 Then /The service status is set as '(.*)'$/ do |service_status|
   if current_url.include?('suppliers')
     find(
@@ -994,88 +911,12 @@ Then /The service status is set as '(.*)'$/ do |service_status|
   end
 end
 
-And /I am presented with a service removal message for the '(.*)' service$/ do |value|
-  service_name = find(:xpath,
-    "//a[contains(@href, '/suppliers/services/#{value}')]"
-  ).text()
-
-  step "And I am presented with the message '#{service_name} has been removed.'"
-end
-
 And /I am presented with the message '(.*)'$/ do |message_text|
   page.should have_content(message_text)
 end
 
-Then /The status of the service is presented as '(.*)' on the supplier users service listings page$/ do |service_status|
-  step "I am logged in as 'DM Functional Test Supplier' 'Supplier' user and am on the service listings page"
-
-  find(:xpath,
-    "//a[contains(@href, '/suppliers/services/#{@servicesupplierID}')]/../../../td[4]/span"
-  ).text().should have_content("#{service_status}")
-end
-
-Then /The status of the service is presented as '(.*)' on the admin users service summary page$/ do |service_status|
-  step "I am logged in as 'Administrator' and am on the '#{@servicesupplierID}' service summary page"
-  find(
-    :xpath,
-    "//*[contains(text(), 'Service status')]/following-sibling::*[@class='selection-button selection-button-selected'][text()]"
-  ).text().should have_content("#{service_status}")
-end
-
-And /A message stating the supplier has stopped offering this service on todays date is presented on the '(.*)' service summary page$/ do |user_type|
-  time = Time.new
-  todays_date = time.strftime("%A %-d %B %Y")
-
-  case user_type
-  when 'Supplier'
-    step "I am logged in as 'DM Functional Test Supplier' 'Supplier' user and am on the dashboard page"
-    page.visit("#{dm_frontend_domain}/suppliers/services/#{@servicesupplierID}")
-    page.find(:xpath,
-      "//div[@class='banner-temporary-message-without-action']/h2[contains(text(),'This service was removed on #{todays_date}')]/following-sibling::p[@class='banner-message'][contains(text(),'If you don’t know why this service was removed')]"
-    )
-  when 'Buyer'
-    page.find(:xpath,
-      "//div[@class='banner-temporary-message-without-action']/h2[contains(text(),'DM Functional Test Supplier stopped offering this service on #{todays_date}.')]/following-sibling::p[@class='banner-message'][contains(text(),'Any existing contracts for this service are still valid')]"
-    )
-  else
-    fail("Unrecognised user type: '#{user_type}'")
-  end
-end
-
 Then /^there is a (success|warning|destructive) banner message containing '(.*)'$/ do |status, message|
   page.find(:css, ".banner-#{status}-without-action").should have_content(message)
-end
-
-And /The service '(.*)' be searched$/ do |ability|
-  sleep 1
-  page.visit("#{dm_frontend_domain}/g-cloud/search?q=#{@servicesupplierID}")
-  page.should have_content('Search results')
-  if "#{ability.downcase}" == 'can'
-    @existing_values = @existing_values || Hash.new
-    page.find(
-      :xpath,
-      "//*[contains(@class, 'search-summary-count') and contains(text(), '1')]"
-    )
-    page.should have_selector(:xpath, "//a[contains(@href, '/services/#{@serviceID}')]")
-    service_name = find(:xpath, "//a[contains(@href, '/services/#{@serviceID}')]").text()
-    @existing_values['service_name'] = service_name
-  elsif "#{ability.downcase}" == 'can not'
-    page.find(
-      :xpath,
-      "//*[contains(@class, 'search-summary-count') and contains(text(), '0')]"
-    )
-    page.should have_no_selector(:xpath, "//a[contains(@href, '/services/#{@serviceID}')]")
-  end
-end
-
-And /The service details page '(.*)' be viewed$/ do |ability|
-  page.visit("#{dm_frontend_domain}/g-cloud/services/#{@servicesupplierID}")
-  if "#{ability.downcase}" == 'can'
-    page.should have_content(@existing_values['service_name'])
-  elsif "#{ability.downcase}" == 'can not'
-    page.should have_content(@existing_values['service_name'])
-    page.should have_content('Page could not be found')
-  end
 end
 
 Given /I am on the '(.*)' landing page$/ do |page_name|
@@ -1282,21 +1123,6 @@ Then /There (?:is|are) (\d+) search results?$/ do |count|
   find(:xpath, "//*[@class='search-summary-count']").text.should == count
 end
 
-Then /I am taken to the search results page with a result for the service '(.*)'$/ do |value|
-  steps %Q{
-    Then I am on a page with '#{value}' in search summary text
-    Then Selected lot is 'All categories' with links to the search for '#{value}'
-    Then There is 1 search result
-  }
-
-  find(:xpath, "//*[@class='search-summary']/em[1]").text().should match("#{value}")
-  find(:xpath, ".//*[@id='content']//*[@class='search-result-title']//a[contains(text(),'#{value}')]")
-  page.should have_no_selector(:xpath, ".//div[@class='lot-filters']//li[1]/a")
-  page.should have_selector(:xpath, ".//p[@class='search-result-supplier'][contains(text(), 'DM Functional Test Supplier')]")
-  page.should have_selector(:xpath, ".//*[@class='search-result-metadata-item'][contains(text(), 'Infrastructure as a Service')]")
-  page.should have_selector(:xpath, ".//*[@class='search-result-metadata-item'][contains(text(), 'G-Cloud 6')]")
-end
-
 Then /I am on a page with that service in search results$/ do
   search_results = all(:xpath, ".//div[@class='search-result']")
   service_result = search_results.find { |r| r.first(:xpath, './h2/a')[:href].include? @service['id']}
@@ -1305,24 +1131,6 @@ Then /I am on a page with that service in search results$/ do
   service_result.first(:xpath, "./p[@class='search-result-supplier']").text.should == normalize_whitespace(@service['supplierName'])
   service_result.first(:xpath, ".//li[@class='search-result-metadata-item'][1]").text.should == (@service['lotName'] || full_lot(@service['lot']))
   service_result.first(:xpath, ".//li[@class='search-result-metadata-item'][2]").text.should == @service['frameworkName']
-end
-
-Given /I am on the search results page for the searched value of '(.*)'$/ do |search_value|
-  steps %Q{
-    Given I am on the 'Cloud technology and support' landing page
-    When I enter '#{search_value}' in the 'q' field
-    And I click 'Show services'
-    Then I am taken to the search results page with a result for the service '#{search_value}'
-  }
-end
-
-Then /Words in the search result excerpt that match the search criteria are highlighted$/ do
-  page.first(:xpath, ".//mark[@class='search-result-highlighted-text'][contains(text(),'N3')]").text().should have_content('N3')
-  page.first(:xpath, ".//mark[@class='search-result-highlighted-text'][contains(text(),'Secure')]").text().should have_content('Secure')
-  page.first(:xpath, ".//mark[@class='search-result-highlighted-text'][contains(text(),'secure')]").text().should have_content('secure')
-  page.first(:xpath, ".//mark[@class='search-result-highlighted-text'][contains(text(),'Remote')]").text().should have_content('Remote')
-  page.first(:xpath, ".//mark[@class='search-result-highlighted-text'][contains(text(),'Access')]").text().should have_content('Access')
-  page.first(:xpath, ".//mark[@class='search-result-highlighted-text'][contains(text(),'access')]").text().should have_content('access')
 end
 
 Given /I am on the search results page with results for that service.lot displayed$/ do
@@ -1342,23 +1150,6 @@ end
 
 When /^I choose file '(.*)' for '(.*)'$/ do |file, label|
   attach_file(label, File.join(Dir.pwd, 'fixtures', file))
-end
-
-Then /The search results is filtered returning just one result for the service '(.*)'$/ do |value|
-  query_string = CGI.escape value
-  current_url.should end_with("#{dm_frontend_domain}/g-cloud/search?q=#{query_string}&lot=iaas")
-  find(:xpath, "//*[@class='search-summary-count']").text().should match(/^1$/)
-  find(:xpath, "//*[@class='search-summary']/em[1]").text().should match("#{query_string}")
-  find(:xpath, "//*[@class='search-summary']/em[2]").text().should match('Infrastructure as a Service')
-  find(
-    :xpath,
-    ".//*[@id='content']//*[@class='search-result-title']//a[contains(text(),'#{query_string} DM Functional Test N3 Secure Remote Access')]"
-  )
-  page.should have_no_selector(:xpath, ".//div[@class='lot-filters']//li[4]/a")
-  page.should have_selector(:xpath, "//a[contains(@href, '/search?q=#{query_string}')]")
-  page.should have_selector(:xpath, "//a[contains(@href, '/search?q=#{query_string}') and contains(@href, '&lot=saas')]")
-  page.should have_selector(:xpath, "//a[contains(@href, '/search?q=#{query_string}') and contains(@href, '&lot=paas')]")
-  page.should have_selector(:xpath, "//a[contains(@href, '/search?q=#{query_string}') and contains(@href, '&lot=scs')]")
 end
 
 When /I select '(.*)' as the filter value under the '(.*)' filter$/ do |filter_value,filter_name|
@@ -1503,23 +1294,6 @@ Given /I am on the G-Cloud supplier A-Z page$/ do
   page.should have_selector(:xpath, "//*[@id='global-breadcrumb']/nav/*[@role='breadcrumbs']/li[2]//*[contains(text(), 'Cloud technology and support')]")
 end
 
-Then /I am on the list of '(.*)' page$/ do |value|
-  current_url.should end_with("#{dm_frontend_domain}/g-cloud/suppliers?prefix=D")
-  page.should have_content('Suppliers starting with D')
-  ('A'..'C').each do |letter|
-    page.should have_selector(:xpath, ".//*[@id='global-atoz-navigation']//*/a[contains(@href, '/g-cloud/suppliers?prefix=#{letter}')]")
-  end
-  ('E'..'Z').each do |letter|
-    page.should have_selector(:xpath, ".//*[@id='global-atoz-navigation']//*/a[contains(@href, '/g-cloud/suppliers?prefix=#{letter}')]")
-  end
-  page.should have_no_selector(:xpath, ".//*[@id='global-atoz-navigation']//*/a[contains(@href, '/g-cloud/suppliers?prefix=D')]")
-  page.should have_selector(:xpath, ".//*[@id='global-atoz-navigation']//*/a[contains(@href, '/g-cloud/suppliers?prefix=other')]")
-  page.should have_selector(:xpath, ".//*[@id='global-atoz-navigation']//*/a[contains(@href, '/g-cloud/suppliers?prefix=other')]")
-  page.should have_selector(:xpath, ".//*[@id='content']//*[@class='selected']//strong[contains(text(), 'D')]")
-  page.should have_selector(:xpath, "//*[@id='global-breadcrumb']/nav/*[@role='breadcrumbs']/li[1]//*[contains(text(), 'Digital Marketplace')]")
-  page.should have_selector(:xpath, "//*[@id='global-breadcrumb']/nav/*[@role='breadcrumbs']/li[2]//*[contains(text(), 'Cloud technology and support')]")
-end
-
 And /The supplier '(.*)' is '(.*)' on the page$/ do |value,availability|
   if availability == 'listed'
     page.should have_content("#{value}")
@@ -1549,21 +1323,6 @@ And /I am taken to the '(.*)' supplier information page$/ do |value|
   page.should have_selector(:xpath, "//*[@id='global-breadcrumb']/nav/*[@role='breadcrumbs']/li[2]//*[contains(text(), 'Cloud technology and support')]")
   page.should have_selector(:xpath, "//*[@id='global-breadcrumb']/nav/*[@role='breadcrumbs']/li[3]//*[contains(text(), 'Suppliers')]")
   page.should have_selector(:xpath, "//*[@id='global-breadcrumb']/nav/*[@role='breadcrumbs']/li[4]//*[contains(text(), 'D')]")
-end
-
-Given /All services associated with supplier with name '(.*)' have a status of '(.*)'$/ do |value,status|
-  step "I am logged in as 'Administrator' and navigated to the 'Services' page for supplier '#{value}'"
-  current_service_status = page.find(:xpath,"//*[@class='summary-item-field-with-action']//*[contains(@href, '1123456789012354')]/../../../td[5][text()]").text()
-  if current_service_status == 'Public' || current_service_status == 'Private'
-    step "I click the 'Edit' link for the service '1123456789012354'"
-  elsif current_service_status == 'Removed'
-    step "I click the 'Details' link for the service '1123456789012354'"
-  end
-  steps %Q{
-    When I select '#{status}' as the service status
-    And I click the 'Update status' button
-    Then The service status is set as '#{status}'
-  }
 end
 
 And /All users for the supplier ID 11111 are listed on the page$/ do
@@ -1681,34 +1440,6 @@ Then /I am presented with the Service status changes page for changes made '(.*)
   page.should have_link('Service updates')
   page.should have_link('Service status changes')
   page.should have_link('Log out')
-end
-
-And /There is a new row for the '(.*)' status change in the service status change page$/ do |service_status|
-  page.visit("#{dm_frontend_domain}/admin/service-status-updates/#{Date.today}")
-  top_record_time_stamp = page.find(:xpath, "//tbody/tr[1]/td[5]/span").text()
-  second_time = DateTime.parse(top_record_time_stamp)
-
-  def check_latest_row_correct(service_status)
-    top_record_time_stamp = page.find(:xpath, "//tbody/tr[1]/td[5]/span").text()
-    case service_status
-    when 'Live'
-      page.should have_xpath("//tbody/tr[1]/td[3]/span[contains(text(),'Live')]/../../td[5]/span[contains(text(),'#{top_record_time_stamp}')]")
-    when 'Removed'
-      page.should have_xpath("//tbody/tr[1]/td[3]/span[contains(text(),'Removed')]/../../td[5]/span[contains(text(),'#{top_record_time_stamp}')]")
-    else
-      fail("There is no such service status: \"#{service_status}\"")
-    end
-  end
-
-  if store.first_time == nil
-    check_latest_row_correct(service_status)
-    store.first_time = DateTime.parse(top_record_time_stamp)
-  elsif store.first_time < second_time
-    check_latest_row_correct(service_status)
-
-  elsif store.first_time == second_time
-      fail("An error has occured: There has not been any new status changes recorded")
-  end
 end
 
 Then /I am presented with the '(.*)' page with the changed supplier name '(.*)' listed on the page$/ do |page_name,supplier_name|

--- a/features/supplier/supplier_journey.feature
+++ b/features/supplier/supplier_journey.feature
@@ -14,22 +14,6 @@ Scenario: As supplier user I wish be able to log in and to log out of Digital Ma
   When I click 'Log out'
   Then I am logged out of Digital Marketplace as a 'Supplier' user
 
-Scenario: As a logged in supplier user, my supplier details are available on the dashboard
-  Given I am logged in as 'DM Functional Test Supplier' 'Supplier' user and am on the dashboard page
-  Then I can see my supplier details on the dashboard
-
-Scenario: As a logged in supplier user, I can navigate to the service listings page from my dashboard and can see all my listings
-  Given I am logged in as 'DM Functional Test Supplier' 'Supplier' user and am on the dashboard page
-  When I click 'View'
-  Then I am presented with the supplier 'DM Functional Test Supplier' 'Current services' page
-  And I can see all listings ordered by lot name followed by listing name
-
-Scenario: As a logged in supplier user, I can view the listings page of a specific service
-  Given I am logged in as 'DM Functional Test Supplier' 'Supplier' user and am on the service listings page
-  When I click the service name link for the second listing on the page
-  And I click 'View service'
-  Then I am presented with the service page for that specific listing
-
 Scenario: As a logged in supplier user, I can see my active contributors on the dashboard
   Given I am logged in as 'DM Functional Test Supplier' 'Supplier' user and am on the dashboard page
   Then I can see active users associated with 'DM Functional Test Supplier' on the dashboard
@@ -45,11 +29,6 @@ Scenario: As a logged in supplier user, I can navigate to the contributors page 
   Then I am logged out of Digital Marketplace as a 'Supplier' user
   And The supplier user 'DM Functional Test Supplier User 2' 'can not' login to Digital Marketplace
   Then The supplier user 'DM Functional Test Supplier User 2' is 'not active' on the admin Users page
-
-Scenario: As a logged in supplier user, I can navigate to the service summary page for a specific service
-  Given I am logged in as 'DM Functional Test Supplier' 'Supplier' user and am on the service listings page
-  When I click the service name link for the second listing on the page
-  Then I am presented with the summary page for that service
 
 Scenario: As a logged in supplier user, I can edit my supplier information
   Given I am logged in as 'DM Functional Test Supplier' 'Supplier' user and am on the dashboard page
@@ -87,18 +66,6 @@ Scenario: As a logged in supplier user, I can edit the features and benefits of 
   And I add 'This is a new service feature' as a 'serviceFeatures'
   And I click 'Save and return to service'
   Then I am presented with the summary page with the changes that were made to the 'Features and benefits'
-
-Scenario: Supplier user changes service status to 'Removed'. The change is reflected in the admin and/or buyer app
-  Given I am logged in as 'Supplier' and am on the '1123456789012346' service summary page
-  When I click 'Remove service'
-  Then I am presented with the message 'Are you sure you want to remove your service?'
-  When I click 'Remove service'
-  And I am presented with a service removal message for the '1123456789012346' service
-  And A message stating the supplier has stopped offering this service on todays date is presented on the 'Supplier' service summary page
-  And The service 'can not' be searched
-  And The service details page 'can' be viewed
-  And A message stating the supplier has stopped offering this service on todays date is presented on the 'Buyer' service summary page
-  And The status of the service is presented as 'Private' on the admin users service summary page
 
 Scenario: Supplier user has 5 failed login attempts and is locked. Login is not allowed unless admin unlocks the user
   Given The supplier user 'DM Functional Test Supplier User 3' has 5 failed login attempts

--- a/scripts/test_dependencies.sh
+++ b/scripts/test_dependencies.sh
@@ -29,7 +29,7 @@ echo -e "\033[0;32mAll services are up\033[0m"
 
 test_framework_status "g-cloud-4" "expired"
 test_framework_status "g-cloud-5" "expired"
-test_framework_status "g-cloud-6" "live"
+test_framework_status "g-cloud-6" "expired"
 test_framework_status "g-cloud-7" "live"
 test_framework_status "g-cloud-8" "live"
 test_framework_status "digital-outcomes-and-specialists" "live"


### PR DESCRIPTION
So we can have g6 expired on preview.

Note, the majority of these tests are covered by the new master branch smoke tests.

These tests identified from the following test report when g6 was expired.
https://ci.beta.digitalmarketplace.service.gov.uk/job/functional-tests-preview-legacy/77/functional_test_report/