### PR TITLE
Swap classnames for selected radios and checkboxes

### DIFF
--- a/features/step_definitions/journey_test_steps.rb
+++ b/features/step_definitions/journey_test_steps.rb
@@ -906,7 +906,7 @@ Then /The service status is set as '(.*)'$/ do |service_status|
   elsif current_url.include?('admin')
     find(
       :xpath,
-      "//*[contains(text(), 'Service status')]/following-sibling::*[@class='selection-button selection-button-selected'][text()]"
+      "//*[contains(text(), 'Service status')]/following-sibling::*[@class='selection-button selected'][text()]"
     ).text().should have_content(service_status)
   end
 end

--- a/features/step_definitions/setup_steps.rb
+++ b/features/step_definitions/setup_steps.rb
@@ -92,7 +92,7 @@ def update_and_check_status (service_status)
   }
   current_service_status = page.find(
     :xpath,
-    "//*[contains(text(), 'Service status')]/following-sibling::*[@class='selection-button selection-button-selected'][text()]"
+    "//*[contains(text(), 'Service status')]/following-sibling::*[@class='selection-button selected'][text()]"
   ).text()
 end
 
@@ -101,7 +101,7 @@ def service_status_public (service_id)
   page.should have_content('Service status')
   current_service_status = ''
   while current_service_status != 'Public'
-    current_service_status = page.find(:xpath,"//*[contains(text(), 'Service status')]/following-sibling::*[@class='selection-button selection-button-selected'][text()]").text()
+    current_service_status = page.find(:xpath,"//*[contains(text(), 'Service status')]/following-sibling::*[@class='selection-button selected'][text()]").text()
     if current_service_status == 'Removed'
       update_and_check_status("Private")
     elsif current_service_status == 'Private'
@@ -175,7 +175,7 @@ And /^The test suppliers have declarations$/ do
   path = "/suppliers/11111/frameworks/g-cloud-7/declaration"
   response = call_api(:put, path, payload: payload)
   response.code.should be(200), response.body
-  
+
   declaration = JSON.parse(File.read("./fixtures/digital-outcomes-and-specialists-2-declaration.json"))
   payload = {
     "declaration" => declaration,


### PR DESCRIPTION
As mentioned in the CHANGELOG for the frontend toolkit.

Version [20.0.0](https://github.com/alphagov/digitalmarketplace-frontend-toolkit/blob/master/CHANGELOG.md#2000)

We've changed a classname in our markup so now the tests need to select other things.