### PR TITLE
Add tests for suppliers not eligible to apply for a brief

### DIFF
--- a/features/buyer/requirements.feature
+++ b/features/buyer/requirements.feature
@@ -1,4 +1,4 @@
-@requirements
+@requirements @skip
 Feature: Create and publish a requirement
   In order to find individuals and teams that can provide the needed services
   As a buyer within government

--- a/features/step_definitions/brief_response_steps.rb
+++ b/features/step_definitions/brief_response_steps.rb
@@ -33,8 +33,8 @@ Given 'that supplier is on that framework' do
   submit_supplier_declaration(@framework['slug'], @supplier["id"], {})
 end
 
-Given /^that supplier has a service on the (.*) lot$/ do |lot_slug|
-  @service = create_live_service(@framework['slug'], lot_slug, @supplier["id"])
+Given /^that supplier has a service on the (.*) lot(?: for the (.*) role)?$/ do |lot_slug, role_type|
+  @service = create_live_service(@framework['slug'], lot_slug, @supplier["id"], role_type)
 end
 
 Given 'that supplier has a user' do

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -226,3 +226,12 @@ Then /^I see the '(.*)' radio button is checked(?: for the '(.*)' question)?$/ d
     page.find_field("#{radio_button_name}").should be_checked
   end
 end
+
+Then /^I see '(.*)' text on the page/ do |expected_text|
+  all(:xpath, "//*[normalize-space() = '#{expected_text}']").length.should >= 1
+end
+
+Then /^I see a '(.*)' attribute with the value '(.*)'/ do |attribute_name, attribute_value|
+  place = "//*[@#{attribute_name} = '#{attribute_value}']"
+  all(:xpath, place).length.should == 1
+end

--- a/features/supplier/brief_response.feature
+++ b/features/supplier/brief_response.feature
@@ -3,14 +3,47 @@ Feature: Supplier applies for a brief
 
 Background:
   Given I have a live digital outcomes and specialists framework
-    And I have a buyer
-    And I have a supplier
-    And that supplier is on that framework
-    And that supplier has a user
-    And that supplier user is logged in
+  And I have a buyer
+  And I have a live digital-specialists brief
+  And I have a supplier
+  And that supplier has a user
+  And that supplier user is logged in
 
+@not-eligible-for-brief-response
+Scenario: Supplier is not eligible as they are not on the framework
+  Given I go to that brief page
+  And I go to that brief page
+  And I click 'Apply'
+  Then I am on 'You can’t apply for this opportunity' page
+  And I see 'You can’t apply for this opportunity because you’re not a Digital Outcomes and Specialists 2 supplier.' text on the page
+  And I see a 'data-reason' attribute with the value 'supplier-not-on-digital-outcomes-and-specialists-2'
+
+@not-eligible-for-brief-response
+Scenario: Supplier is not eligible as they are not on the digital-specialists lot
+  Given that supplier is on that framework
+  And that supplier has a service on the digital-outcomes lot
+  And I go to that brief page
+  And I go to that brief page
+  And I click 'Apply'
+  Then I am on 'You can’t apply for this opportunity' page
+  And I see 'You can’t apply for this opportunity because you didn’t say you could provide services in this category when you applied to the Digital Outcomes and Specialists 2 framework.' text on the page
+  And I see a 'data-reason' attribute with the value 'supplier-not-on-lot'
+
+@not-eligible-for-brief-response
+Scenario: Supplier is not eligible as they can not provide the developer role
+  Given that supplier is on that framework
+  And that supplier has a service on the digital-specialists lot for the designer role
+  And I go to that brief page
+  And I go to that brief page
+  And I click 'Apply'
+  Then I am on 'You can’t apply for this opportunity' page
+  And I see 'You can’t apply for this opportunity because you didn’t say you could provide this specialist role when you applied to the Digital Outcomes and Specialists 2 framework.' text on the page
+  And I see a 'data-reason' attribute with the value 'supplier-not-on-role'
+
+@eligible-for-brief-response
 Scenario: Supplier applies for a digital-specialists brief
-  Given that supplier has a service on the digital-specialists lot
+  Given that supplier is on that framework
+    And that supplier has a service on the digital-specialists lot
     And I have a live digital-specialists brief
     And I go to that brief page
     And I click 'Apply'
@@ -61,8 +94,10 @@ Scenario: Supplier applies for a digital-specialists brief
       | Sip quietly                         | Second nice to have evidence |
       | Provide biscuits                    |                              |
 
