### PR TITLE
DATEFIELD-fix-for-dates-in-dos2-briefs

### DIFF
--- a/features/buyer/requirements.feature
+++ b/features/buyer/requirements.feature
@@ -15,7 +15,12 @@ Scenario: Create individual specialist requirement
 
   Given 'Description of work' should not be ticked
    When I click 'Description of work'
-    And I answer all summary questions
+    And I answer all summary questions with:
+      | field                 | value       | expected_summary_table_value |
+      | startDate-day         | 08          | Tuesday 8                    |
+      | startDate-month       | 9           | September                    |
+      | startDate-year        | 2020        | 2020                         |
+
     And I click 'Return to overview'
    Then 'Description of work' should be ticked
 
@@ -57,7 +62,11 @@ Scenario: Create team to provide an outcome
 
   Given 'Description of work' should not be ticked
    When I click 'Description of work'
-    And I answer all summary questions
+    And I answer all summary questions with:
+      | field                 | value       | expected_summary_table_value |
+      | startDate-day         | 9           | Wednesday 9                    |
+      | startDate-month       | 9           | September                    |
+      | startDate-year        | 2020        | 2020                         |
     And I click 'Return to overview'
    Then 'Description of work' should be ticked
 

--- a/features/supplier/brief_response.feature
+++ b/features/supplier/brief_response.feature
@@ -43,7 +43,7 @@ Scenario: Supplier applies for a digital-specialists brief
   Then I am on 'Apply for ‘Tea drinker’' page
   When I click 'Start application'
   Then I am on 'When is the earliest the specialist can start work?' page
-  And I see 'The buyer needs the specialist to start: 31/12/2016' replayed in the question advice
+  And I see 'The buyer needs the specialist to start: Saturday 31 December 2016' replayed in the question advice
   When I enter '27/12/17' in the 'availability' field
   And I click 'Continue'
   Then I am on the 'What’s the specialist’s day rate?' page
@@ -96,7 +96,7 @@ Scenario: Supplier applies for a digital-outcomes brief
   Then I am on 'Apply for ‘Hide and seek ninjas’' page
   When I click 'Start application'
   Then I am on 'When is the earliest the team can start?' page
-  And I see 'The buyer needs the team to start: 28/09/2017' replayed in the question advice
+  And I see 'The buyer needs the team to start: Thursday 28 September 2017' replayed in the question advice
   When I enter '09/09/17' in the 'availability' field
   And I click 'Continue'
   Then I am on the 'Do you have all the essential skills and experience?' page
@@ -218,7 +218,7 @@ Scenario: Supplier changes their answers before submission
   Then I am on 'Apply for ‘Tea drinker’' page
   When I click 'Continue application'
   Then I am on 'When is the earliest the specialist can start work?' page
-  And I see 'The buyer needs the specialist to start: 31/12/2016' replayed in the question advice
+  And I see 'The buyer needs the specialist to start: Saturday 31 December 2016' replayed in the question advice
   And I see '27/12/17' as the value of the 'availability' field
   When I enter '28/09/17' in the 'availability' field
   And I click 'Continue'

--- a/features/support/fixtures.rb
+++ b/features/support/fixtures.rb
@@ -91,7 +91,7 @@ module Fixtures
       requirementsLength: "2 weeks",
       specialistRole: "developer",
       specialistWork: "Drink tea",
-      startDate: "31\/12\/2016",
+      startDate: "2016-12-31",
       summary: "Drink lots of tea. Brew kettle.",
       technicalWeighting: 75,
       title: "Tea drinker",
@@ -131,7 +131,7 @@ module Fixtures
       phase: "beta",
       priceCriteria: "Fixed price",
       priceWeighting: 20,
-      startDate: "28\/09\/2017",
+      startDate: "2017-09-28",
       successCriteria: [
         "The thingy works"
       ],


### PR DESCRIPTION
* Make sure `startDate` is sent ot api in expected format (`fixtures.rb`).
* Change expected response to match fixture (`brief_response.feature`).
