### PR TITLE
Fix smoke tests now that G9 is live on preview

### DIFF
--- a/features/buyer/catalogue.feature
+++ b/features/buyer/catalogue.feature
@@ -17,25 +17,12 @@ Scenario: User can click through to g-cloud page
   When I click 'Find cloud technology and support'
   Then I am on the 'Cloud technology and support' page
 
-Scenario: User can get the PaaS search results
+Scenario: User can select a lot from the g-cloud page and see search results.
   Given I am on the /g-cloud page
-  When I click 'Platform as a Service'
+  When I have a random g-cloud lot from the API
+  When I click that lot.name
   Then I am on the 'Search results' page
-  And I see the 'Platform as a Service' breadcrumb
-  And I see a search result
-
-Scenario: User can get the SaaS search results
-  Given I am on the /g-cloud page
-  When I click 'Software as a Service'
-  Then I am on the 'Search results' page
-  And I see the 'Software as a Service' breadcrumb
-  And I see a search result
-
-Scenario: User can get the IaaS search results
-  Given I am on the /g-cloud page
-  When I click 'Infrastructure as a Service'
-  Then I am on the 'Search results' page
-  And I see the 'Infrastructure as a Service' breadcrumb
+  And I see that lot.name breadcrumb
   And I see a search result
 
 Scenario: User is able to search by service id and have result returned.

--- a/features/buyer/catalogue.feature
+++ b/features/buyer/catalogue.feature
@@ -39,33 +39,32 @@ Scenario: User can get the IaaS search results
   And I see a search result
 
 Scenario: User is able to search by service id and have result returned.
-  Given I am on the /g-cloud page
+  Given I am on the /g-cloud/search page
   And I have a random g-cloud service from the API
   When I enter that service.id in the 'q' field
-  And I click 'Show services'
+  And I click 'Filter'
   Then I see that service.id in the search summary text
   And I see that service.id as the value of the 'q' field
   And I see that service in the search results
 
 Scenario: User is able to search by service name and have result returned.
-  Given I am on the /g-cloud page
+  Given I am on the /g-cloud/search page
   And I have a random g-cloud service from the API
   When I enter that quoted service.serviceName in the 'q' field
-  And I click 'Show services'
+  And I click 'Filter'
   Then I see that quoted service.serviceName in the search summary text
   And I see that quoted service.serviceName as the value of the 'q' field
   And I see that service in the search results
 
 Scenario: User is able to navigate to service detail page via selecting the service from the search results
-  Given I am on the /g-cloud page
-  When I click 'Infrastructure as a Service'
+  Given I am on the /g-cloud/search page
   Then I am on the 'Search results' page
   When I click a random result in the list of service results returned
   Then I am on that result.title page
   And I see that result.supplier_name as the page header context
 
 Scenario: User is able to search by keywords field on the search results page to narrow down the results returned
-  Given I am on the /g-cloud page
+  Given I am on the /g-cloud/search page
   And I have a random g-cloud service from the API
   When I click that service.lotName
   And I enter that service.id in the 'q' field

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -45,6 +45,17 @@ Given /^I have a random g-cloud service from the API$/ do
   puts "Service name: #{ERB::Util.h @service['serviceName']}"
 end
 
+Given /^I have a random g-cloud lot from the API$/ do
+  frameworks = call_api(:get, "/frameworks")
+  live_g_cloud_frameworks = JSON.parse(frameworks.body)["frameworks"].select {|framework|
+    framework["framework"] == "g-cloud" && framework["status"] == "live"
+  }
+  # reverse sort by whatever is after the final "-" in the framework slug
+  g_cloud_lot = live_g_cloud_frameworks.sort_by {|framework| framework["slug"].split('-')[-1] }.reverse[0]["lots"].sample
+  puts "G-Cloud lot: #{g_cloud_lot['name']}"
+  @lot = g_cloud_lot
+end
+
 # TODO merge with above step
 Given /^I have a random (?:([a-z-]+) )?supplier from the API$/ do |metaframework_slug|
   params = {}

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -167,7 +167,7 @@ When(/^I choose a random uppercase letter$/) do
   puts "letter: #{@letter}"
 end
 
-Then /^I see the '(.*)' breadcrumb$/ do |breadcrumb_text|
+Then /^I see #{MAYBE_VAR} breadcrumb$/ do |breadcrumb_text|
   breadcrumb = page.all(:xpath, "//div[@id='global-breadcrumb']/nav//li").last
   breadcrumb.text().should == breadcrumb_text
 end

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -21,13 +21,14 @@ end
 
 Given /^I have a random g-cloud service from the API$/ do
   frameworks = call_api(:get, "/frameworks")
-  live_g_cloud = JSON.parse(frameworks.body)["frameworks"].select {|framework|
+  live_g_cloud_slugs = JSON.parse(frameworks.body)["frameworks"].select {|framework|
     framework["framework"] == "g-cloud" && framework["status"] == "live"
-  }.map {|framework| framework["slug"]}.join(",")
+  }.map {|framework| framework["slug"]}
+  # reverse sort by whatever is after the final "-" in the framework slug
+  latest_g_cloud_slug = live_g_cloud_slugs.sort_by {|slug| slug.split('-')[-1] }.reverse[0]
+  puts "Latest live g-cloud framework slug: #{latest_g_cloud_slug}"
 
-  puts "Live g-cloud frameworks: #{live_g_cloud}"
-
-  params = {status: "published", framework: live_g_cloud}
+  params = {status: "published", framework: latest_g_cloud_slug}
   page_one = call_api(:get, "/services", params: params)
   page_one.code.should == 200
   last_page_url = JSON.parse(page_one.body)['links']['last']


### PR DESCRIPTION
Our buyer smoke tests broke on preview since G9 was set to "live" and the search index was repopulated with entirely G9 services.  We are still keeping G8 "live", however, as ongoing procurements will be referencing some G8 services and we don't want them to say that they're expired.

The things that broke are:
- hardcoded lot names in our buyer smoke tests don't work because the lot names for G9 have changed
- searching for a random g-cloud service from "live" G-Clouds potentially fails if G8 is live but its services aren't indexed
- looking for the search bar on the `/g-cloud` page is broken

After talking with @TheDoubleK, the solutions we've gone with are:
- use a random lot from the latest "live" G-Cloud instead of hardcoded lot names
- select random services from the latest "live" G-Cloud will always find a services that should be in the search index
- look for the search bar on the `/g-cloud/search` page

These changes generalise the functional tests so that they will work across our environments.