### PR TITLE
Remove G-Cloud search and filter scenarios and fix homepage wording

### DIFF
--- a/features/buyer/buyer_journey.feature
+++ b/features/buyer/buyer_journey.feature
@@ -11,69 +11,6 @@ Scenario: User is able to navigate from the digital marketplace landing page to 
   When I click the 'Find cloud technology and support' link
   Then I am taken to the 'Cloud technology and support' landing page
 
-Scenario: User selects SaaS lot from the g-cloud page is presented with search results page for SaaS lot with SaaS specific filters presented
-  Given I am on the 'Cloud technology and support' landing page
-  When I click the 'Software as a Service' link
-  Then I am taken to the search results page with results for 'Software as a Service' lot displayed
-  And All filters for 'Software as a Service' are available
-
-Scenario: User selects PaaS lot from the g-cloud page is presented with search results page for PaaS lot with PaaS specific filters presented
-  Given I am on the 'Cloud technology and support' landing page
-  When I click the 'Platform as a Service' link
-  Then I am taken to the search results page with results for 'Platform as a Service' lot displayed
-  And All filters for 'Platform as a Service' are available
-
-Scenario: User selects IaaS lot from the g-cloud page is presented with search results page for IaaS lot with IaaS specific filters presented
-  Given I am on the 'Cloud technology and support' landing page
-  When I click the 'Infrastructure as a Service' link
-  Then I am taken to the search results page with results for 'Infrastructure as a Service' lot displayed
-  And All filters for 'Infrastructure as a Service' are available
-
-Scenario: User selects SCS lot from the g-cloud page is presented with search results page for SCS lot with SCS specific filters presented
-  Given I am on the 'Cloud technology and support' landing page
-  When I click the 'Specialist Cloud Services' link
-  Then I am taken to the search results page with results for 'Specialist Cloud Services' lot displayed
-  And All filters for 'Specialist Cloud Services' are available
-
-Scenario: There is pagination on the results page if there are more than the pagination limit results
-  Given I am on the search results page with results for 'Infrastructure as a Service' lot displayed
-  When There is 'more' than the pagination limit results returned
-  Then Pagination is 'available'
-
-  When I click the 'Next page' link
-  Then I am taken to page '2' of results
-
-  When I click the 'Previous page' link
-  Then I am taken to page '1' of results
-
-Scenario: There is no pagination on the results page if there is less than or equal the pagination limit results
-  Given I am on the search results page with results for 'DM Functional Test Secure'
-  When There is 'less' than the pagination limit results returned
-  Then Pagination is 'not available'
-
-Scenario: User is able to use filter to narrow down results set
-  Given I am on the search results page with results for 'Specialist Cloud Services' lot displayed
-  When I select 'Training' as the filter value under the 'Categories' filter
-  And I click 'Filter'
-  Then The search results is narrowed down by the selected filter
-
-  When When I select 'Testing' as the filter value under the 'Categories' filter
-  And I click 'Filter'
-  Then The search results is narrowed down by the selected filter
-
-  When When I select 'Year' as the filter value under the 'Minimum contract period' filter
-  And I click 'Filter'
-  Then The search results is narrowed down by the selected filter
-
-  When When I select 'Support accessible to any third-party suppliers' as the filter value under the 'Service management' filter
-  And I click 'Filter'
-  Then The search results is narrowed down by the selected filter
-
-Scenario: User is able to navigate to service listing page via selecting the service from the search results
-  Given I am on the search results page with results for 'Platform as a Service' lot displayed
-  When I click the first record in the list of results returned
-  Then I am taken to the service listing page of that specific record selected
-
 Scenario: There is pagination on the list of suppliers page if there are more than 100 results
   Given I navigate to the list of 'Suppliers starting with S' page
   When I click the 'Next page' link

--- a/features/smoke_tests.feature
+++ b/features/smoke_tests.feature
@@ -19,48 +19,6 @@ Scenario: User is able to navigate from the digital marketplace landing page to 
   When I click the 'Find cloud technology and support' link
   Then I am taken to the 'Cloud technology and support' landing page
 
