### PR TITLE
Use class contains rather than explicit string

### DIFF
--- a/features/step_definitions/journey_test_steps.rb
+++ b/features/step_definitions/journey_test_steps.rb
@@ -906,7 +906,7 @@ Then /The service status is set as '(.*)'$/ do |service_status|
   elsif current_url.include?('admin')
     find(
       :xpath,
-      "//*[contains(text(), 'Service status')]/following-sibling::*[@class='selection-button selected'][text()]"
+      "//*[contains(text(), 'Service status')]/following-sibling::*[contains(@class, 'selection-button') and contains(@class ,'selected')][text()]"
     ).text().should have_content(service_status)
   end
 end

--- a/features/step_definitions/setup_steps.rb
+++ b/features/step_definitions/setup_steps.rb
@@ -92,7 +92,7 @@ def update_and_check_status (service_status)
   }
   current_service_status = page.find(
     :xpath,
-    "//*[contains(text(), 'Service status')]/following-sibling::*[@class='selection-button selected'][text()]"
+    "//*[contains(text(), 'Service status')]/following-sibling::*[contains(@class, 'selection-button') and contains(@class ,'selected')][text()]"
   ).text()
 end
 
@@ -101,7 +101,7 @@ def service_status_public (service_id)
   page.should have_content('Service status')
   current_service_status = ''
   while current_service_status != 'Public'
-    current_service_status = page.find(:xpath,"//*[contains(text(), 'Service status')]/following-sibling::*[@class='selection-button selected'][text()]").text()
+    current_service_status = page.find(:xpath,"//*[contains(text(), 'Service status')]/following-sibling::*[contains(@class, 'selection-button') and contains(@class ,'selected')][text()]").text()
     if current_service_status == 'Removed'
       update_and_check_status("Private")
     elsif current_service_status == 'Private'


### PR DESCRIPTION
So our radio buttons can have additional classes without breaking our tests (e.g. an updated front end toolkit).