### PR TITLE
Get @brief-response test working again

### DIFF
--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -220,12 +220,13 @@ Then /^I see the '(.*)' summary table filled with:$/ do |table_heading, table|
 end
 
 Then /^I see the '(.*)' radio button is checked(?: for the '(.*)' question)?$/ do |radio_button_name, question|
+  options = {:visible => :all}
   if question
     within(:xpath, "//span[normalize-space(text())='#{question}']/../..") do
-      page.find_field("#{radio_button_name}").should be_checked
+      page.find_field("#{radio_button_name}", options).should be_checked
     end
   else
-    page.find_field("#{radio_button_name}").should be_checked
+    page.find_field("#{radio_button_name}", options).should be_checked
   end
 end
 

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -107,12 +107,14 @@ When /I check #{MAYBE_VAR} checkbox$/ do |checkbox_label|
 end
 
 When /I choose #{MAYBE_VAR} radio button(?: for the '(.*)' question)?$/ do |checkbox_label, question|
+  options = {allow_label_click: true}
+
   if question
     within(:xpath, "//span[normalize-space(text())='#{question}']/../..") do
-      choose(checkbox_label)
+      choose(checkbox_label, options)
     end
   else
-    page.choose(checkbox_label)
+    page.choose(checkbox_label, options)
   end
 end
 

--- a/features/supplier/brief_response.feature
+++ b/features/supplier/brief_response.feature
@@ -20,7 +20,6 @@ Scenario: Supplier is not eligible as they are not on the digital-specialists lo
   Given that supplier is on that framework
   And that supplier has a service on the digital-outcomes lot
   And I go to that brief page
-  And I go to that brief page
   And I click 'Apply'
   Then I am on 'You can’t apply for this opportunity' page
   And I see 'You can’t apply for this opportunity because you didn’t say you could provide services in this category when you applied to the Digital Outcomes and Specialists 2 framework.' text on the page
@@ -29,7 +28,6 @@ Scenario: Supplier is not eligible as they are not on the digital-specialists lo
 Scenario: Supplier is not eligible as they can not provide the developer role
   Given that supplier is on that framework
   And that supplier has a service on the digital-specialists lot for the designer role
-  And I go to that brief page
   And I go to that brief page
   And I click 'Apply'
   Then I am on 'You can’t apply for this opportunity' page

--- a/features/supplier/brief_response.feature
+++ b/features/supplier/brief_response.feature
@@ -34,7 +34,6 @@ Scenario: Supplier is not eligible as they can not provide the developer role
   And I see 'You can’t apply for this opportunity because you didn’t say you could provide this specialist role when you applied to the Digital Outcomes and Specialists 2 framework.' text on the page
   And I see a 'data-reason' attribute with the value 'supplier-not-on-role'
 
-@skip
 Scenario: Supplier applies for a digital-specialists brief
   Given that supplier is on that framework
   And that supplier has a service on the digital-specialists lot
@@ -88,7 +87,6 @@ Scenario: Supplier applies for a digital-specialists brief
       | Sip quietly                         | Second nice to have evidence |
       | Provide biscuits                    |                              |
 
-@skip
 Scenario: Supplier applies for a digital-outcomes brief
   Given that supplier is on that framework
   And that supplier has a service on the digital-outcomes lot
@@ -133,7 +131,6 @@ Scenario: Supplier applies for a digital-outcomes brief
       | Be able to count to 100 really really quickly. |                                 |
       | Have a nice smile                              | Takes just over 100 seconds     |
 
-@skip
 Scenario: Supplier applies for a user-research-participants brief
   Given that supplier is on that framework
   And that supplier has a service on the user-research-participants lot
@@ -180,7 +177,6 @@ Scenario: Supplier applies for a user-research-participants brief
       | Being good at jumping over fences  | No jump is too high. |
       | Saying "Neigh"                     | NEIGH                |
 
-@skip
 Scenario: Previous page links are used during response flow and existing data is replayed
   Given that supplier is on that framework
   And that supplier has a service on the digital-specialists lot
