### PR TITLE
Make brief responses agnostic to framework

### DIFF
--- a/features/step_definitions/brief_response_steps.rb
+++ b/features/step_definitions/brief_response_steps.rb
@@ -3,6 +3,7 @@ Given 'I have a live digital outcomes and specialists framework' do
   response.code.should be(200), _error(response, "Failed getting frameworks")
   frameworks = JSON.parse(response.body)['frameworks']
   frameworks.delete_if {|framework| framework['framework'] != 'digital-outcomes-and-specialists' || framework['status'] != 'live'}
+  frameworks.empty?.should be(false), _error(response, "No live digital outcomes and specialists frameworks found")
   @framework = frameworks[0]
   puts @framework['slug']
 end

--- a/features/step_definitions/brief_response_steps.rb
+++ b/features/step_definitions/brief_response_steps.rb
@@ -1,5 +1,14 @@
+Given 'I have a live digital outcomes and specialists framework' do
+  response = call_api(:get, "/frameworks")
+  response.code.should be(200), _error(response, "Failed getting frameworks")
+  frameworks = JSON.parse(response.body)['frameworks']
+  frameworks.delete_if {|framework| framework['framework'] != 'digital-outcomes-and-specialists' || framework['status'] != 'live'}
+  @framework = frameworks[0]
+  puts @framework['slug']
+end
+
 Given /^I have a live (.*) brief$/ do |lot_slug|
-  brief_id = create_brief(lot_slug, @buyer["id"])
+  brief_id = create_brief(@framework['slug'], lot_slug, @buyer["id"])
   puts "created brief with id #{brief_id}"
   brief = publish_brief(brief_id)
   @brief_id = brief_id
@@ -19,12 +28,12 @@ Given 'I have a supplier' do
   @supplier = create_supplier
 end
 
-Given /^that supplier is on the (.*) framework$/ do |framework_slug|
-  submit_supplier_declaration(framework_slug, @supplier["id"], {})
+Given 'that supplier is on that framework' do
+  submit_supplier_declaration(@framework['slug'], @supplier["id"], {})
 end
 
 Given /^that supplier has a service on the (.*) lot$/ do |lot_slug|
-  @service = create_live_service(lot_slug, @supplier["id"])
+  @service = create_live_service(@framework['slug'], lot_slug, @supplier["id"])
 end
 
 Given 'that supplier has a user' do

--- a/features/supplier/brief_response.feature
+++ b/features/supplier/brief_response.feature
@@ -3,15 +3,15 @@ Feature: Supplier applies for a brief
 
 Background:
   Given I have a live digital outcomes and specialists framework
-  Given I have a buyer
-  Given I have a supplier
+    And I have a buyer
+    And I have a supplier
     And that supplier is on that framework
     And that supplier has a user
     And that supplier user is logged in
 
 Scenario: Supplier applies for a digital-specialists brief
   Given that supplier has a service on the digital-specialists lot
-  Given I have a live digital-specialists brief
+    And I have a live digital-specialists brief
     And I go to that brief page
     And I click 'Apply'
     Then I am on 'Apply for ‘Tea drinker’' page
@@ -63,7 +63,7 @@ Scenario: Supplier applies for a digital-specialists brief
 
 Scenario: Supplier applies for a digital-outcomes brief
   Given that supplier has a service on the digital-outcomes lot
-  Given I have a live digital-outcomes brief
+    And I have a live digital-outcomes brief
     And I go to that brief page
     And I click 'Apply'
     Then I am on 'Apply for ‘Hide and seek ninjas’' page
@@ -106,7 +106,7 @@ Scenario: Supplier applies for a digital-outcomes brief
 
 Scenario: Supplier applies for a user-research-participants brief
   Given that supplier has a service on the user-research-participants lot
-  Given I have a live user-research-participants brief
+    And I have a live user-research-participants brief
     And I go to that brief page
     And I click 'Apply'
     Then I am on 'Apply for ‘I need horses.’' page

--- a/features/supplier/brief_response.feature
+++ b/features/supplier/brief_response.feature
@@ -2,9 +2,10 @@
 Feature: Supplier applies for a brief
 
 Background:
+  Given I have a live digital outcomes and specialists framework
   Given I have a buyer
   Given I have a supplier
-    And that supplier is on the digital-outcomes-and-specialists framework
+    And that supplier is on that framework
     And that supplier has a user
     And that supplier user is logged in
 

--- a/features/support/api_helpers.rb
+++ b/features/support/api_helpers.rb
@@ -118,7 +118,7 @@ def submit_supplier_declaration(framework_slug, supplier_id, declaration)
   JSON.parse(response.body)['declaration']
 end
 
-def create_brief(lot_slug, user_id)
+def create_brief(framework_slug, lot_slug, user_id)  
   brief_data = {
     updated_by: "functional tests"
   }
@@ -134,6 +134,7 @@ def create_brief(lot_slug, user_id)
   end
 
   brief_data['briefs']['userId'] = user_id
+  brief_data['briefs']['frameworkSlug'] = framework_slug
 
   response = call_api(:post, '/briefs', payload: brief_data)
   response.code.should be(201), _error(response, "Failed to create brief for #{lot_slug}, #{user_id}")
