### PR TITLE
Find & select new input fields

### DIFF
--- a/features/buyer/requirements.feature
+++ b/features/buyer/requirements.feature
@@ -1,4 +1,4 @@
-@requirements @skip
+@requirements
 Feature: Create and publish a requirement
   In order to find individuals and teams that can provide the needed services
   As a buyer within government

--- a/features/buyer/requirements.feature
+++ b/features/buyer/requirements.feature
@@ -38,7 +38,7 @@ Scenario: Create individual specialist requirement
 
    When I click 'Review and publish your requirements'
     And I click 'Publish requirements'
-   
+
   Then I don't see the 'Title' link
    And I don't see the 'Specialist role' link
    And I don't see the 'Location' link
@@ -47,7 +47,6 @@ Scenario: Create individual specialist requirement
    And I don't see the 'Set how long your requirements will be open for' link
    And I don't see the 'Describe question and answer session' link
    And I don't see the 'Review and publish your requirements' link
-
 
 Scenario: Create team to provide an outcome
   Given I am logged in as a buyer user

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -115,7 +115,9 @@ When /I click #{MAYBE_VAR} ?(button|link)?$/ do |button_link_name, elem_type|
 end
 
 When /I check #{MAYBE_VAR} checkbox$/ do |checkbox_label|
-  page.check(checkbox_label)
+  options = {allow_label_click: true}
+
+  page.check(checkbox_label, options)
 end
 
 When /I choose #{MAYBE_VAR} radio button(?: for the '(.*)' question)?$/ do |checkbox_label, question|
@@ -131,8 +133,12 @@ When /I choose #{MAYBE_VAR} radio button(?: for the '(.*)' question)?$/ do |chec
 end
 
 When /I check a random '(.*)' checkbox$/ do |checkbox_name|
-  checkbox = all(:xpath, "//input[@type='checkbox'][@name='#{checkbox_name}']").sample
-  page.check(checkbox[:id])
+  checkbox = all(:xpath, "//input[@type='checkbox'][@name='#{checkbox_name}']", {:visible => :all}).sample
+
+  # If the label for this checkbox is not visible, it is effectively hidden from the user
+  checkbox.find_xpath('parent::label')[0].visible?.should be(true), "Expected label for checkbox \"#{checkbox.value}\" to be visible"
+
+  page.check(checkbox[:id], {allow_label_click: true})
   puts "Checkbox value: #{checkbox.value}"
 end
 
@@ -149,7 +155,14 @@ When /I choose a random '(.*)' radio button$/ do |name|
 end
 
 When /I check all '(.*)' checkboxes$/ do |checkbox_name|
-  all(:xpath, "//input[@type='checkbox'][@name='#{checkbox_name}']").each do |element| page.check(element[:id]) end
+
+  all(:xpath, "//input[@type='checkbox'][@name='#{checkbox_name}']", {:visible => :all}).each do |checkbox|
+
+    # If the label for this radio is not visible, it is effectively hidden from the user
+    checkbox.find_xpath('parent::label')[0].visible?.should be(true), "Expected label for checkbox \"#{checkbox.value}\" to be visible"
+
+    page.check(checkbox[:id], {allow_label_click: true})
+  end
 end
 
 When /^I enter a random value in the '(.*)' field( and click its associated '(.*)' button)?$/ do |field_name, maybe_click_statement, click_button_name|

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -5,7 +5,7 @@ def choose_radio(label_or_radio, find_options={}, choose_options={})
   if label_or_radio.is_a? Capybara::Node::Element and label_or_radio[:type] == 'radio'
     radio = label_or_radio
   else
-    radio = find_field(label_or_radio, find_options.merge({visible: :all}))
+    radio = first_field(label_or_radio, find_options)
   end
 
   # If the label for this radio is not visible, it is effectively hidden from the user
@@ -19,7 +19,7 @@ def check_checkbox(label_or_checkbox, find_options={}, check_options={})
   if label_or_checkbox.is_a? Capybara::Node::Element and label_or_checkbox[:type] == 'checkbox'
     checkbox = label_or_checkbox
   else
