### PR TITLE
Create users with standard password

### DIFF
--- a/features/step_definitions/login_steps.rb
+++ b/features/step_definitions/login_steps.rb
@@ -16,7 +16,7 @@ end
 
 Given /^I have a ([a-z-]+) user(?: with supplier id (\d*))?$/ do |user_role, supplier_id|
   randomString = SecureRandom.hex
-  password = SecureRandom.hex
+  password = ENV["DM_PRODUCTION_#{user_role.upcase.gsub('-', '_')}_USER_PASSWORD"]
 
   user_data = {
     "emailAddress" => randomString + '@example.gov.uk',


### PR DESCRIPTION
For this chore on Pivotal: [https://www.pivotaltracker.com/story/show/139941307](https://www.pivotaltracker.com/story/show/139941307)

Users were being created with a random password which is unhelpful. Now
we know what it is.

Have run the tests locally and all is well.