### PR TITLE
Stop checking for lot name for keyword search test

### DIFF
--- a/features/buyer/catalogue.feature
+++ b/features/buyer/catalogue.feature
@@ -53,7 +53,6 @@ Scenario: User is able to navigate to service detail page via selecting the serv
 Scenario: User is able to search by keywords field on the search results page to narrow down the results returned
   Given I am on the /g-cloud/search page
   And I have a random g-cloud service from the API
-  When I click that service.lotName
   And I enter that service.id in the 'q' field
   And I click 'Filter'
   Then I see that service.id in the search summary text


### PR DESCRIPTION
This test is testing that searching for an id in the search box works, it doesn't actually need to select a lot.
The previous iteration of this test started from the `/g-cloud` page, and clicking the lot would bring you to the `/g-cloud/search` page.  Since the new test is begins on the search results page, we can skip selecting a lot, which was purely navigational.