@@ -212,7 +208,6 @@ Scenario: Previous page links are used during response flow and existing data is
   And I see '27/12/17' as the value of the 'availability' field
   And I don't see the 'Back to previous page' link
 
-@skip
 Scenario: Supplier changes their answers before submission
   Given that supplier is on that framework
   And that supplier has a service on the digital-specialists lot

--- a/features/support/api_helpers.rb
+++ b/features/support/api_helpers.rb
@@ -118,17 +118,17 @@ def submit_supplier_declaration(framework_slug, supplier_id, declaration)
   JSON.parse(response.body)['declaration']
 end
 
-def create_brief(framework_slug, lot_slug, user_id)  
+def create_brief(framework_slug, lot_slug, user_id)
   brief_data = {
     updated_by: "functional tests"
   }
   case lot_slug
   when 'digital-specialists'
-    brief_data['briefs'] = Fixtures::DIGITAL_SPECIALISTS_BRIEF
+    brief_data['briefs'] = Fixtures.digital_specialists_brief
   when 'digital-outcomes'
-    brief_data['briefs'] = Fixtures::DIGITAL_OUTCOMES_BRIEF
+    brief_data['briefs'] = Fixtures.digital_outcomes_brief
   when 'user-research-participants'
-    brief_data['briefs'] = Fixtures::USER_RESEARCH_PARTICIPANTS_BRIEF
+    brief_data['briefs'] = Fixtures.user_research_participants_brief
   else
     puts 'Lot slug not recognised'
   end
@@ -147,7 +147,7 @@ def create_brief_response(lot_slug, brief_id, supplier_id)
   }
   case lot_slug
   when 'digital-specialists'
-    brief_response_data['briefResponses'] = Fixtures::DIGITAL_SPECIALISTS_BRIEF_RESPONSE
+    brief_response_data['briefResponses'] = Fixtures.digital_specialists_brief_response
   else
     puts 'Lot slug not recognised'
   end
@@ -202,11 +202,11 @@ def create_live_service(framework_slug, lot_slug, supplier_id, role=nil)
 
   case lot_slug
     when 'digital-specialists'
-      service_data['services'] = Fixtures::DIGITAL_SPECIALISTS_SERVICE
+      service_data['services'] = Fixtures.digital_specialists_service
     when 'digital-outcomes'
-      service_data['services'] = Fixtures::DIGITAL_OUTCOMES_SERVICE
+      service_data['services'] = Fixtures.digital_outcomes_service
     when 'user-research-participants'
-      service_data['services'] = Fixtures::USER_RESEARCH_PARTICIPANTS_SERVICE
+      service_data['services'] = Fixtures.user_research_participants_service
     else
       puts 'Lot slug not recoginsed'
   end

--- a/features/support/fixtures.rb
+++ b/features/support/fixtures.rb
@@ -1,192 +1,207 @@
 module Fixtures
