### PR TITLE
Refactor selecting radios and checkboxes in common_steps.rb

### DIFF
--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -115,7 +115,9 @@ When /I click #{MAYBE_VAR} ?(button|link)?$/ do |button_link_name, elem_type|
 end
 
 When /I check #{MAYBE_VAR} checkbox$/ do |checkbox_label|
-  page.check(checkbox_label)
+  options = {allow_label_click: true}
+
+  page.check(checkbox_label, options)
 end
 
 When /I choose #{MAYBE_VAR} radio button(?: for the '(.*)' question)?$/ do |checkbox_label, question|
@@ -131,8 +133,12 @@ When /I choose #{MAYBE_VAR} radio button(?: for the '(.*)' question)?$/ do |chec
 end
 
 When /I check a random '(.*)' checkbox$/ do |checkbox_name|
-  checkbox = all(:xpath, "//input[@type='checkbox'][@name='#{checkbox_name}']").sample
-  page.check(checkbox[:id])
+  checkbox = all(:xpath, "//input[@type='checkbox'][@name='#{checkbox_name}']", {:visible => :all}).sample
+
+  # If the label for this checkbox is not visible, it is effectively hidden from the user
+  checkbox.find_xpath('parent::label')[0].visible?.should be(true), "Expected label for checkbox \"#{checkbox.value}\" to be visible"
+
+  page.check(checkbox[:id], {allow_label_click: true})
   puts "Checkbox value: #{checkbox.value}"
 end
 
@@ -149,7 +155,14 @@ When /I choose a random '(.*)' radio button$/ do |name|
 end
 
 When /I check all '(.*)' checkboxes$/ do |checkbox_name|
-  all(:xpath, "//input[@type='checkbox'][@name='#{checkbox_name}']").each do |element| page.check(element[:id]) end
+
+  all(:xpath, "//input[@type='checkbox'][@name='#{checkbox_name}']", {:visible => :all}).each do |checkbox|
+
+    # If the label for this radio is not visible, it is effectively hidden from the user
+    checkbox.find_xpath('parent::label')[0].visible?.should be(true), "Expected label for checkbox \"#{checkbox.value}\" to be visible"
+
+    page.check(checkbox[:id], {allow_label_click: true})
+  end
 end
 
 When /^I enter a random value in the '(.*)' field( and click its associated '(.*)' button)?$/ do |field_name, maybe_click_statement, click_button_name|

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -137,8 +137,14 @@ When /I check a random '(.*)' checkbox$/ do |checkbox_name|
 end
 
 When /I choose a random '(.*)' radio button$/ do |name|
-  radio = all(:xpath, "//input[@type='radio'][@name='#{name}']").sample
-  page.choose(radio[:id])
+
+  radio = all(:xpath, "//input[@type='radio'][@name='#{name}']", {:visible => :all}).sample
+
+  # If the label for this radio is not visible, it is effectively hidden from the user
+  radio.find_xpath('parent::label')[0].visible?.should be(true), "Expected label for radio button \"#{radio.value}\" to be visible"
+
+  page.choose(radio[:id], {allow_label_click: true})
+
   puts "Radio button value: #{radio.value}"
 end
 

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -210,8 +210,8 @@ Then(/^I see the page's h1 ends in #{MAYBE_VAR}$/) do |term|
 end
 
 Then /I see #{MAYBE_VAR} as the value of the '(.*)' field$/ do |value, field|
-  if page.has_field?(field, {type: 'radio'}) or page.has_field?(field, {type: 'checkbox'})
-    page.find_field(field, {checked: true}).value.should == value
+  if page.has_field?(field, {type: 'radio', visible: :all}) or page.has_field?(field, {type: 'checkbox', visible: :all})
+    page.find_field(field, {checked: true, visible: :all}).value.should == value
   else
     page.find_field(field).value.should == value
   end


### PR DESCRIPTION
**The reason the functional tests broke is that our <input> elements are invisible to selenium. [More on that here](https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/453).**

***

**Update: pull request #269 takes this code and builds more on top of it.**

What this pull request does:

Whereas my last pull request fixed only the steps needed to get the `@brief-response` tests to work, this one fixes the rest of the steps in this file to do with radios and checkboxes and tries to do it in a way that's reasonably clean.

The generic function for choosing radios and checking checkboxes will accept either a value (as a string) or an input, and then will only select the input if its label is visible onscreen.  Since all of the inputs are hidden, the only way we can make sure that the question isn't totally hidden is by checking its parent label.  Once the label is found, the input will be clicked and its value will be printed as part of the output.

It seems to me this is a reasonable refactor, but if anyone has opinions about where this general code should go, I'm happy to listen.

What this pull request does not do:

- fix the brief creation test
- provide a general way to fill out fields on a page that has hidden fields