### PR TITLE
Test 'Publish requirements' button not visible for incomplete drafts

### DIFF
--- a/features/buyer/requirements.feature
+++ b/features/buyer/requirements.feature
@@ -127,6 +127,7 @@ Scenario: Create user research participants
    Then 'Describe question and answer session' should be ticked
 
    When I click 'Review and publish your requirements'
+   Then I see the 'Publish requirements' button
     And I click 'Publish requirements'
 
   Then I don't see the 'Title' link
@@ -179,3 +180,10 @@ Scenario: Delete a draft requirement
   Then I see a destructive banner message containing 'Are you sure you want to delete these requirements?'
   When I click 'Yes, delete'
   Then I see a success banner message containing 'were deleted'
+
+
+Scenario: There is no 'Publish requirements' button for an incomplete requirement draft
+  Given I am logged in as a buyer user
+  And I have created an individual specialist requirement
+  When I click 'Review and publish your requirements'
+  Then I don't see the 'Publish requirements' button

--- a/features/buyer/requirements.feature
+++ b/features/buyer/requirements.feature
@@ -135,7 +135,7 @@ Scenario: Create user research participants
    And I don't see the 'Shortlist and evaluation process' link
    And I don't see the 'Review and publish your requirements' link
 
-@copy
+
 Scenario Outline: Copy requirements
   Given I have a live digital outcomes and specialists framework
   And I have a buyer
@@ -155,7 +155,22 @@ Scenario Outline: Copy requirements
     | draft     |
 
 
-@delete_draft
+Scenario Outline: View requirement in a dashboard
+  Given I have a live digital outcomes and specialists framework
+  And I have a buyer
+  And that buyer is logged in
+  And I have a <status> digital-specialists brief
+  When I click 'View your account'
+  Then I am on the /buyers page
+  And I see 'Tea drinker' in the '<table heading>' summary table
+
+  Examples:
+    | status    | table heading            |
+    | live      | Published requirements   |
+    | withdrawn | Closed requirements      |
+    | draft     | Unpublished requirements |
+
+
 Scenario: Delete a draft requirement
   Given I am logged in as a buyer user
   And I have created an individual specialist requirement

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -181,10 +181,9 @@ Then /^I see #{MAYBE_VAR} breadcrumb$/ do |breadcrumb_text|
   breadcrumb.text().should == breadcrumb_text
 end
 
-Then /^I (don't |)see the '(.*)' link$/ do |negative, link_text|
-  page.should have_link(link_text) if negative.empty?
-
-  page.should_not have_link(link_text) unless negative.empty?
+Then /^I (don't |)see the '(.*)' (button|link)$/ do |negative, selector_text, selector_type|
+page.should have_selector(:link_or_button, selector_text) if negative.empty?
+page.should_not have_selector(:link_or_button, selector_text) unless negative.empty?
 end
 
 Then /^I am on #{MAYBE_VAR} page$/ do |page_name|

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -166,7 +166,7 @@ When(/^I choose a random uppercase letter$/) do
   puts "letter: #{@letter}"
 end
 
-# the rescue is used because if a banner cannot be found the function throws an exception and does not look for the other option  
+# the rescue is used because if a banner cannot be found the function throws an exception and does not look for the other option
 Then /^I see a (success|warning|destructive|temporary-message) banner message containing '(.*)'$/ do |status, message|
   begin
     banner_message = page.find(:css, ".banner-#{status}-without-action")
@@ -238,6 +238,13 @@ Then /^I see the '(.*)' summary table filled with:$/ do |table_heading, table|
     result_items[0].text.should == row[0]
     result_items[1].text.should == row[1]
   end
+end
+
+Then /^I see '(.*)' in the '(.*)' summary table$/ do |content, table_heading|
+  result_table_location = "//*[@class='summary-item-heading'][normalize-space(text())='#{table_heading}']/following-sibling::table[1]"
+  result_table_rows_location = result_table_location + "/tbody/tr[@class='summary-item-row']"
+  result_table_rows = all(:xpath, result_table_rows_location)
+  result_table_rows.any? {|row| row.text.include? content}.should be true
 end
 
 Then /^I see the '(.*)' radio button is checked(?: for the '(.*)' question)?$/ do |radio_button_name, question|


### PR DESCRIPTION
#### Trello card:
https://trello.com/c/NvaIQwOs/539-functional-test-the-publish-button-shouldnt-be-visible-for-incomplete-requirements   
      
#### Superseded legacy test:
https://github.com/alphagov/digitalmarketplace-functional-tests/blob/jenkins/features/buyer/buyer_create_requirements.feature#L27