### PR TITLE
Source env files if they exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 DM_ENVIRONMENT ?= local
 
 smoke-tests: setup
-	. config/${DM_ENVIRONMENT}.sh && bundle exec cucumber --tags @smoke-tests --tags ~@skip --tags ~@skip-${DM_ENVIRONMENT}
+	[ -f config/${DM_ENVIRONMENT}.sh ] && . config/${DM_ENVIRONMENT}.sh ; bundle exec cucumber --tags @smoke-tests --tags ~@skip --tags ~@skip-${DM_ENVIRONMENT}
 
 run: setup
-	. config/${DM_ENVIRONMENT}.sh && bundle exec cucumber --tags ~@skip --tags ~@skip-${DM_ENVIRONMENT}
+	[ -f config/${DM_ENVIRONMENT}.sh ] && . config/${DM_ENVIRONMENT}.sh ; bundle exec cucumber --tags ~@skip --tags ~@skip-${DM_ENVIRONMENT}
 
 rerun:
-	. config/${DM_ENVIRONMENT}.sh && bundle exec cucumber -p rerun
+	[ -f config/${DM_ENVIRONMENT}.sh ] && . config/${DM_ENVIRONMENT}.sh ; bundle exec cucumber -p rerun
 
 setup: install clean
 	@echo "Environment:" ${DM_ENVIRONMENT}


### PR DESCRIPTION
A local.sh file is supplied to populate environment variables so tests can easily be run locally. When the tests are run via jenkins, these environment variables are populated automatically.

This will source a local.sh if it exists and skips that step if running against preview/staging/prod.