-Scenario: User selects SaaS lot from the g-cloud page is presented with search results page for SaaS lot with SaaS specific filters presented
-  Given I am on the 'Cloud technology and support' landing page
-  When I click the 'Software as a Service' link
-  Then I am taken to the search results page with results for 'Software as a Service' lot displayed
-
-Scenario: User selects PaaS lot from the g-cloud page is presented with search results page for PaaS lot with PaaS specific filters presented
-  Given I am on the 'Cloud technology and support' landing page
-  When I click the 'Platform as a Service' link
-  Then I am taken to the search results page with results for 'Platform as a Service' lot displayed
-
-Scenario: User selects IaaS lot from the g-cloud page is presented with search results page for IaaS lot with IaaS specific filters presented
-  Given I am on the 'Cloud technology and support' landing page
-  When I click the 'Infrastructure as a Service' link
-  Then I am taken to the search results page with results for 'Infrastructure as a Service' lot displayed
-
-Scenario: User selects SCS lot from the g-cloud page is presented with search results page for SCS lot with SCS specific filters presented
-  Given I am on the 'Cloud technology and support' landing page
-  When I click the 'Specialist Cloud Services' link
-  Then I am taken to the search results page with results for 'Specialist Cloud Services' lot displayed
-
-Scenario: User able to search by service ID and have result returned
-  Given I am on the 'Cloud technology and support' landing page
-  And I have a random service from the API
-  When I enter that service.id in the 'q' field
-  And I click 'Show services'
-  Then I am on a page with that service.id in search summary text
-  And There is 1 search result
-  And I am on a page with that service in search results
-
-Scenario: User is able to search by service name and have result returned.
-  Given I am on the 'Cloud technology and support' landing page
-  And I have a random service from the API
-  When I enter that service.serviceName in the 'q' field
-  And I click 'Show services'
-  Then I am on a page with that service.serviceName in search summary text
-  And I am on a page with that service in search results
-
-Scenario: User is able to navigate to service listing page via selecting the service from the search results
-  Given I am on the search results page with results for 'Platform as a Service' lot displayed
-  When I click the first record in the list of results returned
-  Then I am taken to the service listing page of that specific record selected
-
 Scenario: User able to search by keywords field on the search results page to narrow down the results returned
   Given I have a random service from the API
   Given I am on the search results page with results for that service.lot displayed

--- a/features/step_definitions/journey_test_steps.rb
+++ b/features/step_definitions/journey_test_steps.rb
@@ -959,11 +959,6 @@ end
 
 Then /I am taken to the '(.*)' landing page$/ do |page_name|
   page.should have_content("#{page_name}")
-  page.should have_button('Show services')
-  page.should have_link('Software as a Service')
-  page.should have_link('Platform as a Service')
-  page.should have_link('Infrastructure as a Service')
-  page.should have_link('Specialist Cloud Services')
   page.should have_selector(:xpath, ".//*[@id='global-breadcrumb']/nav/*[@role='breadcrumbs']/li[1]//*[contains(text(), 'Digital Marketplace')]")
   page.should have_selector(:xpath, ".//*[@id='global-breadcrumb']/nav/*[@role='breadcrumbs']/li[2][contains(text(), '#{page_name}')]")
 end

--- a/features/step_definitions/journey_test_steps.rb
+++ b/features/step_definitions/journey_test_steps.rb
@@ -963,19 +963,6 @@ Then /I am taken to the '(.*)' landing page$/ do |page_name|
   page.should have_selector(:xpath, ".//*[@id='global-breadcrumb']/nav/*[@role='breadcrumbs']/li[2][contains(text(), '#{page_name}')]")
 end
 