+@eligible-for-brief-response
 Scenario: Supplier applies for a digital-outcomes brief
-  Given that supplier has a service on the digital-outcomes lot
+  Given that supplier is on that framework
+    And that supplier has a service on the digital-outcomes lot
     And I have a live digital-outcomes brief
     And I go to that brief page
     And I click 'Apply'
@@ -104,8 +139,10 @@ Scenario: Supplier applies for a digital-outcomes brief
       | Be able to count to 100 really really quickly. |                                 |
       | Have a nice smile                              | Takes just over 100 seconds     |
 
+@eligible-for-brief-response
 Scenario: Supplier applies for a user-research-participants brief
-  Given that supplier has a service on the user-research-participants lot
+  Given that supplier is on that framework
+    And that supplier has a service on the user-research-participants lot
     And I have a live user-research-participants brief
     And I go to that brief page
     And I click 'Apply'
@@ -149,8 +186,10 @@ Scenario: Supplier applies for a user-research-participants brief
       | Being good at jumping over fences  | No jump is too high. |
       | Saying "Neigh"                     | NEIGH                |
 
+@eligible-for-brief-response
 Scenario: Previous page links are used during response flow and existing data is replayed
-  Given that supplier has a service on the digital-specialists lot
+  Given that supplier is on that framework
+    And that supplier has a service on the digital-specialists lot
     And I have a live digital-specialists brief
     And that supplier has filled in their application but not submitted it
   When I visit the 'Respond to email address' question page for that brief response
@@ -179,8 +218,10 @@ Scenario: Previous page links are used during response flow and existing data is
     And I see '27/12/17' as the value of the 'availability' field
     And I don't see the 'Back to previous page' link
 
+@eligible-for-brief-response
 Scenario: Supplier changes their answers before submission
-  Given that supplier has a service on the digital-specialists lot
+  Given that supplier is on that framework
+    And that supplier has a service on the digital-specialists lot
     And I have a live digital-specialists brief
     And that supplier has filled in their application but not submitted it
     And I go to that brief page

--- a/features/supplier/brief_response.feature
+++ b/features/supplier/brief_response.feature
@@ -9,7 +9,6 @@ Background:
   And that supplier has a user
   And that supplier user is logged in
 
-@not-eligible-for-brief-response
 Scenario: Supplier is not eligible as they are not on the framework
   Given I go to that brief page
   And I click 'Apply'
@@ -17,7 +16,6 @@ Scenario: Supplier is not eligible as they are not on the framework
   And I see 'You can’t apply for this opportunity because you’re not a Digital Outcomes and Specialists 2 supplier.' text on the page
   And I see a 'data-reason' attribute with the value 'supplier-not-on-digital-outcomes-and-specialists-2'
 
-@not-eligible-for-brief-response
 Scenario: Supplier is not eligible as they are not on the digital-specialists lot
   Given that supplier is on that framework
   And that supplier has a service on the digital-outcomes lot
@@ -28,7 +26,6 @@ Scenario: Supplier is not eligible as they are not on the digital-specialists lo
   And I see 'You can’t apply for this opportunity because you didn’t say you could provide services in this category when you applied to the Digital Outcomes and Specialists 2 framework.' text on the page
   And I see a 'data-reason' attribute with the value 'supplier-not-on-lot'
 
-@not-eligible-for-brief-response
 Scenario: Supplier is not eligible as they can not provide the developer role
   Given that supplier is on that framework
   And that supplier has a service on the digital-specialists lot for the designer role
@@ -39,7 +36,7 @@ Scenario: Supplier is not eligible as they can not provide the developer role
   And I see 'You can’t apply for this opportunity because you didn’t say you could provide this specialist role when you applied to the Digital Outcomes and Specialists 2 framework.' text on the page
   And I see a 'data-reason' attribute with the value 'supplier-not-on-role'
 
-@eligible-for-brief-response
+@skip
 Scenario: Supplier applies for a digital-specialists brief
   Given that supplier is on that framework
   And that supplier has a service on the digital-specialists lot
@@ -93,7 +90,7 @@ Scenario: Supplier applies for a digital-specialists brief
       | Sip quietly                         | Second nice to have evidence |
       | Provide biscuits                    |                              |
 
-@eligible-for-brief-response
+@skip
 Scenario: Supplier applies for a digital-outcomes brief
   Given that supplier is on that framework
   And that supplier has a service on the digital-outcomes lot
@@ -138,7 +135,7 @@ Scenario: Supplier applies for a digital-outcomes brief
       | Be able to count to 100 really really quickly. |                                 |
       | Have a nice smile                              | Takes just over 100 seconds     |
 
-@eligible-for-brief-response
+@skip
 Scenario: Supplier applies for a user-research-participants brief
   Given that supplier is on that framework
   And that supplier has a service on the user-research-participants lot
@@ -185,7 +182,7 @@ Scenario: Supplier applies for a user-research-participants brief
       | Being good at jumping over fences  | No jump is too high. |
       | Saying "Neigh"                     | NEIGH                |
 
-@eligible-for-brief-response
+@skip
 Scenario: Previous page links are used during response flow and existing data is replayed
   Given that supplier is on that framework
   And that supplier has a service on the digital-specialists lot
@@ -217,7 +214,7 @@ Scenario: Previous page links are used during response flow and existing data is
   And I see '27/12/17' as the value of the 'availability' field
   And I don't see the 'Back to previous page' link
 
-@eligible-for-brief-response
+@skip
 Scenario: Supplier changes their answers before submission
   Given that supplier is on that framework
   And that supplier has a service on the digital-specialists lot

--- a/features/supplier/brief_response.feature
+++ b/features/supplier/brief_response.feature
@@ -12,7 +12,6 @@ Background:
 @not-eligible-for-brief-response
 Scenario: Supplier is not eligible as they are not on the framework
   Given I go to that brief page
-  And I go to that brief page
   And I click 'Apply'
   Then I am on 'You can’t apply for this opportunity' page
   And I see 'You can’t apply for this opportunity because you’re not a Digital Outcomes and Specialists 2 supplier.' text on the page

--- a/features/supplier/brief_response.feature
+++ b/features/supplier/brief_response.feature
@@ -43,52 +43,52 @@ Scenario: Supplier is not eligible as they can not provide the developer role
 @eligible-for-brief-response
 Scenario: Supplier applies for a digital-specialists brief
   Given that supplier is on that framework
-    And that supplier has a service on the digital-specialists lot
-    And I have a live digital-specialists brief
-    And I go to that brief page
-    And I click 'Apply'
-    Then I am on 'Apply for ‘Tea drinker’' page
+  And that supplier has a service on the digital-specialists lot
+  And I have a live digital-specialists brief
+  And I go to that brief page
+  And I click 'Apply'
+  Then I am on 'Apply for ‘Tea drinker’' page
   When I click 'Start application'
-    Then I am on 'When is the earliest the specialist can start work?' page
-    And I see 'The buyer needs the specialist to start: 31/12/2016' replayed in the question advice
+  Then I am on 'When is the earliest the specialist can start work?' page
+  And I see 'The buyer needs the specialist to start: 31/12/2016' replayed in the question advice
   When I enter '27/12/17' in the 'availability' field
-    And I click 'Continue'
-    Then I am on the 'What’s the specialist’s day rate?' page
-    And I see '£200' replayed in the question advice
+  And I click 'Continue'
+  Then I am on the 'What’s the specialist’s day rate?' page
+  And I see '£200' replayed in the question advice
   When I enter '200' in the 'dayRate' field
-    And I click 'Continue'
-    Then I am on the 'Do you have all the essential skills and experience?' page
+  And I click 'Continue'
+  Then I am on the 'Do you have all the essential skills and experience?' page
   When I choose 'Yes' radio button
-    And I click 'Continue'
-    Then I am on the 'Give evidence of the essential skills and experience' page
+  And I click 'Continue'
+  Then I am on the 'Give evidence of the essential skills and experience' page
   When I enter 'first evidence' in the 'Boil kettle' field
-    And I enter 'second evidence' in the 'Taste tea' field
-    And I enter 'third evidence' in the 'Wash mug' field
-    And I enter 'fourth evidence' in the 'Dry mug' field
-    And I click 'Continue'
-    Then I am on the 'Do you have any of the nice-to-have skills or experience?' page
+  And I enter 'second evidence' in the 'Taste tea' field
+  And I enter 'third evidence' in the 'Wash mug' field
+  And I enter 'fourth evidence' in the 'Dry mug' field
+  And I click 'Continue'
+  Then I am on the 'Do you have any of the nice-to-have skills or experience?' page
   When I choose 'Yes' radio button for the 'Talk snobbishly about water quality' question
-    And I enter 'First nice to have evidence' in the 'Evidence of Talk snobbishly about water quality' field
-    And I choose 'Yes' radio button for the 'Sip quietly' question
-    And I enter 'Second nice to have evidence' in the 'Evidence of Sip quietly' field
-    And I choose 'No' radio button for the 'Provide biscuits' question
-    And I click 'Continue'
-    Then I am on the 'Email address the buyer should use to contact you' page
+  And I enter 'First nice to have evidence' in the 'Evidence of Talk snobbishly about water quality' field
+  And I choose 'Yes' radio button for the 'Sip quietly' question
+  And I enter 'Second nice to have evidence' in the 'Evidence of Sip quietly' field
+  And I choose 'No' radio button for the 'Provide biscuits' question
+  And I click 'Continue'
+  Then I am on the 'Email address the buyer should use to contact you' page
   When I enter 'example-email@gov.uk' in the 'respondToEmailAddress' field
-    And I click 'Submit application'
-    Then I am on the 'Your application for ‘Tea drinker’' page
-    And I see the 'Your details' summary table filled with:
+  And I click 'Submit application'
+  Then I am on the 'Your application for ‘Tea drinker’' page
+  And I see the 'Your details' summary table filled with:
       | field               | value                |
       | Day rate            | £200                 |
       | Earliest start date | 27/12/17             |
       | Email address       | example-email@gov.uk |
-    And I see the 'Your essential skills and experience' summary table filled with:
+  And I see the 'Your essential skills and experience' summary table filled with:
       | field       | value           |
       | Boil kettle | first evidence  |
       | Taste tea   | second evidence |
       | Wash mug    | third evidence  |
       | Dry mug     | fourth evidence |
-    And I see the 'Your nice-to-have skills and experience' summary table filled with:
+  And I see the 'Your nice-to-have skills and experience' summary table filled with:
       | field                               | value |
       | Talk snobbishly about water quality | First nice to have evidence  |
       | Sip quietly                         | Second nice to have evidence |
@@ -97,43 +97,43 @@ Scenario: Supplier applies for a digital-specialists brief
 @eligible-for-brief-response
 Scenario: Supplier applies for a digital-outcomes brief
   Given that supplier is on that framework
-    And that supplier has a service on the digital-outcomes lot
-    And I have a live digital-outcomes brief
-    And I go to that brief page
-    And I click 'Apply'
-    Then I am on 'Apply for ‘Hide and seek ninjas’' page
+  And that supplier has a service on the digital-outcomes lot
+  And I have a live digital-outcomes brief
+  And I go to that brief page
+  And I click 'Apply'
+  Then I am on 'Apply for ‘Hide and seek ninjas’' page
   When I click 'Start application'
-    Then I am on 'When is the earliest the team can start?' page
-    And I see 'The buyer needs the team to start: 28/09/2017' replayed in the question advice
+  Then I am on 'When is the earliest the team can start?' page
+  And I see 'The buyer needs the team to start: 28/09/2017' replayed in the question advice
   When I enter '09/09/17' in the 'availability' field
-    And I click 'Continue'
-    Then I am on the 'Do you have all the essential skills and experience?' page
+  And I click 'Continue'
+  Then I am on the 'Do you have all the essential skills and experience?' page
   When I choose 'Yes' radio button
-    And I click 'Continue'
-    Then I am on the 'Give evidence of the essential skills and experience' page
+  And I click 'Continue'
+  Then I am on the 'Give evidence of the essential skills and experience' page
   When I enter 'I know all the rules' in the 'Understand the rules.' field
-    And I enter 'I know the best hiding' in the 'Hide dead good.' field
-    And I click 'Continue'
-    Then I am on the 'Do you have any of the nice-to-have skills or experience?' page
+  And I enter 'I know the best hiding' in the 'Hide dead good.' field
+  And I click 'Continue'
+  Then I am on the 'Do you have any of the nice-to-have skills or experience?' page
   When I choose 'Yes' radio button for the 'Be invisible.' question
-    And I enter 'You can see right through them.' in the 'Evidence of Be invisible.' field
-    And I choose 'No' radio button for the 'Be able to count to 100 really really quickly.' question
-    And I choose 'Yes' radio button for the 'Have a nice smile' question
-    And I enter 'Takes just over 100 seconds' in the 'Evidence of Have a nice smile' field
-    And I click 'Continue'
-    Then I am on the 'Email address the buyer should use to contact you' page
+  And I enter 'You can see right through them.' in the 'Evidence of Be invisible.' field
+  And I choose 'No' radio button for the 'Be able to count to 100 really really quickly.' question
+  And I choose 'Yes' radio button for the 'Have a nice smile' question
+  And I enter 'Takes just over 100 seconds' in the 'Evidence of Have a nice smile' field
+  And I click 'Continue'
+  Then I am on the 'Email address the buyer should use to contact you' page
   When I enter 'example-email@gov.uk' in the 'respondToEmailAddress' field
