### PR TITLE
Replace regularly failing opportunity filtering step

### DIFF
--- a/features/step_definitions/opportunities_steps.rb
+++ b/features/step_definitions/opportunities_steps.rb
@@ -19,22 +19,6 @@ Then (/^I see an opportunity in the search results$/) do
   page.should have_selector(:css, ".search-result")
 end
 
-Then (/^I see that brief in one of the pages that follow from clicking '(.*)'$/) do |next_link_label|
-  until page.all(:xpath, "//*[@class='search-result'][.//h2//a[contains(@href, '#{@brief['id']}')]]").any? { |sr_element|
-    # now refine with a much more precise test
-    sr_element.all(:css, "h2.search-result-title > a").any? { |a_element|
-      a_element.text == normalize_whitespace(@brief['title'])
-    } and sr_element.all(:css, ".search-result-metadata-item").any? { |mi_element|
-      mi_element.text == normalize_whitespace(@brief['organisation'])
-    } and sr_element.all(:css, ".search-result-metadata-item").any? { |mi_element|
-      mi_element.text == normalize_whitespace(@brief['lotName'])
-    }
-  }
-    page.click_link(next_link_label)
-    # if there wasn't another matching "next" link we should have errored out above
-  end
-end
-
 Then (/^I see that the stated number of results does not exceed that (\w+)$/) do |variable_name|
   var = instance_variable_get("@#{variable_name}")
   page.first(:css, ".search-summary-count").text.to_i.should <= var
@@ -43,4 +27,26 @@ end
 Then (/^I see that the stated number of results equals that (\w+)$/) do |variable_name|
   var = instance_variable_get("@#{variable_name}")
   var.should == page.first(:css, ".search-summary-count").text.to_i
+end
+
+Then (/^I see all the opportunities on the page are on the '(.*)' lot$/) do |lot|
+  lots_found = all(
+    :xpath,
+    '//*[@class="search-result"]//*[@class="search-result-metadata"][1]//*[@class="search-result-metadata-item"][1]'
+  )
+  lots_found.each { |x| x.text.should == lot }
+end
+
+Then (/^I see all the opportunities on the page are of the '(.*)' status$/) do |status|
+  published_or_closed = all(
+    :xpath,
+    '//*[@class="search-result"]//*[@class="search-result-metadata"][2]//*[@class="search-result-metadata-item"][1]'
+  )
+  published_or_closed.each do |x|
+    if status == 'Closed'
+      x.text.should == 'Closed'
+    else
+      x.text.include?("Published").should be true
+    end
+  end
 end

--- a/features/supplier/opportunities.feature
+++ b/features/supplier/opportunities.feature
@@ -1,4 +1,4 @@
-@smoke-tests
+@smoke-tests @opportunities
 Feature: Passive opportunity supplier journey
 
 Scenario: User can see the main links on the homepage
@@ -11,59 +11,56 @@ Scenario: User can click through to opportunities page
   Then I am on the 'Digital Outcomes and Specialists opportunities' page
   And I see an opportunity in the search results
 
-Scenario: User is able have specific opportunity search result returned
-  Given I am on the /digital-outcomes-and-specialists/opportunities page
-  And I have a random dos brief from the API
-  Then I see that brief in one of the pages that follow from clicking 'Next page'
-
-Scenario: User is able to filter by lot and have specific result returned
-  Given I am on the /digital-outcomes-and-specialists/opportunities page
-  And I have a random dos brief from the API
-  When I check that brief.lotName checkbox
-  And I click the 'Filter' button
-  Then I see that brief in one of the pages that follow from clicking 'Next page'
-
-Scenario: User is able to filter by status and have specific result returned
-  Given I am on the /digital-outcomes-and-specialists/opportunities page
-  And I have a random dos brief from the API
-  When I check that brief.statusLabel checkbox
-  And I click the 'Filter' button
-  Then I see that brief in one of the pages that follow from clicking 'Next page'
-
-Scenario: User is able to filter by both status and lot and have specific result returned
-  Given I am on the /digital-outcomes-and-specialists/opportunities page
-  And I have a random dos brief from the API
-  When I check that brief.lotName checkbox
-  When I check that brief.statusLabel checkbox
-  And I click the 'Filter' button
-  Then I see that brief in one of the pages that follow from clicking 'Next page'
-
 Scenario: User is able to navigate to opportunity detail page via selecting the opportunity from the search results
   Given I am on the /digital-outcomes-and-specialists/opportunities page
   When I click a random result in the list of opportunity results returned
   Then I am on that result.title page
 
-Scenario: Filtering by lot doesn't increase result count
+Scenario Outline: User can filter by individual lot
   Given I am on the /digital-outcomes-and-specialists/opportunities page
   When I note the result_count
-  And I check a random 'lot' checkbox
+  And I check '<lot>' checkbox
   And I click the 'Filter' button
   Then I see that the stated number of results does not exceed that result_count
+  And I see all the opportunities on the page are on the '<lot>' lot
 
-Scenario: Filtering by status doesn't increase result count
-  Given I am on the /digital-outcomes-and-specialists/opportunities page
-  When I note the result_count
-  And I check a random 'status' checkbox
-  And I click the 'Filter' button
-  Then I see that the stated number of results does not exceed that result_count
+  Examples:
+    | lot                        |
+    | Digital specialists        |
+    | Digital outcomes           |
+    | User research participants |
 
-Scenario: Filtering by both status and lot doesn't increase result count
+Scenario Outline: User can filter by individual status
   Given I am on the /digital-outcomes-and-specialists/opportunities page
   When I note the result_count
-  And I check a random 'status' checkbox
-  And I check a random 'lot' checkbox
+  And I check '<status>' checkbox
   And I click the 'Filter' button
   Then I see that the stated number of results does not exceed that result_count
+  And I see all the opportunities on the page are of the '<status>' status
+
+  Examples:
+    | status |
+    | Open   |
+    | Closed |
+
+Scenario Outline: User can filter by both status and lot
+  Given I am on the /digital-outcomes-and-specialists/opportunities page
+  When I note the result_count
+  And I check '<lot>' checkbox
+  And I check '<status>' checkbox
+  And I click the 'Filter' button
+  Then I see that the stated number of results does not exceed that result_count
+  And I see all the opportunities on the page are on the '<lot>' lot
+  And I see all the opportunities on the page are of the '<status>' status
+
+  Examples:
+    | lot                        | status   |
+    | Digital specialists        | Open     |
+    | Digital outcomes           | Open     |
+    | User research participants | Open     |
+    | Digital specialists        | Closed   |
+    | Digital outcomes           | Closed   |
+    | User research participants | Closed   |
 
 Scenario: Checking all lots returns all results
   Given I am on the /digital-outcomes-and-specialists/opportunities page


### PR DESCRIPTION
For this pivotal story - https://www.pivotaltracker.com/story/show/141321125

The `I see that brief in one of the pages that follow from clicking` step has been failing often. This is because it loops through many pages after another until it finds the result and pages may randomly break for example during a deployment. This generally doesn't cause the actual jenkins job to fail because it reruns automatically but does make our tests a bit flakey. Therefore I have removed tests that use this step and added assertions that all the briefs returned on the first page of filtering match the correct status and/or lot.

I decided to check all possible options rather than pick a random status or lot. This makes the tests slightly more rigerous in case the environment only contains briefs of a certain lot or status on the first page (e.g. the first page is entirely open briefs).