-Then /I am taken to the search results page with results for '(.*)' lot displayed$/ do |lot_name|
-  page.should have_selector(:xpath, ".//*[@id='global-breadcrumb']/nav/*[@role='breadcrumbs']/li[1]//*[contains(text(), 'Digital Marketplace')]")
-  page.should have_selector(:xpath, ".//*[@id='global-breadcrumb']/nav/*[@role='breadcrumbs']/li[2]//*[contains(text(), 'Cloud technology and support')]")
-  page.should have_selector(:xpath, ".//*[@id='content']//*[@class= 'page-heading']//*[contains(text(), 'Search results')]")
-  page.should have_selector(:xpath, ".//*[@id='content']//*[@class='lot-filters']//*[contains(text(), 'Choose a category')]")
-  page.should have_selector(:xpath, "//a[contains(@href, '/search') and contains(text(), 'All categories')]")
-  find(:xpath, "//*[@class='search-summary-count']").text().should_not match(/^0$/)
-  page.should have_selector(:xpath, ".//*[@id='content']//*[@class= 'search-summary']//*[contains(text(), '#{lot_name}')]")
-  page.should have_selector(:xpath, "//*/label[contains(@class, 'option-select-label') and contains(text(), 'Keywords')]")
-
-  step "Then Selected lot is '#{lot_name}' with links to the search for ''"
-end
-
 def filter_to_check(filter_name,filter_value,filter_exist)
   if "#{filter_value}" == '' and "#{filter_exist}" == 'yes'
     page.should have_selector(:xpath, "//div[contains(@class, 'option-select-label') and contains(text(), '#{filter_name}')]")
@@ -983,93 +970,6 @@ def filter_to_check(filter_name,filter_value,filter_exist)
     page.should have_no_selector(:xpath, "//div[contains(@class, 'option-select-label') and contains(text(), '#{filter_name}')]")
   else
     page.should have_selector(:xpath, "//div[contains(@class, 'option-select-label') and contains(text(), '#{filter_name}')]/../..//label[contains(text()[2], '#{filter_value}')]/input[@type='checkbox']")
-  end
-end
-
-And /All filters for '(.*)' are available$/ do |lot_name|
-  filter_to_check("Minimum contract period","","yes")
-  filter_to_check("Service management","","yes")
-  filter_to_check("Minimum contract period","Hour","")
-  filter_to_check("Minimum contract period","Day","")
-  filter_to_check("Minimum contract period","Month","")
-  filter_to_check("Minimum contract period","Year","")
-  filter_to_check("Minimum contract period","Other","")
-  filter_to_check("Service management","Support accessible to any third-party suppliers","")
-
-  if "#{lot_name.downcase}" == 'software as a service' or "#{lot_name.downcase}" == 'infrastructure as a service' or "#{lot_name.downcase}" == 'specialist cloud services'
-    filter_to_check("Categories","","yes")
-  elsif "#{lot_name.downcase}" == 'platform as a service'
-    filter_to_check("Categories","","no")
-  end
-
-  if "#{lot_name.downcase}" == 'specialist cloud services'
-    filter_to_check("Pricing","","no")
-    filter_to_check("Datacentre tier","","no")
-    filter_to_check("Networks the service is directly connected to","","no")
-    filter_to_check("Interoperability","","no")
-    filter_to_check("Categories","Implementation","")
-    filter_to_check("Categories","Ongoing support","")
-    filter_to_check("Categories","Planning","")
-    filter_to_check("Categories","Testing","")
-    filter_to_check("Categories","Training","")
-  elsif "#{lot_name.downcase}" == 'software as a service' or "#{lot_name.downcase}" == 'platform as a service' or "#{lot_name.downcase}" == 'infrastructure as a service'
-    filter_to_check("Pricing","","yes")
-    filter_to_check("Datacentre tier","","yes")
-    filter_to_check("Networks the service is directly connected to","","yes")
-    filter_to_check("Interoperability","","yes")
-    filter_to_check("Pricing","Free option","")
-    filter_to_check("Pricing","Trial option","")
-    filter_to_check("Service management","Data extraction/removal plan in place","")
-    filter_to_check("Service management","Datacentres adhere to the EU code of conduct for energy-efficient datacentres","")
-    filter_to_check("Service management","Backup, disaster recovery and resilience plan in place","")
-    filter_to_check("Service management","Self-service provisioning supported","")
-    filter_to_check("Service management","Support accessible to any third-party suppliers","")
-    filter_to_check("Datacentre tier","TIA-942 Tier 1","")
-    filter_to_check("Datacentre tier","TIA-942 Tier 2","")
-    filter_to_check("Datacentre tier","TIA-942 Tier 3","")
-    filter_to_check("Datacentre tier","TIA-942 Tier 4","")
-    filter_to_check("Datacentre tier","Uptime Institute Tier 1","")
-    filter_to_check("Datacentre tier","Uptime Institute Tier 2","")
-    filter_to_check("Datacentre tier","Uptime Institute Tier 3","")
-    filter_to_check("Datacentre tier","Uptime Institute Tier 4","")
-    filter_to_check("Datacentre tier","None of the above","")
-    filter_to_check("Networks the service is directly connected to","Internet","")
-    filter_to_check("Networks the service is directly connected to","Public Services Network (PSN)","")
-    filter_to_check("Networks the service is directly connected to","Police National Network (PNN)","")
-    filter_to_check("Networks the service is directly connected to","New NHS Network (N3)","")
-    filter_to_check("Networks the service is directly connected to","Joint Academic Network (JANET)","")
-    filter_to_check("Networks the service is directly connected to","Other","")
-    filter_to_check("Interoperability","API access available and supported","")
-    filter_to_check("Interoperability","Open standards supported and documented","")
-    filter_to_check("Interoperability","Open-source software used and supported","")
-  end
-
-  if "#{lot_name.downcase}" == 'software as a service'
-    filter_to_check("Categories","Accounting and finance","")
-    filter_to_check("Categories","Business intelligence and analytics","")
-    filter_to_check("Categories","Collaboration","")
-    filter_to_check("Categories","Creative and design","")
-    filter_to_check("Categories","Customer relationship management (CRM)","")
-    filter_to_check("Categories","Data management","")
-    filter_to_check("Categories","Electronic document and records management (EDRM)","")
-    filter_to_check("Categories","Energy and environment","")
-    filter_to_check("Categories","Healthcare","")
-    filter_to_check("Categories","Human resources and employee management","")
-    filter_to_check("Categories","IT management","")
-    filter_to_check("Categories","Legal","")
-    filter_to_check("Categories","Libraries","")
-    filter_to_check("Categories","Marketing","")
-    filter_to_check("Categories","Operations management","")
-    filter_to_check("Categories","Project management and planning","")
-    filter_to_check("Categories","Sales","")
-    filter_to_check("Categories","Schools and education","")
-    filter_to_check("Categories","Security","")
-    filter_to_check("Categories","Software development tools","")
-    filter_to_check("Categories","Telecoms","")
-    filter_to_check("Categories","Transport and logistics","")
-  elsif "#{lot_name.downcase}" == 'infrastructure as a service'
-    filter_to_check("Categories","Compute","")
-    filter_to_check("Categories","Storage","")
   end
 end
 
