### PR TITLE
Add random string to supplier name

### DIFF
--- a/features/support/api_helpers.rb
+++ b/features/support/api_helpers.rb
@@ -175,7 +175,7 @@ def create_supplier
   response = call_api(:post, "/suppliers", payload: {
     updated_by: "functional tests",
     suppliers: {
-      name: 'functional test supplier',
+      name: 'functional test supplier ' + random_string,
       dunsNumber: rand(9999999999).to_s,
       contactInformation: [
         {


### PR DESCRIPTION
For this bug on Pivotal: [https://www.pivotaltracker.com/story/show/140326163](https://www.pivotaltracker.com/story/show/140326163)

All suppliers were being created with the same name, which made the
functional tests a little shakey when searching by supplier name.

Adding a random string to the end of the supplier name will make sure
that they're all special snowflakes.

The random string is the same as already used for the suppliers contact
name and email which should make them easy to identify.