-    And I click 'Submit application'
-    Then I am on the 'Your application for ‘Hide and seek ninjas’' page
-    And I see the 'Your details' summary table filled with:
+  And I click 'Submit application'
+  Then I am on the 'Your application for ‘Hide and seek ninjas’' page
+  And I see the 'Your details' summary table filled with:
       | field               | value                |
       | Earliest start date | 09/09/17             |
       | Email address       | example-email@gov.uk |
-    And I see the 'Your essential skills and experience' summary table filled with:
+  And I see the 'Your essential skills and experience' summary table filled with:
       | field                 | value                  |
       | Understand the rules. | I know all the rules   |
       | Hide dead good.       | I know the best hiding |
-    And I see the 'Your nice-to-have skills and experience' summary table filled with:
+  And I see the 'Your nice-to-have skills and experience' summary table filled with:
       | field                                          | value                           |
       | Be invisible.                                  | You can see right through them. |
       | Be able to count to 100 really really quickly. |                                 |
@@ -142,45 +142,45 @@ Scenario: Supplier applies for a digital-outcomes brief
 @eligible-for-brief-response
 Scenario: Supplier applies for a user-research-participants brief
   Given that supplier is on that framework
-    And that supplier has a service on the user-research-participants lot
-    And I have a live user-research-participants brief
-    And I go to that brief page
-    And I click 'Apply'
-    Then I am on 'Apply for ‘I need horses.’' page
+  And that supplier has a service on the user-research-participants lot
+  And I have a live user-research-participants brief
+  And I go to that brief page
+  And I click 'Apply'
+  Then I am on 'Apply for ‘I need horses.’' page
   When I click 'Start application'
-    Then I am on 'When is the earliest you can recruit participants?' page
-    And I see 'The buyer needs participants: January to April' replayed in the question advice
+  Then I am on 'When is the earliest you can recruit participants?' page
+  And I see 'The buyer needs participants: January to April' replayed in the question advice
   When I enter '09/09/17' in the 'availability' field
-    And I click 'Continue'
-    Then I am on the 'Do you have all the essential skills and experience?' page
+  And I click 'Continue'
+  Then I am on the 'Do you have all the essential skills and experience?' page
   When I choose 'Yes' radio button
-    And I click 'Continue'
-    Then I am on the 'Give evidence of the essential skills and experience' page
+  And I click 'Continue'
+  Then I am on the 'Give evidence of the essential skills and experience' page
   When I enter 'They have the correct number of hooves.' in the 'The horses must have four hooves' field
-    And I enter 'So shiny...' in the 'The horses must have lovely coats' field
-    And I enter 'All at least 50' in the 'The horses must be many hands tall' field
-    And I click 'Continue'
-    Then I am on the 'Do you have any of the nice-to-have skills or experience?' page
+  And I enter 'So shiny...' in the 'The horses must have lovely coats' field
+  And I enter 'All at least 50' in the 'The horses must be many hands tall' field
+  And I click 'Continue'
+  Then I am on the 'Do you have any of the nice-to-have skills or experience?' page
   When I choose 'No' radio button for the 'Liking sugar lumps' question
-    And I choose 'Yes' radio button for the 'Being good at jumping over fences' question
-    And I enter 'No jump is too high.' in the 'Evidence of Being good at jumping over fences' field
-    And I choose 'Yes' radio button for the 'Saying "Neigh"' question
-    And I enter 'NEIGH' in the 'Evidence of Saying "Neigh"' field
-    And I click 'Continue'
-    Then I am on the 'Email address the buyer should use to contact you' page
+  And I choose 'Yes' radio button for the 'Being good at jumping over fences' question
+  And I enter 'No jump is too high.' in the 'Evidence of Being good at jumping over fences' field
+  And I choose 'Yes' radio button for the 'Saying "Neigh"' question
+  And I enter 'NEIGH' in the 'Evidence of Saying "Neigh"' field
+  And I click 'Continue'
+  Then I am on the 'Email address the buyer should use to contact you' page
   When I enter 'example-email@gov.uk' in the 'respondToEmailAddress' field