@@ -1147,57 +1047,17 @@ When /^I choose file '(.*)' for '(.*)'$/ do |file, label|
   attach_file(label, File.join(Dir.pwd, 'fixtures', file))
 end
 
-When /I select '(.*)' as the filter value under the '(.*)' filter$/ do |filter_value,filter_name|
-  page.find(:xpath, "//div[contains(@class, 'option-select-label') and contains(text(), '#{filter_name}')]/../..//label[contains(text()[2], '#{filter_value}')]/input[@type='checkbox']").trigger('click')
-end
-
-Then /The search results is narrowed down by the selected filter$/ do
-  current_count = find(:xpath, "//*[@class='search-summary-count']").text().to_i
-  find(:xpath, "//*[@class='search-summary-count']").text().to_i.should be < @data_store['searchsummarycount'].to_i
-  @data_store['searchsummarycount'] = current_count
-end
-
-When /I click the first record in the list of results returned$/ do
-  @data_store = @data_store || Hash.new
-  servicename = first(:xpath, ".//*[@class='search-result-title']/a").text()
-  servicesuppliername = first(:xpath, ".//p[@class='search-result-supplier']").text()
-  url = first(:xpath, ".//h2[@class='search-result-title']/a")[:href]
-  @data_store['servicename'] = servicename
-  @data_store['servicesuppliername'] = servicesuppliername
-  @data_store['url'] = url
-  page.first(:xpath, ".//*[@id='content']/*//h2/a").click
-end
-
 Given /I am on the search results page with results for '(.*)'$/ do |search_value|
   visit("#{dm_frontend_domain}/g-cloud/search?q=#{search_value.gsub(' ','+')}")
   page.find(:xpath, "//*[@class='search-summary']/em[1]").text().should match("#{search_value}")
   page.find(:xpath, "//*[@class='search-summary']/em[2]").text().should match('All categories')
 end
 
