### PR TITLE
DATEFIELD-fix-for-dates-in-dos2-briefs

### DIFF
--- a/features/support/api_helpers.rb
+++ b/features/support/api_helpers.rb
@@ -122,15 +122,29 @@ def create_brief(framework_slug, lot_slug, user_id)
   brief_data = {
     updated_by: "functional tests"
   }
-  case lot_slug
-  when 'digital-specialists'
-    brief_data['briefs'] = Fixtures.digital_specialists_brief
-  when 'digital-outcomes'
-    brief_data['briefs'] = Fixtures.digital_outcomes_brief
-  when 'user-research-participants'
-    brief_data['briefs'] = Fixtures.user_research_participants_brief
-  else
-    puts 'Lot slug not recognised'
+  case framework_slug
+  when 'digital-outcomes-and-specialists'
+    case lot_slug
+    when 'digital-specialists'
+      brief_data['briefs'] = Fixtures.digital_specialists_brief
+    when 'digital-outcomes'
+      brief_data['briefs'] = Fixtures.digital_outcomes_brief
+    when 'user-research-participants'
+      brief_data['briefs'] = Fixtures.user_research_participants_brief
+    else
+      puts 'Lot slug not recognised'
+    end
+  when 'digital-outcomes-and-specialists-2'
+    case lot_slug
+    when 'digital-specialists'
+      brief_data['briefs'] = Fixtures.dos2_digital_specialists_brief
+    when 'digital-outcomes'
+      brief_data['briefs'] = Fixtures.dos2_digital_outcomes_brief
+    when 'user-research-participants'
+      brief_data['briefs'] = Fixtures.user_research_participants_brief
+    else
+      puts 'Lot slug not recognised'
+    end
   end
 
   brief_data['briefs']['userId'] = user_id

--- a/features/support/fixtures.rb
+++ b/features/support/fixtures.rb
@@ -100,6 +100,15 @@ module Fixtures
     }
   end
 
+  def self.dos2_digital_specialists_brief
+    brief_fixture = self.digital_specialists_brief
+    brief_fixture[:'startDate-day'] = "31"
+    brief_fixture[:'startDate-month'] = "12"
+    brief_fixture[:'startDate-year'] = "2016"
+    brief_fixture.delete(:startDate)
+    return brief_fixture
+  end
+
   def self.digital_outcomes_brief
     return {
       # `nil` values should be updated within the step when this fixture is used
@@ -141,6 +150,15 @@ module Fixtures
       workingArrangements: "You work.",
       workplaceAddress: "Wherever we send you",
     }
+  end
+
+  def self.dos2_digital_outcomes_brief
+    brief_fixture = self.digital_outcomes_brief
+    brief_fixture[:'startDate-day'] = "28"
+    brief_fixture[:'startDate-month'] = "09"
+    brief_fixture[:'startDate-year'] = "2017"
+    brief_fixture.delete(:startDate)
+    return brief_fixture
   end
 
   def self.user_research_participants_brief


### PR DESCRIPTION
* Adjust `create_brief` method to return a different breif fixture for dos2 digital outcomes and digital specialists lots.
* Add new fixures to `fixtures.rb` reflecting the changed date format.

http://stackoverflow.com/questions/2134702/ruby-1-9-hash-with-a-dash-in-a-key
https://repl.it/HS9g/0