-    And I click 'Submit application'
-    Then I am on the 'Your application for ‘I need horses.’' page
-    And I see the 'Your details' summary table filled with:
+  And I click 'Submit application'
+  Then I am on the 'Your application for ‘I need horses.’' page
+  And I see the 'Your details' summary table filled with:
       | field               | value                |
       | Earliest start date | 09/09/17             |
       | Email address       | example-email@gov.uk |
-    And I see the 'Your essential skills and experience' summary table filled with:
+  And I see the 'Your essential skills and experience' summary table filled with:
       | field                              | value                                   |
       | The horses must have four hooves   | They have the correct number of hooves. |
       | The horses must have lovely coats  | So shiny...                             |
       | The horses must be many hands tall | All at least 50                         |
-    And I see the 'Your nice-to-have skills and experience' summary table filled with:
+  And I see the 'Your nice-to-have skills and experience' summary table filled with:
       | field                              | value                |
       | Liking sugar lumps                 |                      |
       | Being good at jumping over fences  | No jump is too high. |
@@ -189,93 +189,93 @@ Scenario: Supplier applies for a user-research-participants brief
 @eligible-for-brief-response
 Scenario: Previous page links are used during response flow and existing data is replayed
   Given that supplier is on that framework
-    And that supplier has a service on the digital-specialists lot
-    And I have a live digital-specialists brief
-    And that supplier has filled in their application but not submitted it
+  And that supplier has a service on the digital-specialists lot
+  And I have a live digital-specialists brief
+  And that supplier has filled in their application but not submitted it
   When I visit the 'Respond to email address' question page for that brief response
-    And I click 'Back to previous page' link
+  And I click 'Back to previous page' link
   Then I am on 'Do you have any of the nice-to-have skills or experience?' page
-    And I see the 'Yes' radio button is checked for the 'Talk snobbishly about water quality' question
-    And I see 'First nice to have evidence' as the value of the 'Evidence of Talk snobbishly about water quality' field
-    And I see the 'Yes' radio button is checked for the 'Sip quietly' question
-    And I see 'Second nice to have evidence' as the value of the 'Evidence of Sip quietly' field
-    And I see the 'No' radio button is checked for the 'Provide biscuits' question
-    And I do not see the 'Evidence of Provide biscuits' field
+  And I see the 'Yes' radio button is checked for the 'Talk snobbishly about water quality' question
+  And I see 'First nice to have evidence' as the value of the 'Evidence of Talk snobbishly about water quality' field
+  And I see the 'Yes' radio button is checked for the 'Sip quietly' question
+  And I see 'Second nice to have evidence' as the value of the 'Evidence of Sip quietly' field
+  And I see the 'No' radio button is checked for the 'Provide biscuits' question
+  And I do not see the 'Evidence of Provide biscuits' field
   When I click 'Back to previous page' link
   Then I am on 'Give evidence of the essential skills and experience' page
-    And I see 'first evidence' as the value of the 'Boil kettle' field
-    And I see 'second evidence' as the value of the 'Taste tea' field
-    And I see 'third evidence' as the value of the 'Wash mug' field
-    And I see 'fourth evidence' as the value of the 'Dry mug' field
+  And I see 'first evidence' as the value of the 'Boil kettle' field
+  And I see 'second evidence' as the value of the 'Taste tea' field
+  And I see 'third evidence' as the value of the 'Wash mug' field
+  And I see 'fourth evidence' as the value of the 'Dry mug' field
   When I click 'Back to previous page' link
   Then I am on 'Do you have all the essential skills and experience?' page
-    And I see the 'Yes' radio button is checked
+  And I see the 'Yes' radio button is checked
   When I click 'Back to previous page' link
   Then I am on 'What’s the specialist’s day rate?' page
-    And I see '200' as the value of the 'dayRate' field
+  And I see '200' as the value of the 'dayRate' field
   When I click 'Back to previous page' link
   Then I am on 'When is the earliest the specialist can start work?' page
-    And I see '27/12/17' as the value of the 'availability' field
-    And I don't see the 'Back to previous page' link
+  And I see '27/12/17' as the value of the 'availability' field
+  And I don't see the 'Back to previous page' link
 
 @eligible-for-brief-response
 Scenario: Supplier changes their answers before submission
   Given that supplier is on that framework
-    And that supplier has a service on the digital-specialists lot
-    And I have a live digital-specialists brief
-    And that supplier has filled in their application but not submitted it
-    And I go to that brief page
-    And I click 'Apply'
+  And that supplier has a service on the digital-specialists lot
+  And I have a live digital-specialists brief
+  And that supplier has filled in their application but not submitted it
+  And I go to that brief page
+  And I click 'Apply'
   Then I am on 'Apply for ‘Tea drinker’' page
   When I click 'Continue application'
   Then I am on 'When is the earliest the specialist can start work?' page
-    And I see 'The buyer needs the specialist to start: 31/12/2016' replayed in the question advice
-    And I see '27/12/17' as the value of the 'availability' field
+  And I see 'The buyer needs the specialist to start: 31/12/2016' replayed in the question advice
+  And I see '27/12/17' as the value of the 'availability' field
   When I enter '28/09/17' in the 'availability' field
-    And I click 'Continue'
+  And I click 'Continue'
   Then I am on the 'What’s the specialist’s day rate?' page
-    And I see '£200' replayed in the question advice
-    And I see '200' as the value of the 'dayRate' field
+  And I see '£200' replayed in the question advice
+  And I see '200' as the value of the 'dayRate' field
   When I enter '100' in the 'dayRate' field
-    And I click 'Continue'
+  And I click 'Continue'
   Then I am on the 'Do you have all the essential skills and experience?' page
   When I click 'Continue'
   Then I am on the 'Give evidence of the essential skills and experience' page
-    And I see 'first evidence' as the value of the 'Boil kettle' field
-    And I see 'second evidence' as the value of the 'Taste tea' field
-    And I see 'third evidence' as the value of the 'Wash mug' field
-    And I see 'fourth evidence' as the value of the 'Dry mug' field
+  And I see 'first evidence' as the value of the 'Boil kettle' field
+  And I see 'second evidence' as the value of the 'Taste tea' field
+  And I see 'third evidence' as the value of the 'Wash mug' field
+  And I see 'fourth evidence' as the value of the 'Dry mug' field
   When I enter 'Flick the switch' in the 'Boil kettle' field
-    And I enter 'Drink the tea' in the 'Taste tea' field
-    And I enter 'Use soap' in the 'Wash mug' field
-    And I click 'Continue'
+  And I enter 'Drink the tea' in the 'Taste tea' field
+  And I enter 'Use soap' in the 'Wash mug' field
+  And I click 'Continue'
   Then I am on the 'Do you have any of the nice-to-have skills or experience?' page
-    And I see the 'Yes' radio button is checked for the 'Talk snobbishly about water quality' question
-    And I see 'First nice to have evidence' as the value of the 'Evidence of Talk snobbishly about water quality' field
-    And I see the 'Yes' radio button is checked for the 'Sip quietly' question
-    And I see 'Second nice to have evidence' as the value of the 'Evidence of Sip quietly' field
-    And I see the 'No' radio button is checked for the 'Provide biscuits' question
-    And I do not see the 'Evidence of Provide biscuits' field
+  And I see the 'Yes' radio button is checked for the 'Talk snobbishly about water quality' question
+  And I see 'First nice to have evidence' as the value of the 'Evidence of Talk snobbishly about water quality' field
+  And I see the 'Yes' radio button is checked for the 'Sip quietly' question
+  And I see 'Second nice to have evidence' as the value of the 'Evidence of Sip quietly' field
+  And I see the 'No' radio button is checked for the 'Provide biscuits' question
+  And I do not see the 'Evidence of Provide biscuits' field
   When I choose 'No' radio button for the 'Sip quietly' question
-    And I choose 'Yes' radio button for the 'Provide biscuits' question
-    And I enter 'Only the finest' in the 'Evidence of Provide biscuits' field
-    And I click 'Continue'
+  And I choose 'Yes' radio button for the 'Provide biscuits' question
+  And I enter 'Only the finest' in the 'Evidence of Provide biscuits' field
+  And I click 'Continue'
   Then I am on the 'Email address the buyer should use to contact you' page
   When I enter 'example-email@gov.uk' in the 'respondToEmailAddress' field
-    And I click 'Submit application'
+  And I click 'Submit application'
   Then I am on the 'Your application for ‘Tea drinker’' page
-    And I see the 'Your details' summary table filled with:
+  And I see the 'Your details' summary table filled with:
       | field               | value                |
       | Day rate            | £100                 |
       | Earliest start date | 28/09/17             |
       | Email address       | example-email@gov.uk |