-    checkbox = find_field(label_or_checkbox, find_options.merge({visible: :all}))
+    checkbox = first_field(label_or_checkbox, find_options)
   end
 
   # If the label for this checkbox is not visible, it is effectively hidden from the user
@@ -29,20 +29,16 @@ def check_checkbox(label_or_checkbox, find_options={}, check_options={})
   puts "Checkbox value: #{checkbox.value}"
 end
 
-def find_inputs_by_name(type, name, options={})
-  return all(:xpath, "//input[@type='#{type}'][@name='#{name}']", options.merge({visible: :all}))
-end
-
 def find_checkboxes_by_name(name, options={})
-  return find_inputs_by_name('checkbox', name, options)
+  return all_fields(name, options.merge({type: 'checkbox'}))
 end
 
 def find_radios_by_name(name, options={})
-  return find_inputs_by_name('radio', name, options)
+  return all_fields(name, options.merge({type: 'radio'}))
 end
 
 def find_radio_by_name(name, options={})
-  return find_field("#{name}", options.merge({visible: :all}))
+  return first_field(name, options.merge({type: 'radio'}))
 end
 
 Given /^I am on the homepage$/ do
@@ -276,10 +272,10 @@ end
 Then /^I see the '(.*)' radio button is checked(?: for the '(.*)' question)?$/ do |radio_button_name, question|
   if question
     within(:xpath, "//span[normalize-space(text())='#{question}']/../..") do
-      find_radio_by_name(radio_button_name).should be_checked
+      first_field(radio_button_name).should be_checked
     end
   else
-    find_radio_by_name(radio_button_name).should be_checked
+    first_field(radio_button_name).should be_checked
   end
 end
 

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -137,8 +137,14 @@ When /I check a random '(.*)' checkbox$/ do |checkbox_name|
 end
 
 When /I choose a random '(.*)' radio button$/ do |name|
-  radio = all(:xpath, "//input[@type='radio'][@name='#{name}']").sample
-  page.choose(radio[:id])
+
+  radio = all(:xpath, "//input[@type='radio'][@name='#{name}']", {:visible => :all}).sample
+
+  # If the label for this radio is not visible, it is effectively hidden from the user
+  radio.find_xpath('parent::label')[0].visible?.should be(true), "Expected label for radio button \"#{radio.value}\" to be visible"
+
+  page.choose(radio[:id], {allow_label_click: true})
+
   puts "Radio button value: #{radio.value}"
 end
 

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -210,8 +210,8 @@ Then(/^I see the page's h1 ends in #{MAYBE_VAR}$/) do |term|
 end
 
 Then /I see #{MAYBE_VAR} as the value of the '(.*)' field$/ do |value, field|
-  if page.has_field?(field, {type: 'radio'}) or page.has_field?(field, {type: 'checkbox'})
-    page.find_field(field, {checked: true}).value.should == value
+  if page.has_field?(field, {type: 'radio', visible: :all}) or page.has_field?(field, {type: 'checkbox', visible: :all})
+    page.find_field(field, {checked: true, visible: :all}).value.should == value
   else
     page.find_field(field).value.should == value
   end

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -1,34 +1,6 @@
 require 'uri'
 require 'securerandom'
 
-def choose_radio(label_or_radio, find_options={}, choose_options={})
-  if label_or_radio.is_a? Capybara::Node::Element and label_or_radio[:type] == 'radio'
-    radio = label_or_radio
-  else
-    radio = first_field(label_or_radio, find_options)
-  end
-
-  # If the label for this radio is not visible, it is effectively hidden from the user
-  radio.find_xpath('parent::label')[0].visible?.should be(true), "Expected label for radio button \"#{radio.value}\" to be visible"
-
-  choose(radio[:id], choose_options.merge({allow_label_click: true}))
-  puts "Radio button value: #{radio.value}"
-end
-
-def check_checkbox(label_or_checkbox, find_options={}, check_options={})
-  if label_or_checkbox.is_a? Capybara::Node::Element and label_or_checkbox[:type] == 'checkbox'
-    checkbox = label_or_checkbox
-  else
-    checkbox = first_field(label_or_checkbox, find_options)
-  end
-
-  # If the label for this checkbox is not visible, it is effectively hidden from the user
-  checkbox.find_xpath('parent::label')[0].visible?.should be(true), "Expected label for checkbox \"#{checkbox.value}\" to be visible"
-
-  check(checkbox[:id], check_options.merge({allow_label_click: true}))
-  puts "Checkbox value: #{checkbox.value}"
-end
-
 def find_checkboxes_by_name(name, options={})
   return all_fields(name, options.merge({type: 'checkbox'}))
 end

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -1,18 +1,6 @@
 require 'uri'
 require 'securerandom'
 
-def find_checkboxes_by_name(name, options={})
-  return all_fields(name, options.merge({type: 'checkbox'}))
-end
-
-def find_radios_by_name(name, options={})
-  return all_fields(name, options.merge({type: 'radio'}))
-end
-
-def find_radio_by_name(name, options={})
-  return first_field(name, options.merge({type: 'radio'}))
-end
-
 Given /^I am on the homepage$/ do
   page.visit("#{dm_frontend_domain}")
   page.should have_content("Digital Marketplace")

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -141,17 +141,18 @@ When /I choose #{MAYBE_VAR} radio button(?: for the '(.*)' question)?$/ do |radi
 end
 
 When /I check a random '(.*)' checkbox$/ do |checkbox_name|
-  checkbox = find_checkboxes_by_name(checkbox_name).sample
+  checkbox = all_fields(checkbox_name, {type: 'checkbox'}).sample
   check_checkbox(checkbox)
 end
 
 When /I choose a random '(.*)' radio button$/ do |name|
-  radio = find_radios_by_name(name).sample
+
+  radio = all_fields(name, {type: 'radio'}).sample
   choose_radio(radio)
 end
 
 When /I check all '(.*)' checkboxes$/ do |checkbox_name|
-  find_checkboxes_by_name(checkbox_name).each do |checkbox|
+  all_fields(checkbox_name, {type: 'checkbox'}).each do |checkbox|
     check_checkbox(checkbox)
   end
 end
@@ -202,9 +203,9 @@ end
 
 Then /I see #{MAYBE_VAR} as the value of the '(.*)' field$/ do |value, field|
   if page.has_field?(field, {type: 'radio', visible: :all}) or page.has_field?(field, {type: 'checkbox', visible: :all})
-    page.find_field(field, {checked: true, visible: :all}).value.should == value
+    first_field(field, {checked: true}).value.should == value
   else
-    page.find_field(field).value.should == value
+    first_field(field).value.should == value
   end
 end
 
@@ -244,10 +245,10 @@ end
 Then /^I see the '(.*)' radio button is checked(?: for the '(.*)' question)?$/ do |radio_button_name, question|
   if question
     within(:xpath, "//span[normalize-space(text())='#{question}']/../..") do
-      first_field(radio_button_name).should be_checked
+      first_field(radio_button_name, {type: 'radio'}).should be_checked
     end
   else
-    first_field(radio_button_name).should be_checked
+    first_field(radio_button_name, {type: 'radio'}).should be_checked
   end
 end
 

--- a/features/step_definitions/requirements_steps.rb
+++ b/features/step_definitions/requirements_steps.rb
@@ -67,7 +67,6 @@ When "I answer all summary questions with:" do |table|
     substitutions = find_substitutions
 
     puts answer
-    puts substitutions
 
     click_on 'Save and continue'
 

--- a/features/step_definitions/requirements_steps.rb
+++ b/features/step_definitions/requirements_steps.rb
@@ -33,8 +33,10 @@ When "I answer the following questions:" do |table|
   table.rows.flatten.each { |question|
     expr = "//li[a[text()='#{question}']]/span[@class='tick']"
 
+    # should be no tick mark beside the question name on the overview page
     page.should have_selector(:xpath, expr, :count => 0)
 
+    # click the question name on the overview page (eg, "Location")
     click_on question
 
     @fields.merge! fill_form

--- a/features/support/form_helpers.rb
+++ b/features/support/form_helpers.rb
@@ -1,9 +1,9 @@
 module FormHelper
   # Helper utilities for dealing with forms
-  
+
   def field_type(el)
     # Returns the type of field for a Capybara::Node::Element
-    
+
     if el[:type] == 'checkbox'
       :checkbox
     elsif el[:type] == 'radio'
@@ -18,13 +18,13 @@ module FormHelper
 
   def random_string
     # Generate a random string
-    
+
     (0..rand(3)).map{ |i| SecureRandom.base64.gsub(/[+=\/]/, '') }.join
   end
 
   def random_for(locator, options={})
     # Generate a suitable random value based on locator
-    
+
     locator, options = nil, locator if locator.is_a? Hash
     raise "Must pass a hash" if not options.is_a?(Hash)
     result = all(:field, locator, options)
@@ -57,7 +57,7 @@ module FormHelper
   def check_only(locator=nil, options={})
     # Ensure only the values provided in options[:with] are selected
     # takes either a single string or array of strings
-    
+
     locator, options = nil, locator if locator.is_a? Hash
     raise "Must pass a hash containing 'with'" if not options.is_a?(Hash) or not options.has_key?(:with)
     with = [options.delete(:with)].flatten
@@ -69,8 +69,8 @@ module FormHelper
 
     with.each do |value|
       checked = result.select { |v| v.value == value }
-    
-      if checked.empty? 
+
+      if checked.empty?
         query = Capybara::Queries::SelectorQuery.new(:field, locator, options)
         raise Capybara::ElementNotFound.new("Unable to find #{query.description} with value '#{value}'")
       end
@@ -89,15 +89,15 @@ module FormHelper
     raise "Must pass a hash containing 'with'" if not options.is_a?(Hash) or not options.has_key?(:with)
     with = [options.delete(:with)].flatten
     result = all(:field, locator, options)
-    
+
     within result[0] do
       within(:xpath, '../..') do
         (3..with.length).each { click_on find('.list-entry-add').text } if with.length > 2
       end
     end
-    
+
     result = all(:field, locator, options)
-    
+
     with.zip(result).each do |value, element|
       fill_in element[:id], :with => value
     end
@@ -111,6 +111,7 @@ module FormHelper
     locator, options = nil, locator if locator.is_a? Hash
     raise "Must pass a hash containing 'with'" if not options.is_a?(Hash) or not options.has_key?(:with)
     with = options.delete(:with)
+
     result = all(:field, locator, options)
 
     if result.empty?
@@ -129,11 +130,11 @@ module FormHelper
       input_list locator, options.merge({ :with => with })
     else
       result = fill_in locator, options.merge({ :with => with })
-      
+
       [result]
     end
   end
-  
+
   def maybe_within(locator=nil, options={}, &block)
     locator, options = nil, locator if locator.is_a? Hash
     raise "Must pass a hash" if not options.is_a?(Hash)
@@ -154,17 +155,17 @@ module FormHelper
 
     # hash that initialises empty keys to a hash
     values = Hash.new{|h,k| h[k] = {}}
-    
+
     results.each do |result|
       if [:checkbox, :radio].include? field_type(result)
         label = find("label[for='#{result[:id]}']").text
 
         begin
           description = find("label[for='#{result[:id]}'] p").text
-          
+
           label = label[0..(label.length - description.length - 2)]
         rescue Capybara::ElementNotFound
-          
+
         end
 
         values[result[:name]][result[:value]] = label
@@ -191,7 +192,7 @@ module FormHelper
         fill_field name, with: values[name]
       end
     end
-    
+
     values
   end
 end

--- a/features/support/form_helpers.rb
+++ b/features/support/form_helpers.rb
@@ -1,10 +1,6 @@
 module FormHelper
   # Helper utilities for dealing with forms
 
-  def all_fields(locator, options={})
-    all(:field, locator, options.merge({:visible => :all}))
-  end
-
   def field_type(el)
     # Returns the type of field for a Capybara::Node::Element
 

--- a/features/support/form_helpers.rb
+++ b/features/support/form_helpers.rb
@@ -75,7 +75,7 @@ module FormHelper
     result = all_fields(locator, options)
 
     result.select { |v| not with.include?(v.value) }.each do |element|
-      uncheck element[:id], allow_label_click: true
+      uncheck_checkbox(element[:id])
     end
 
     with.each do |value|
@@ -86,7 +86,7 @@ module FormHelper
         raise Capybara::ElementNotFound.new("Unable to find #{query.description} with value '#{value}'")
       end
 
-      check checked.first[:id], allow_label_click: true
+      check_checkbox(checked.first[:id])
     end
 
     result
@@ -132,7 +132,7 @@ module FormHelper
 
     case field_type result.first
     when :radio
-      choose locator, options.merge({ option: with, allow_label_click: true })
+      choose_radio(locator, options.merge({ option: with }))
 
       result.select { |v| v.value == with }
     when :checkbox

--- a/features/support/form_helpers.rb
+++ b/features/support/form_helpers.rb
@@ -46,10 +46,20 @@ module FormHelper
     end
   end
 
+  def get_parent_label(el)
+    el.find_xpath('parent::label')[0]
+  end
+
   def find_fields(locator=nil, options={})
     # Find all field names
-
-    results = all(:field, locator, options).map { |v| v[:name] }
+    # If the inputs themselves aren't visible (ie, radios and checkboxes), verify that the parent labels are
+    results = all(
+      :field, locator, options.merge({:visible => :all})
+    ).select { |el|
+      el.visible? or get_parent_label(el).visible?
+    }.map { |v|
+      v[:name]
+    }
 
     results.uniq
   end

--- a/features/support/form_helpers.rb
+++ b/features/support/form_helpers.rb
@@ -170,12 +170,16 @@ module FormHelper
 
     results.each do |result|
       if [:checkbox, :radio].include? field_type(result)
+
         label = find("label[for='#{result[:id]}']").text
 
         begin
-          description = find("label[for='#{result[:id]}'] p").text
+          description = all("label[for='#{result[:id]}'] p").map {|el| el.text}.join
 
-          label = label[0..(label.length - description.length - 2)]
+          if not description.empty?
+            label = label[0..(label.length - description.length - 2)]
+          end
+
         rescue Capybara::ElementNotFound
 
         end

--- a/features/support/form_helpers.rb
+++ b/features/support/form_helpers.rb
@@ -1,6 +1,10 @@
 module FormHelper
   # Helper utilities for dealing with forms
 
+  def all_fields(locator, options={})
+    all(:field, locator, options.merge({:visible => :all}))
+  end
+
   def field_type(el)
     # Returns the type of field for a Capybara::Node::Element
 
@@ -27,7 +31,8 @@ module FormHelper
 
     locator, options = nil, locator if locator.is_a? Hash
     raise "Must pass a hash" if not options.is_a?(Hash)
-    result = all(:field, locator, options)
+
+    result = all_fields(locator, options)
 
     if result.empty?
       query = Capybara::Queries::SelectorQuery.new(:field, locator, options)
@@ -53,8 +58,8 @@ module FormHelper
   def find_fields(locator=nil, options={})
     # Find all field names
     # If the inputs themselves aren't visible (ie, radios and checkboxes), verify that the parent labels are
-    results = all(
-      :field, locator, options.merge({:visible => :all})
+    results = all_fields(
+      locator, options
     ).select { |el|
       el.visible? or get_parent_label(el).visible?
     }.map { |v|
@@ -71,7 +76,7 @@ module FormHelper
     locator, options = nil, locator if locator.is_a? Hash
     raise "Must pass a hash containing 'with'" if not options.is_a?(Hash) or not options.has_key?(:with)
     with = [options.delete(:with)].flatten
-    result = all(:field, locator, options)
+    result = all_fields(locator, options)
 
     result.select { |v| not with.include?(v.value) }.each do |element|
       uncheck element[:id]
@@ -122,7 +127,7 @@ module FormHelper
     raise "Must pass a hash containing 'with'" if not options.is_a?(Hash) or not options.has_key?(:with)
     with = options.delete(:with)
 
-    result = all(:field, locator, options)
+    result = all_fields(locator, options)
 
     if result.empty?
       query = Capybara::Queries::SelectorQuery.new(:field, locator, options)
@@ -161,7 +166,8 @@ module FormHelper
   def find_substitutions(locator=nil, options={})
     locator, options = nil, locator if locator.is_a? Hash
     raise "Must pass a hash" if not options.is_a?(Hash)
-    results = all(:field, locator, options)
+
+    results = all_fields(locator, options)
 
     # hash that initialises empty keys to a hash
     values = Hash.new{|h,k| h[k] = {}}
@@ -197,6 +203,7 @@ module FormHelper
 
     maybe_within do
       find_fields.each do |name|
+
         values[name] = (with[name] or random_for name)
 
         fill_field name, with: values[name]

--- a/features/support/form_helpers.rb
+++ b/features/support/form_helpers.rb
@@ -75,7 +75,7 @@ module FormHelper
     result = all_fields(locator, options)
 
     result.select { |v| not with.include?(v.value) }.each do |element|
-      uncheck element[:id]
+      uncheck element[:id], allow_label_click: true
     end
 
     with.each do |value|
@@ -86,7 +86,7 @@ module FormHelper
         raise Capybara::ElementNotFound.new("Unable to find #{query.description} with value '#{value}'")
       end
 
-      check checked.first[:id]
+      check checked.first[:id], allow_label_click: true
     end
 
     result
@@ -132,7 +132,7 @@ module FormHelper
 
     case field_type result.first
     when :radio
-      choose locator, options.merge({ option: with })
+      choose locator, options.merge({ option: with, allow_label_click: true })
 
       result.select { |v| v.value == with }
     when :checkbox

--- a/features/support/helpers.rb
+++ b/features/support/helpers.rb
@@ -21,6 +21,12 @@ def normalize_whitespace(text)
   Capybara::Helpers.normalize_whitespace(text)
 end
 
+## selecting and checking invisible fields
+
+def all_fields(locator, options={})
+  all(:field, locator, options.merge({:visible => :all}))
+end
+
 def urls_are_equal(url1, url2)
   # horrible hack, if it's a relative href stick a fake scheme and prefix on
   if url1.start_with? "/"

--- a/features/support/helpers.rb
+++ b/features/support/helpers.rb
@@ -31,6 +31,35 @@ def first_field(locator, options={})
   all_fields(locator, options)[0]
 end
 
+def choose_radio(label_or_radio, find_options={}, choose_options={})
+  if label_or_radio.is_a? Capybara::Node::Element and label_or_radio[:type] == 'radio'
+    radio = label_or_radio
+  else
+    radio = first_field(label_or_radio, find_options)
+  end
+
+  # If the label for this radio is not visible, it is effectively hidden from the user
+  radio.find_xpath('parent::label')[0].visible?.should be(true), "Expected label for radio button \"#{radio.value}\" to be visible"
+
+  choose(radio[:id], choose_options.merge({allow_label_click: true}))
+  puts "Radio button value: #{radio.value}"
+end
+
+def check_checkbox(label_or_checkbox, find_options={}, check_options={})
+  if label_or_checkbox.is_a? Capybara::Node::Element and label_or_checkbox[:type] == 'checkbox'
+    checkbox = label_or_checkbox
+  else
+    checkbox = first_field(label_or_checkbox, find_options)
+  end
+
+  # If the label for this checkbox is not visible, it is effectively hidden from the user
+  checkbox.find_xpath('parent::label')[0].visible?.should be(true), "Expected label for checkbox \"#{checkbox.value}\" to be visible"
+
+  check(checkbox[:id], check_options.merge({allow_label_click: true}))
+  puts "Checkbox value: #{checkbox.value}"
+end
+
+
 def urls_are_equal(url1, url2)
   # horrible hack, if it's a relative href stick a fake scheme and prefix on
   if url1.start_with? "/"

--- a/features/support/helpers.rb
+++ b/features/support/helpers.rb
@@ -27,6 +27,10 @@ def all_fields(locator, options={})
   all(:field, locator, options.merge({:visible => :all}))
 end
 
+def first_field(locator, options={})
+  all_fields(locator, options)[0]
+end
+
 def urls_are_equal(url1, url2)
   # horrible hack, if it's a relative href stick a fake scheme and prefix on
   if url1.start_with? "/"

--- a/features/support/helpers.rb
+++ b/features/support/helpers.rb
@@ -21,7 +21,7 @@ def normalize_whitespace(text)
   Capybara::Helpers.normalize_whitespace(text)
 end
 
-## selecting and checking invisible fields
+## finding and selecting invisible fields
 
 def all_fields(locator, options={})
   all(:field, locator, options.merge({:visible => :all}))
@@ -31,32 +31,41 @@ def first_field(locator, options={})
   all_fields(locator, options)[0]
 end
 
-def choose_radio(label_or_radio, find_options={}, choose_options={})
-  if label_or_radio.is_a? Capybara::Node::Element and label_or_radio[:type] == 'radio'
-    radio = label_or_radio
+def return_element(type, locator_or_element, options={})
+  if locator_or_element.is_a? Capybara::Node::Element
+    element = locator_or_element
   else
-    radio = first_field(label_or_radio, find_options)
+    # when passing in the value of the element we want to choose/check, we pass it in as {:option => "value"}
+    # but when we're finding it, we need to pass it in as {:with => "value"}
+    find_options = options[:option] ? {:with => options[:option]} : {}
+    element = first_field(locator_or_element, find_options.merge({type: type}))
   end
 
-  # If the label for this radio is not visible, it is effectively hidden from the user
-  radio.find_xpath('parent::label')[0].visible?.should be(true), "Expected label for radio button \"#{radio.value}\" to be visible"
+  # If the label for this radio/checkbox is not visible, it is effectively hidden from the user
+  element.find_xpath('parent::label')[0].visible?.should be(true), "Expected label for #{type} \"#{element.value}\" to be visible"
 
-  choose(radio[:id], choose_options.merge({allow_label_click: true}))
+  return element
+end
+
+def choose_radio(locator_or_radio, options={})
+  radio = return_element('radio', locator_or_radio, options)
+
+  choose(radio[:id], options.merge({allow_label_click: true}))
   puts "Radio button value: #{radio.value}"
 end
 
-def check_checkbox(label_or_checkbox, find_options={}, check_options={})
-  if label_or_checkbox.is_a? Capybara::Node::Element and label_or_checkbox[:type] == 'checkbox'
-    checkbox = label_or_checkbox
-  else
-    checkbox = first_field(label_or_checkbox, find_options)
-  end
+def check_checkbox(locator_or_checkbox, options={})
+  checkbox = return_element('checkbox', locator_or_checkbox, options)
 
-  # If the label for this checkbox is not visible, it is effectively hidden from the user
-  checkbox.find_xpath('parent::label')[0].visible?.should be(true), "Expected label for checkbox \"#{checkbox.value}\" to be visible"
-
-  check(checkbox[:id], check_options.merge({allow_label_click: true}))
+  check(checkbox[:id], options.merge({allow_label_click: true}))
   puts "Checkbox value: #{checkbox.value}"
+end
+
+def uncheck_checkbox(locator_or_checkbox, options={})
+  checkbox = return_element('checkbox', locator_or_checkbox, options)
+
+  check(checkbox[:id], options.merge({allow_label_click: true}))
+  puts "Unselected: #{checkbox.value}"
 end
 
 


### PR DESCRIPTION
**The reason the functional tests broke is that our <input> elements are invisible to selenium. [More on that here](https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/453).**

***

What this pull request does:

This pull request fixes the `@requirements` tests and tries to provide some general methods for

- finding all fields on a page
- finding the first field on a page
- choosing a radio
- (un)checking a checkbox

while making sure that the fields are themselves either visible to users or their labels are. 
Once this pull request is merged, we'll have removed all of the remaining `@skip` tags.

This pull request does not: 

- provide any specific help for filling out a page where some inputs are hidden until others are selected (like [this question](https://cloud.githubusercontent.com/assets/2454380/25229940/3ad4cb60-25ca-11e7-9fe7-526b1ab1776b.gif))

If you need that, you can build it yourself -- although it will be easier now that you can find/select inputs without having to check if they're hidden to users or not.

This pull request relies on #259, so either we merge that one first or we merge this one and close that one.