### PR TITLE
Skip `@skip` tagged tests when running through Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 DM_ENVIRONMENT ?= local
 
 smoke-tests: setup
-	. config/${DM_ENVIRONMENT}.sh && bundle exec cucumber --tags @smoke-tests
+	. config/${DM_ENVIRONMENT}.sh && bundle exec cucumber --tags @smoke-tests --tags ~@skip 
 
 run: setup
-	. config/${DM_ENVIRONMENT}.sh && bundle exec cucumber ${ARGS}
+	. config/${DM_ENVIRONMENT}.sh && bundle exec cucumber --tags ~@skip ${ARGS}
 
 rerun:
 	. config/${DM_ENVIRONMENT}.sh && bundle exec cucumber -p rerun

--- a/features/buyer/catalogue.feature
+++ b/features/buyer/catalogue.feature
@@ -50,6 +50,7 @@ Scenario: User is able to navigate to service detail page via selecting the serv
   Then I am on that result.title page
   And I see that result.supplier_name as the page header context
 
+@skip
 Scenario: User is able to search by keywords field on the search results page to narrow down the results returned
   Given I am on the /g-cloud/search page
   And I have a random g-cloud service from the API


### PR DESCRIPTION
We have a failing test that we wish to skip running until we have time to fix it. Therefore we tag it with the `@skip` tag and don't run any tests with this tag when running all tests or smoke
tests.

Question.
Previously we use the jenkins jobs to exclude the skip tags (https://github.gds/gds/digitalmarketplace-jenkins/blob/master/job_definitions/functional_tests.yml#L103). Should we continue that pattern and add the skip tag to the smoke tests jenkins job or use this PR and do it on the Makefile?