### PR TITLE
Test that buyer can see their requirements on dashboard

### DIFF
--- a/features/buyer/requirements.feature
+++ b/features/buyer/requirements.feature
@@ -135,7 +135,7 @@ Scenario: Create user research participants
    And I don't see the 'Shortlist and evaluation process' link
    And I don't see the 'Review and publish your requirements' link
 
-@copy
+
 Scenario Outline: Copy requirements
   Given I have a live digital outcomes and specialists framework
   And I have a buyer
@@ -155,7 +155,22 @@ Scenario Outline: Copy requirements
     | draft     |
 
 
-@delete_draft
+Scenario Outline: View requirement in a dashboard
+  Given I have a live digital outcomes and specialists framework
+  And I have a buyer
+  And that buyer is logged in
+  And I have a <status> digital-specialists brief
+  When I click 'View your account'
+  Then I am on the /buyers page
+  And I see 'Tea drinker' in the '<table heading>' summary table
+
+  Examples:
+    | status    | table heading            |
+    | live      | Published requirements   |
+    | withdrawn | Closed requirements      |
+    | draft     | Unpublished requirements |
+
+
 Scenario: Delete a draft requirement
   Given I am logged in as a buyer user
   And I have created an individual specialist requirement

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -166,7 +166,7 @@ When(/^I choose a random uppercase letter$/) do
   puts "letter: #{@letter}"
 end
 
-# the rescue is used because if a banner cannot be found the function throws an exception and does not look for the other option  
+# the rescue is used because if a banner cannot be found the function throws an exception and does not look for the other option
 Then /^I see a (success|warning|destructive|temporary-message) banner message containing '(.*)'$/ do |status, message|
   begin
     banner_message = page.find(:css, ".banner-#{status}-without-action")
@@ -238,6 +238,13 @@ Then /^I see the '(.*)' summary table filled with:$/ do |table_heading, table|
     result_items[0].text.should == row[0]
     result_items[1].text.should == row[1]
   end
+end
+
+Then /^I see '(.*)' in the '(.*)' summary table$/ do |content, table_heading|
+  result_table_location = "//*[@class='summary-item-heading'][normalize-space(text())='#{table_heading}']/following-sibling::table[1]"
+  result_table_rows_location = result_table_location + "/tbody/tr[@class='summary-item-row']"
+  result_table_rows = all(:xpath, result_table_rows_location)
+  result_table_rows.any? {|row| row.text.include? content}.should be true
 end
 
 Then /^I see the '(.*)' radio button is checked(?: for the '(.*)' question)?$/ do |radio_button_name, question|


### PR DESCRIPTION
Trello card:
https://trello.com/c/q9b3WiQE/531-functional-test-ensure-requirements-visible-in-buyer-dash
Superseded legacy test:
https://github.com/alphagov/digitalmarketplace-functional-tests/blob/jenkins/features/buyer/buyer_create_requirements.feature#L21