### PR TITLE
Update skip tags

### DIFF
--- a/features/buyer/catalogue.feature
+++ b/features/buyer/catalogue.feature
@@ -1,7 +1,7 @@
 @smoke-tests
 Feature: Passive catalogue buyer journey
 
-@skip-local @skip-preview
+@skip-local @skip-preview @skip-staging
 Scenario: User can see the main links on the homepage
   Given I am on the homepage
   Then I see the 'Find cloud technology and support' link
@@ -13,13 +13,13 @@ Scenario: User can see the main links on the homepage
   And I see the 'View Digital Outcomes and Specialists opportunities' link
   And I see the 'Create a supplier account' link
 
-@skip-local @skip-preview
+@skip-local @skip-preview @skip-staging
 Scenario: User can click through to g-cloud page
   Given I am on the homepage
   When I click 'Find cloud technology and support'
   Then I am on the 'Cloud technology and support' page
 
-@skip-staging @skip-production
+@skip-production
 Scenario: User can see the main links on the homepage
   Given I am on the homepage
   Then I see the 'Find cloud hosting, software and support' link
@@ -31,7 +31,7 @@ Scenario: User can see the main links on the homepage
   And I see the 'View Digital Outcomes and Specialists opportunities' link
   And I see the 'Create a supplier account' link
 
-@skip-staging @skip-production
+@skip-production
 Scenario: User can click through to g-cloud page
   Given I am on the homepage
   When I click 'Find cloud hosting, software and support'


### PR DESCRIPTION
## Summary
G-Cloud 9 is now live on staging, and the functional tests are failing. This PR moves the `skip-staging` tags to the correct tests for live G9.