### PR TITLE
Skip tests on certain stages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 DM_ENVIRONMENT ?= local
 
 smoke-tests: setup
-	. config/${DM_ENVIRONMENT}.sh && bundle exec cucumber --tags @smoke-tests
+	. config/${DM_ENVIRONMENT}.sh && bundle exec cucumber --tags @smoke-tests --tags ~@skip --tags ~@skip-${DM_ENVIRONMENT}
 
 run: setup
-	. config/${DM_ENVIRONMENT}.sh && bundle exec cucumber ${ARGS}
+	. config/${DM_ENVIRONMENT}.sh && bundle exec cucumber --tags ~@skip --tags ~@skip-${DM_ENVIRONMENT}
 
 rerun:
 	. config/${DM_ENVIRONMENT}.sh && bundle exec cucumber -p rerun

--- a/README.md
+++ b/README.md
@@ -47,6 +47,22 @@ To run features with a specific tag run
 
 To include or exclude tags see [the cucumber documentation](https://github.com/cucumber/cucumber/wiki/Tags#running-a-subset-of-scenarios)
 
+## Tags
+Tags are used to include/exclude given tests on certain environments. The following tags are currently supported:
+
+| Tag Name                    | Description                                           |
+|-----------------------------|-------------------------------------------------------|
+| smoke-tests                 |                                                       |
+| opportunities               |                                                       |               
+| requirements                |                                                       |
+| brief-response              |                                                       |
+| with-production-<type>-user |                                                       |
+| skip                        | Skip this test everywhere (e.g. temporarily disabled) |
+| skip-preview                | Will not run on the preview environment.              |
+| skip-staging                | Will not run on the staging environment.              |
+| skip-production             | Will not run on the production environment.           |
+
+
 ## Run tests against local services
 
 First you need to create a file to set up your local environment variables - this must be in

--- a/features/buyer/catalogue.feature
+++ b/features/buyer/catalogue.feature
@@ -1,6 +1,7 @@
 @smoke-tests
 Feature: Passive catalogue buyer journey
 
+@skip-preview
 Scenario: User can see the main links on the homepage
   Given I am on the homepage
   Then I see the 'Find cloud technology and support' link
@@ -12,9 +13,28 @@ Scenario: User can see the main links on the homepage
   And I see the 'View Digital Outcomes and Specialists opportunities' link
   And I see the 'Create a supplier account' link
 
+@skip-preview
 Scenario: User can click through to g-cloud page
   Given I am on the homepage
   When I click 'Find cloud technology and support'
+  Then I am on the 'Cloud technology and support' page
+
+@skip-staging @skip-production
+Scenario: User can see the main links on the homepage
+  Given I am on the homepage
+  Then I see the 'Find cloud hosting, software and support' link
+  And I see the 'Buy physical datacentre space' link
+  And I see the 'Find an individual specialist' link
+  And I see the 'Find a team to provide an outcome' link
+  And I see the 'Find user research participants' link
+  And I see the 'Find a user research lab' link
+  And I see the 'View Digital Outcomes and Specialists opportunities' link
+  And I see the 'Create a supplier account' link
+
+@skip-staging @skip-production
+Scenario: User can click through to g-cloud page
+  Given I am on the homepage
+  When I click 'Find cloud hosting, software and support'
   Then I am on the 'Cloud technology and support' page
 
 Scenario: User can select a lot from the g-cloud page and see search results.


### PR DESCRIPTION
## Summary
Two tests are currently failing on preview because we have some text on the homepage that changes depending on a framework state. This PR adds support for skipping specific tests based on the stage they're run against, and then duplicates (with text changes) the two failing tests and forks them to the correct branches.