-    And I see the 'Your essential skills and experience' summary table filled with:
+  And I see the 'Your essential skills and experience' summary table filled with:
       | field       | value            |
       | Boil kettle | Flick the switch |
       | Taste tea   | Drink the tea    |
       | Wash mug    | Use soap         |
       | Dry mug     | fourth evidence  |
-    And I see the 'Your nice-to-have skills and experience' summary table filled with:
+  And I see the 'Your nice-to-have skills and experience' summary table filled with:
       | field                               | value |
       | Talk snobbishly about water quality | First nice to have evidence |
       | Sip quietly                         |                             |

--- a/features/support/api_helpers.rb
+++ b/features/support/api_helpers.rb
@@ -190,7 +190,7 @@ def create_supplier
   JSON.parse(response.body)['suppliers']
 end
 
-def create_live_service(framework_slug, lot_slug, supplier_id)
+def create_live_service(framework_slug, lot_slug, supplier_id, role=nil)
   # Create a 15 digit service ID, miniscule clash risk
   start = 10 ** 14
   last = 10 ** 15 - 1
@@ -209,6 +209,12 @@ def create_live_service(framework_slug, lot_slug, supplier_id)
       service_data['services'] = Fixtures::USER_RESEARCH_PARTICIPANTS_SERVICE
     else
       puts 'Lot slug not recoginsed'
+  end
+
+  if lot_slug == 'digital-specialists' and role
+    service_data['services']["#{role}Locations".to_sym] = service_data['services'].delete(:developerLocations)
+    service_data['services']["#{role}PriceMax".to_sym] = service_data['services'].delete(:developerPriceMax)
+    service_data['services']["#{role}PriceMin".to_sym] = service_data['services'].delete(:developerPriceMin)
   end
 
   service_data['services']['id'] = random_service_id

--- a/features/support/api_helpers.rb
+++ b/features/support/api_helpers.rb
@@ -211,15 +211,18 @@ def create_live_service(framework_slug, lot_slug, supplier_id, role=nil)
       puts 'Lot slug not recoginsed'
   end
 
+  # Set attributes not included in the fixture
+  service_data['services']['id'] = random_service_id
+  service_data['services']['supplierId'] = supplier_id
+  service_data['services']['frameworkSlug'] = framework_slug
+
   if lot_slug == 'digital-specialists' and role
+    # Override the specialist role from the fixture by removing the old developer keys and adding keys
+    # for the new role using the original developer values
     service_data['services']["#{role}Locations".to_sym] = service_data['services'].delete(:developerLocations)
     service_data['services']["#{role}PriceMax".to_sym] = service_data['services'].delete(:developerPriceMax)
     service_data['services']["#{role}PriceMin".to_sym] = service_data['services'].delete(:developerPriceMin)
   end
-
-  service_data['services']['id'] = random_service_id
-  service_data['services']['supplierId'] = supplier_id
-  service_data['services']['frameworkSlug'] = framework_slug
 
   service_path = "/services/#{random_service_id}"
   response = call_api(:put, service_path, payload: service_data)


### PR DESCRIPTION
For this pivotal story - https://www.pivotaltracker.com/story/show/130019195

As we are moving from integration tests for this behaviour in the supplier front end app (see this PR - https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/635 for how and why we are doing this) we add functional tests to cover this behaviour for the main use case

To add the 3 tests for when suppliers aren't eligible this PR:
- adds ability to define the role for a digital specialists service
- adds ability to check a string of text is found at least once anywhere on the page
- adds ability to check if one element is found with an attribute with a certain value. Example usage being 'data-reason' tags which are used by the frontend to send custom dimensions to google
analytics

Tests will fail until this bug fix PR (https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/655) is merged and deployed to PROD.

They will also not be run on jenkins because we are currently excluding all `@brief-response` tests - https://github.gds/gds/digitalmarketplace-jenkins/blob/master/job_definitions/functional_tests.yml#L104
We could change this jenkins job to only exclude the `@eligible-for-brief-response` tests or we could use a different tagging structure like `@skip`. Thoughts?

We might also want to add a test for a supplier trying to apply to a brief they've already applied for (they should be redirected to their response instead).

#### Question
The tests rely on on a DOS2 hardcoding when looking for things such as 'data-reason' attribute values. Is this OK or should we go to the effort now of making them framework independant and taking their value from the `I have a live digital outcomes and specialists framework` step.

#### Question: 
`Then /^I see a '(.*)' attribute with the value '(.*)'/`
or
`Then /^I see an element with a '(.*)' attribute with the value '(.*)'/ `