@@ -189,7 +190,7 @@ def create_supplier
   JSON.parse(response.body)['suppliers']
 end
 
-def create_live_service(lot_slug, supplier_id)
+def create_live_service(framework_slug, lot_slug, supplier_id)
   # Create a 15 digit service ID, miniscule clash risk
   start = 10 ** 14
   last = 10 ** 15 - 1
@@ -212,6 +213,7 @@ def create_live_service(lot_slug, supplier_id)
 
   service_data['services']['id'] = random_service_id
   service_data['services']['supplierId'] = supplier_id
+  service_data['services']['frameworkSlug'] = framework_slug
 
   service_path = "/services/#{random_service_id}"
   response = call_api(:put, service_path, payload: service_data)

--- a/features/support/fixtures.rb
+++ b/features/support/fixtures.rb
@@ -1,9 +1,9 @@
 module Fixtures
   DIGITAL_SPECIALISTS_SERVICE = {
-    # ID's should be updated within the step this fixture is used in.
+    # `nil` values should be updated within the step when this fixture is used
     id: nil,
     supplierId: nil,
-    frameworkSlug: 'digital-outcomes-and-specialists',
+    frameworkSlug: nil,
     lot: 'digital-specialists',
     developerLocations: [
         "London",
@@ -18,10 +18,10 @@ module Fixtures
   }
 
   DIGITAL_OUTCOMES_SERVICE = {
-    # ID's should be updated within the step this fixture is used in.
+    # `nil` values should be updated within the step when this fixture is used
     id: nil,
     supplierId: nil,
-    frameworkSlug: 'digital-outcomes-and-specialists',
+    frameworkSlug: nil,
     lot: 'digital-outcomes',
     bespokeSystemInformation: true,
     dataProtocols: true,
@@ -37,10 +37,10 @@ module Fixtures
   }
 
   USER_RESEARCH_PARTICIPANTS_SERVICE = {
-    # ID's should be updated within the step this fixture is used in.
+    # `nil` values should be updated within the step when this fixture is used
     id: nil,
     supplierId: nil,
-    frameworkSlug: 'digital-outcomes-and-specialists',
+    frameworkSlug: nil,
     lot: 'user-research-participants',
     anonymousRecruitment: true,
     locations: [
@@ -55,10 +55,10 @@ module Fixtures
   }
 
   DIGITAL_SPECIALISTS_BRIEF = {
-    frameworkSlug: 'digital-outcomes-and-specialists',
-    lot: 'digital-specialists',
-    # ID's should be updated within the step this fixture is used in.
+    # `nil` values should be updated within the step when this fixture is used
+    frameworkSlug: nil,
     userId: nil,
+    lot: 'digital-specialists',
     culturalFitCriteria: [
       "Just a great guy gal",
       "blah blah"
@@ -92,10 +92,10 @@ module Fixtures
   }
 
   DIGITAL_OUTCOMES_BRIEF = {
-    frameworkSlug: "digital-outcomes-and-specialists",
-    lot: "digital-outcomes",
-    # ID's should be updated within the step this fixture is used in.
+    # `nil` values should be updated within the step when this fixture is used
+    frameworkSlug: nil,
     userId: nil,
+    lot: "digital-outcomes",
     backgroundInformation: "Some background information.",
     budgetRange: "The range of the budget",
     culturalFitCriteria: [
@@ -133,10 +133,10 @@ module Fixtures
   }
 
   USER_RESEARCH_PARTICIPANTS_BRIEF = {
-    frameworkSlug: "digital-outcomes-and-specialists",
-    lot: "user-research-participants",
-    # ID's should be updated within the step this fixture is used in.
+    # `nil` values should be updated within the step when this fixture is used
+    frameworkSlug: nil,
     userId: nil,
+    lot: "user-research-participants",
     culturalWeighting: 20,
     essentialRequirements: [
       "The horses must have four hooves",
@@ -168,7 +168,9 @@ module Fixtures
   }
 
   DIGITAL_SPECIALISTS_BRIEF_RESPONSE = {
-    # ID's should be updated within the step this fixture is used in.
+    # `nil` values should be updated within the step when this fixture is used
+    frameworkSlug: nil,
+    userId: nil,
     briefId: nil,
     supplierId: nil,
     availability: "27/12/17",


### PR DESCRIPTION
At the moment we hardcode 'digital-outcomes-and-specialists' into our code and fixtures. This causes issues as we now move to DOS2. Instead of changing the hardcodings to be DOS2 (which throws it's own set of issues because functional tests run on both preview and staging environments which may have frameworks in different states), we make our tests take the first DOS framework
which is live. This way we don't need to worry about framework states across our environments.

 ✨  ✨  ✨  ✨  ✨  ✨  ✨  ✨  ✨  ✨  ✨  ✨  ✨  ✨  ✨  ✨  ✨  ✨  ✨  ✨ 
These tests pass on my local with both DOS1 live and expired.
These tests pass on preview with DOS1 live. 
✨  ✨  ✨  ✨  ✨  ✨  ✨  ✨  ✨  ✨  ✨  ✨  ✨  ✨  ✨  ✨  ✨  ✨  ✨  ✨ 