### PR TITLE
Look for a random dos 2 brief

### DIFF
--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -82,7 +82,7 @@ end
 
 # TODO merge with above step
 Given /^I have a random dos brief from the API$/ do
-  params = {status: "live,closed", framework: "digital-outcomes-and-specialists"}
+  params = {status: "live,closed", framework: "digital-outcomes-and-specialists-2"}
   page_one = call_api(:get, "/briefs", params: params)
   last_page_url = JSON.parse(page_one.body)['links']['last']
   params[:page] = if last_page_url then


### PR DESCRIPTION
The common step to get a random dos brief was looking for a dos 1 brief.
I've just cleaned up a lot of old briefs on preview, which included
deleting all old dos 1 briefs.