### PR TITLE
Remove DOS1 framework agreement admin uploading tests

### DIFF
--- a/features/admin/admin_journey.feature
+++ b/features/admin/admin_journey.feature
@@ -158,13 +158,6 @@ Scenario: As an admin user I want to change the supplier name of a current suppl
   And I click 'Save'
   Then I am presented with the 'Suppliers' page with the changed supplier name 'DM Functional Test Supplier 2 name changed' listed on the page
 
-Scenario: Most recently uploaded agreements should be shown last: Digital Outcomes and Specialists
-  Given I have logged in to Digital Marketplace as a 'Administrator' user
-  When a 'digital-outcomes-and-specialists-2' signed agreement is uploaded for supplier '11111'
-  And a 'digital-outcomes-and-specialists-2' signed agreement is uploaded for supplier '11112'
-  When I click 'Digital Outcomes and Specialists 2 agreements'
-  Then the last signed agreement should be for supplier 'DM Functional Test Supplier 2 name changed'
-
 Scenario: Re-uploading an agreement brings it to the bottom of the list: G-Cloud 7
   Given I have logged in to Digital Marketplace as a 'Administrator' user
   When a 'g-cloud-7' signed agreement is uploaded for supplier '11111'

--- a/features/admin/ccs_sourcing_admin_journey.feature
+++ b/features/admin/ccs_sourcing_admin_journey.feature
@@ -37,14 +37,6 @@ Scenario: Most recently uploaded agreements should be shown last: G-Cloud 7
   When I click 'G-Cloud 7 agreements'
   Then the last signed agreement should be for supplier 'DM Functional Test Supplier 2'
 
-Scenario: Re-uploading an agreement brings it to the bottom of the list: Digital Outcomes and Specialists
-  Given I have logged in to Digital Marketplace as a 'CCS Sourcing' user
-  When a 'digital-outcomes-and-specialists-2' signed agreement is uploaded for supplier '11111'
-  And a 'digital-outcomes-and-specialists-2' signed agreement is uploaded for supplier '11112'
-  And a 'digital-outcomes-and-specialists-2' signed agreement is uploaded for supplier '11111'
-  When I click 'Digital Outcomes and Specialists 2 agreements'
-  Then the last signed agreement should be for supplier 'DM Functional Test Supplier'
-
 Scenario: CCS Sourcing should not have access to Administrator specific pages
   Given I have logged in to Digital Marketplace as a 'CCS Sourcing' user
   Then There is no 'Digital Outcomes and Specialists communications' link

--- a/features/support/api_helpers.rb
+++ b/features/support/api_helpers.rb
@@ -57,9 +57,9 @@ def create_and_sign_framework_agreement(framework_slug, supplier_id)
       "agreement" => {"signedAgreementPath" => "digitalmarketplace-agreements-preview-preview/#{framework_slug}/agreements/#{supplier_id}/signed-framework-agreement.pdf"},
       "updated_by" => "functional tests"
   })
-  response2.code.should be(200), _error(response, "Failed to add document path to agreement for #{supplier_id} #{framework_slug}")
+  response2.code.should be(200), _error(response2, "Failed to add document path to agreement for #{supplier_id} #{framework_slug}")
   response3 = call_api(:post, "/agreements/#{agreement_id}/sign", payload: {"updated_by" => "functional tests"})
-  response3.code.should be(200), _error(response, "Failed to sign agreement for #{supplier_id} #{framework_slug}")
+  response3.code.should be(200), _error(response3, "Failed to sign agreement for #{supplier_id} #{framework_slug}")
 end
 
 def register_interest_in_framework(framework_slug, supplier_id)


### PR DESCRIPTION
This behaviour does not exist for DOS2 due to changes in the framework agreement signing process.

As DOS1 is expiring, we will naturally no longer be using this functionality for DOS1 and therefore we remove these tests.