-Then /I am taken to the service listing page of that specific record selected$/ do
-  page.should have_content(@data_store['servicename'])
-  page.should have_content(@data_store['servicesuppliername'])
-  current_url.should end_with("#{dm_frontend_domain}#{@data_store['url']}")
-end
-
-When /There is '(.*)' than the pagination limit results returned$/ do |more_or_less|
-  @data_store = @data_store || Hash.new
-  current_count = find(:xpath, "//*[@class='search-summary-count']").text().to_i
-  number_of_pages = (current_count.to_f/dm_pagination_limit()).ceil
-  @data_store['currentcount'] = current_count
-  @data_store['numberofpages'] = number_of_pages
-  @data_store['moreorless'] = more_or_less
-end
-
 Then /Pagination is '(.*)'$/ do |availability|
-  if current_url.include?('search?')
-    if @data_store['currentcount'] > dm_pagination_limit() && @data_store['moreorless'] == 'more'
-      pagination_available = 'available'
-    elsif @data_store['currentcount'] <= dm_pagination_limit() && @data_store['moreorless'] == 'less'
-      pagination_available = 'not available'
-    end
-  elsif current_url.include?('suppliers?')
+  if current_url.include?('suppliers?')
     pagination_available = "#{availability}"
+  else
+    fail("Pagination check only works for the suppliers list page these days.")
   end
 
   if pagination_available == 'available'

--- a/features/step_definitions/journey_test_steps.rb
+++ b/features/step_definitions/journey_test_steps.rb
@@ -928,7 +928,7 @@ Given /I am on the '(.*)' landing page$/ do |page_name|
     page.should have_link('Find user research participants')
     page.should have_link('Find a user research lab')
     page.should have_link('Find cloud technology and support')
-    page.should have_link('Buy physical datacentre space for legacy systems')
+    page.should have_link('Buy physical datacentre space')
 
   elsif page_name == 'Cloud technology and support'
     page.visit("#{dm_frontend_domain}/g-cloud")


### PR DESCRIPTION
A couple of things here:
1. The wording of the Crown Hosting link on the homepage has changed - updated in this PR.
2. Old G-Cloud lots are no longer shown on Preview, so I've removed the scenarios that search and filter specific old G-Cloud lots.  

The removed scenarios are:
 - Scenario: User selects SaaS lot from the g-cloud page is presented with search results page for SaaS lot with SaaS specific filters presented
 - Scenario: User selects PaaS lot from the g-cloud page is presented with search results page for PaaS lot with PaaS specific filters presented
 - Scenario: User selects IaaS lot from the g-cloud page is presented with search results page for IaaS lot with IaaS specific filters presented
 - Scenario: User selects SCS lot from the g-cloud page is presented with search results page for SCS lot with SCS specific filters presented
 - Scenario: There is pagination on the results page if there are more than the pagination limit results
 - Scenario: There is no pagination on the results page if there is less than or equal the pagination limit results
 - Scenario: User is able to use filter to narrow down results set
 - Scenario: User is able to navigate to service listing page via selecting the service from the search results

These removed scenarios have **mostly** been replaced in the master branch smoketests by steps that select the "latest" G-Cloud framework and try to do some searches.  We should build out some functional test steps that do the same thing (i.e. not just smoketests), and also add filtering steps that check we reduce the count of returned services when filtering, etc. once we know how the G-9 filters are going to work.

I have run this branch against PREVIEW locally and everything is green:
:sparkles::sparkles::sparkles::sparkles::sparkles::sparkles::sparkles::sparkles::sparkles::sparkles::sparkles::sparkles::sparkles::sparkles:
![screen shot 2017-04-19 at 14 48 17](https://cloud.githubusercontent.com/assets/6525554/25183369/48636838-250f-11e7-8141-a32b0381d299.png)
:sparkles::sparkles::sparkles::sparkles::sparkles::sparkles::sparkles::sparkles::sparkles::sparkles::sparkles::sparkles::sparkles::sparkles: