### PR TITLE
Prevent non-GET API calls for @smoke-test runs

### DIFF
--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -1,0 +1,3 @@
+Before('@smoke-tests') do
+  @SMOKE_TESTS = true
+end


### PR DESCRIPTION
We've had an issue with smoke test jobs accidentally including
scenarios that are creating or modifying data in the database.

Since smoke tests are supposed to be side-effect free so that we
can safely and repeatedly run them on production we need a better
way to highlight any attempts to modify data during their run.

This adds a check the the call_api method to only allow GET requests
from scenarios tagged with `@smoke-tests`. This method is used by
most data setup step definitions.

This also adds a way to override the restriction by setting the
`safe_for_smoke_tests` option when calling `call_api`. This
override is currently only used for setting up read-only users in
all environments.

Note: since this check only applies to the API calls made through
`call_api` it doesn't guarantee that the smoke test runs don't
modify any data. It's still possible to make changes using either
different methods that would send API requests or by running
steps that make modifications trough the user interface.