-  DIGITAL_SPECIALISTS_SERVICE = {
-    # `nil` values should be updated within the step when this fixture is used
-    id: nil,
-    supplierId: nil,
-    frameworkSlug: nil,
-    lot: 'digital-specialists',
-    developerLocations: [
+
+  def self.digital_specialists_service
+    return {
+      # `nil` values should be updated within the step when this fixture is used
+      id: nil,
+      supplierId: nil,
+      frameworkSlug: nil,
+      lot: 'digital-specialists',
+      developerLocations: [
+          "London",
+          "Scotland"
+        ],
+      developerPriceMax: "200",
+      developerPriceMin: "100",
+      bespokeSystemInformation: true,
+      dataProtocols: true,
+      helpGovernmentImproveServices: true,
+      openStandardsPrinciples: true
+    }
+  end
+
+  def self.digital_outcomes_service
+    return {
+      # `nil` values should be updated within the step when this fixture is used
+      id: nil,
+      supplierId: nil,
+      frameworkSlug: nil,
+      lot: 'digital-outcomes',
+      bespokeSystemInformation: true,
+      dataProtocols: true,
+      deliveryTypes: [
+        "Agile coaching"
+      ],
+      helpGovernmentImproveServices: true,
+      locations: [
         "London",
         "Scotland"
       ],
-    developerPriceMax: "200",
-    developerPriceMin: "100",
-    bespokeSystemInformation: true,
-    dataProtocols: true,
-    helpGovernmentImproveServices: true,
-    openStandardsPrinciples: true
-  }
+      openStandardsPrinciples: true,
+    }
+  end
 
-  DIGITAL_OUTCOMES_SERVICE = {
-    # `nil` values should be updated within the step when this fixture is used
-    id: nil,
-    supplierId: nil,
-    frameworkSlug: nil,
-    lot: 'digital-outcomes',
-    bespokeSystemInformation: true,
-    dataProtocols: true,
-    deliveryTypes: [
-      "Agile coaching"
-    ],
-    helpGovernmentImproveServices: true,
-    locations: [
-      "London",
-      "Scotland"
-    ],
-    openStandardsPrinciples: true,
-  }
+  def self.user_research_participants_service
+    return {
+      # `nil` values should be updated within the step when this fixture is used
+      id: nil,
+      supplierId: nil,
+      frameworkSlug: nil,
+      lot: 'user-research-participants',
+      anonymousRecruitment: true,
+      locations: [
+        "London",
+        "Scotland"
+      ],
+      manageIncentives: true,
+      recruitFromList: true,
+      recruitMethods: [
+        "Entirely offline"
+      ]
+    }
+  end
 
-  USER_RESEARCH_PARTICIPANTS_SERVICE = {
-    # `nil` values should be updated within the step when this fixture is used
-    id: nil,
-    supplierId: nil,
-    frameworkSlug: nil,
-    lot: 'user-research-participants',
-    anonymousRecruitment: true,
-    locations: [
-      "London",
-      "Scotland"
-    ],
-    manageIncentives: true,
-    recruitFromList: true,
-    recruitMethods: [
-      "Entirely offline"
-    ]
-  }
+  def self.digital_specialists_brief
+    return {
+      # `nil` values should be updated within the step when this fixture is used
+      frameworkSlug: nil,
+      userId: nil,
+      lot: 'digital-specialists',
+      culturalFitCriteria: [
+        "Just a great guy gal",
+        "blah blah"
+      ],
+      culturalWeighting: 5,
+      essentialRequirements: [
+        "Boil kettle",
+        "Taste tea",
+        "Wash mug",
+        "Dry mug"
+      ],
+      existingTeam: "Lots of us",
+      location: "London",
+      niceToHaveRequirements: [
+        "Talk snobbishly about water quality",
+        "Sip quietly",
+        "Provide biscuits"
+      ],
+      numberOfSuppliers: 3,
+      organisation: "NAO",
+      priceWeighting: 20,
+      requirementsLength: "2 weeks",
+      specialistRole: "developer",
+      specialistWork: "Drink tea",
+      startDate: "31\/12\/2016",
+      summary: "Drink lots of tea. Brew kettle.",
+      technicalWeighting: 75,
+      title: "Tea drinker",
+      workingArrangements: "Hard work",
+      workplaceAddress: "London",
+    }
+  end
 
-  DIGITAL_SPECIALISTS_BRIEF = {
-    # `nil` values should be updated within the step when this fixture is used
-    frameworkSlug: nil,
-    userId: nil,
-    lot: 'digital-specialists',
-    culturalFitCriteria: [
-      "Just a great guy gal",
-      "blah blah"
-    ],
-    culturalWeighting: 5,
-    essentialRequirements: [
-      "Boil kettle",
-      "Taste tea",
-      "Wash mug",
-      "Dry mug"
-    ],
-    existingTeam: "Lots of us",
-    location: "London",
-    niceToHaveRequirements: [
-      "Talk snobbishly about water quality",
-      "Sip quietly",
-      "Provide biscuits"
-    ],
-    numberOfSuppliers: 3,
-    organisation: "NAO",
-    priceWeighting: 20,
-    requirementsLength: "2 weeks",
-    specialistRole: "developer",
-    specialistWork: "Drink tea",
-    startDate: "31\/12\/2016",
-    summary: "Drink lots of tea. Brew kettle.",
-    technicalWeighting: 75,
-    title: "Tea drinker",
-    workingArrangements: "Hard work",
-    workplaceAddress: "London",
-  }
+  def self.digital_outcomes_brief
+    return {
+      # `nil` values should be updated within the step when this fixture is used
+      frameworkSlug: nil,
+      userId: nil,
+      lot: "digital-outcomes",
+      backgroundInformation: "Some background information.",
+      budgetRange: "The range of the budget",
+      culturalFitCriteria: [
+        "Must be up in work at the crack of dawn every day.",
+        "Must love a good game of hide and seek."
+      ],
+      culturalWeighting: 5,
+      endUsers: "Tout le monde",
+      essentialRequirements: [
+        "Understand the rules.",
+        "Hide dead good.",
+      ],
+      existingTeam: "Lots of us",
+      location: "London",
+      niceToHaveRequirements: [
+        "Be invisible.",
+        "Be able to count to 100 really really quickly.",
+        "Have a nice smile"
+      ],
+      numberOfSuppliers: 3,
+      organisation: "The Big Hide And Seek Company",
+      outcome: "A thingy to do a thingy",
+      phase: "beta",
+      priceCriteria: "Fixed price",
+      priceWeighting: 20,
+      startDate: "28\/09\/2017",
+      successCriteria: [
+        "The thingy works"
+      ],
+      summary: "A team of exceptional hide and seek players.",
+      technicalWeighting: 75,
+      title: "Hide and seek ninjas",
+      workingArrangements: "You work.",
+      workplaceAddress: "Wherever we send you",
+    }
+  end
 
-  DIGITAL_OUTCOMES_BRIEF = {
-    # `nil` values should be updated within the step when this fixture is used
-    frameworkSlug: nil,
-    userId: nil,
-    lot: "digital-outcomes",
-    backgroundInformation: "Some background information.",
-    budgetRange: "The range of the budget",
-    culturalFitCriteria: [
-      "Must be up in work at the crack of dawn every day.",
-      "Must love a good game of hide and seek."
-    ],
-    culturalWeighting: 5,
-    endUsers: "Tout le monde",
-    essentialRequirements: [
-      "Understand the rules.",
-      "Hide dead good.",
-    ],
-    existingTeam: "Lots of us",
-    location: "London",
-    niceToHaveRequirements: [
-      "Be invisible.",
-      "Be able to count to 100 really really quickly.",
-      "Have a nice smile"
-    ],
-    numberOfSuppliers: 3,
-    organisation: "The Big Hide And Seek Company",
-    outcome: "A thingy to do a thingy",
-    phase: "beta",
-    priceCriteria: "Fixed price",
-    priceWeighting: 20,
-    startDate: "28\/09\/2017",
-    successCriteria: [
-      "The thingy works"
-    ],
-    summary: "A team of exceptional hide and seek players.",
-    technicalWeighting: 75,
-    title: "Hide and seek ninjas",
-    workingArrangements: "You work.",
-    workplaceAddress: "Wherever we send you",
-  }
+  def self.user_research_participants_brief
+    return {
+      # `nil` values should be updated within the step when this fixture is used
+      frameworkSlug: nil,
+      userId: nil,
+      lot: "user-research-participants",
+      culturalWeighting: 20,
+      essentialRequirements: [
+        "The horses must have four hooves",
+        "The horses must have lovely coats",
+        "The horses must be many hands tall"
+      ],
+      location: "London",
+      niceToHaveRequirements: [
+        "Liking sugar lumps",
+        "Being good at jumping over fences",
+        "Saying \"Neigh\""
+      ],
+      numberOfSuppliers: 3,
+      organisation: "The Horse Force",
+      participantSpecification: "Loads of horses",
+      participantsPerRound: "At least 100",
+      priceWeighting: 20,
+      researchAddress: "64 Horse Road, Horseville.",
+      researchDates: "January to April",
+      researchFrequency: "At least 60 Hz",
+      researchRounds: "Seven",
+      successCriteria: [
+        "One criterion",
+        "Another criterion"
+      ],
+      summary: "Horses are really good.",
+      technicalWeighting: 60,
+      title: "I need horses."
+    }
+  end
 
-  USER_RESEARCH_PARTICIPANTS_BRIEF = {
-    # `nil` values should be updated within the step when this fixture is used
-    frameworkSlug: nil,
-    userId: nil,
-    lot: "user-research-participants",
-    culturalWeighting: 20,
-    essentialRequirements: [
-      "The horses must have four hooves",
-      "The horses must have lovely coats",
-      "The horses must be many hands tall"
-    ],
-    location: "London",
-    niceToHaveRequirements: [
-      "Liking sugar lumps",
-      "Being good at jumping over fences",
-      "Saying \"Neigh\""
-    ],
-    numberOfSuppliers: 3,
-    organisation: "The Horse Force",
-    participantSpecification: "Loads of horses",
-    participantsPerRound: "At least 100",
-    priceWeighting: 20,
-    researchAddress: "64 Horse Road, Horseville.",
-    researchDates: "January to April",
-    researchFrequency: "At least 60 Hz",
-    researchRounds: "Seven",
-    successCriteria: [
-      "One criterion",
-      "Another criterion"
-    ],
-    summary: "Horses are really good.",
-    technicalWeighting: 60,
-    title: "I need horses."
-  }
-
-  DIGITAL_SPECIALISTS_BRIEF_RESPONSE = {
-    # `nil` values should be updated within the step when this fixture is used
-    frameworkSlug: nil,
-    userId: nil,
-    briefId: nil,
-    supplierId: nil,
-    availability: "27/12/17",
-    dayRate: "200",
-    essentialRequirements: [
-      { "evidence": "first evidence" },
-      { "evidence": "second evidence" },
-      { "evidence": "third evidence" },
-      { "evidence": "fourth evidence" },
-    ],
-    essentialRequirementsMet: true,
-    niceToHaveRequirements: [
-      { "yesNo": true, "evidence": "First nice to have evidence" },
-      { "yesNo": true, "evidence": "Second nice to have evidence" },
-      { "yesNo": false },
-    ],
-    respondToEmailAddress: "example-email@gov.uk",
-  }
+  def self.digital_specialists_brief_response
+    return {
+      # `nil` values should be updated within the step when this fixture is used
+      frameworkSlug: nil,
+      userId: nil,
+      briefId: nil,
+      supplierId: nil,
+      availability: "27/12/17",
+      dayRate: "200",
+      essentialRequirements: [
+        { "evidence": "first evidence" },
+        { "evidence": "second evidence" },
+        { "evidence": "third evidence" },
+        { "evidence": "fourth evidence" },
+      ],
+      essentialRequirementsMet: true,
+      niceToHaveRequirements: [
+        { "yesNo": true, "evidence": "First nice to have evidence" },
+        { "yesNo": true, "evidence": "Second nice to have evidence" },
+        { "yesNo": false },
+      ],
+      respondToEmailAddress: "example-email@gov.uk",
+    }
+  end
 end


### PR DESCRIPTION
**The reason the functional tests broke is that our <input> elements are invisible to selenium. [More on that here](https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/453).**

***

This pull request updates the functional tests so that the `@brief-response` scenario works again.

It does not:
- fix the brief creation test
- provide a general way to fill out fields on a page that has hidden fields
- fix all of the general radio `choose()` or checkbox `check()` functions

I've been working on the last one (there are a few functions in `common_steps.rb` around clicking random things that we're not using, it looks like), but then removed all that code for a follow-up pull request.
 