### PR TITLE
G9 tests

### DIFF
--- a/features/smoke-tests/buyer/catalogue.feature
+++ b/features/smoke-tests/buyer/catalogue.feature
@@ -71,3 +71,27 @@ Scenario: User is able to click on a random category
   And I see that category_name in the search summary text
   And I see a search result
   And I see fewer search results than before
+
+Scenario: User is able to click on several random filters
+  Given I am on the /g-cloud page
+  And I have a random g-cloud lot from the API
+  And I click that lot.name
+  Then I am on the 'Search results' page
+  And I note the number of search results
+  Then I select several random filters
+  And I click 'Filter'
+  Then I am on the 'Search results' page
+  And I see fewer search results than before
+
+Scenario: User is able to paginate through search results and all of the navigation is preserved
+  Given I am on the /g-cloud page
+  And I have a random g-cloud lot from the API
+  And I click that lot.name
+  Then I am on the 'Search results' page
+  And I note the number of category links
+  And I click 'Next'
+  Then I am taken to page 2 of results
+  And I see the same number of category links as before
+  When I click 'Previous'
+  Then I am taken to page 1 of results
+  And I see the same number of category links as before

--- a/features/smoke-tests/buyer/catalogue.feature
+++ b/features/smoke-tests/buyer/catalogue.feature
@@ -70,7 +70,7 @@ Scenario: User is able to click on a random category
   Then I am on the 'Search results' page
   And I see that category_name in the search summary text
   And I see a search result
-  And I see fewer search results than before
+  And I see fewer search results than noted
 
 Scenario: User is able to click on several random filters
   Given I am on the /g-cloud page
@@ -81,7 +81,7 @@ Scenario: User is able to click on several random filters
   Then I select several random filters
   And I click 'Filter'
   Then I am on the 'Search results' page
-  And I see fewer search results than before
+  And I see fewer search results than noted
 
 Scenario: User is able to paginate through search results and all of the navigation is preserved
   Given I am on the /g-cloud page
@@ -91,7 +91,7 @@ Scenario: User is able to paginate through search results and all of the navigat
   And I note the number of category links
   And I click 'Next'
   Then I am taken to page 2 of results
-  And I see the same number of category links as before
+  And I see the same number of category links as noted
   When I click 'Previous'
   Then I am taken to page 1 of results
-  And I see the same number of category links as before
+  And I see the same number of category links as noted

--- a/features/smoke-tests/buyer/catalogue.feature
+++ b/features/smoke-tests/buyer/catalogue.feature
@@ -58,3 +58,16 @@ Scenario: User is able to search by keywords field on the search results page to
   Then I see that service.id in the search summary text
   And I see that service.id as the value of the 'q' field
   And I see that service in the search results
+
+Scenario: User is able to click on a random category
+  Given I am on the /g-cloud page
+  And I have a random g-cloud lot from the API
+  And I click that lot.name
+  Then I am on the 'Search results' page
+  And I note the number of search results
+
+  When I click a random category link
+  Then I am on the 'Search results' page
+  And I see that category_name in the search summary text
+  And I see a search result
+  And I see fewer search results than before

--- a/features/step_definitions/catalogue_steps.rb
+++ b/features/step_definitions/catalogue_steps.rb
@@ -39,5 +39,20 @@ Then (/^I see that service in the search results$/) do
 end
 
 Then(/^I see #{MAYBE_VAR} in the search summary text$/) do |value|
-  find(:xpath, "//*[@class='search-summary']/em[1]").text().should == normalize_whitespace(value)
+  expect(find(:xpath, "//*[@class='search-summary']").text()).to include(normalize_whitespace(value))
+end
+
+Then (/^I note the number of search results$/) do
+  @service_count = CatalogueHelpers.get_service_count(page)
+end
+
+Then /^I click a random category link$/ do
+  links = page.all(:css, ".lot-filters ul ul :link")
+  link_el = links.sample
+  @category_name = link_el.text.sub(/ \([0-9]*\)/, "")  # remove service count
+  link_el.click
+end
+
+Then(/^I see fewer search results than before$/) do
+  expect(CatalogueHelpers.get_service_count(page)).to be < @service_count
 end

--- a/features/step_definitions/catalogue_steps.rb
+++ b/features/step_definitions/catalogue_steps.rb
@@ -47,7 +47,7 @@ Then (/^I note the number of search results$/) do
 end
 
 Then /^I click a random category link$/ do
-  links = page.all(:css, ".lot-filters ul ul :link")
+  links = CatalogueHelpers.get_category_links(page)
   link_el = links.sample
   @category_name = link_el.text.sub(/ \([0-9]*\)/, "")  # remove service count
   link_el.click
@@ -55,4 +55,31 @@ end
 
 Then(/^I see fewer search results than before$/) do
   expect(CatalogueHelpers.get_service_count(page)).to be < @service_count
+end
+
+Then(/^I select several random filters$/) do
+  page.all(:xpath, "//div[contains(@class, 'govuk-option-select')]//input[@type='checkbox']").sample.click
+end
+
+Then(/^I note the number of category links$/) do
+  @category_link_count = CatalogueHelpers.get_category_links(page).length
+end
+
+Then(/^I am taken to page (\d+) of results$/) do |page_number|
+  page_number = page_number.to_i
+  current_url.should include("page=#{page_number}")
+  page.should have_selector(:xpath, "//a[contains(text(), 'Next')]//following-sibling::span[contains(text(),'page')]")
+  page.should have_selector(:xpath, "//a[contains(text(), 'Next')]//following-sibling::span[contains(text(),'page')]/..//following-sibling::span[@class='page-numbers'][contains(text(), '#{page_number+1} of')]")
+  if page_number == 1
+    page.should have_selector(:xpath, "//a[contains(text(), 'Next')]//following-sibling::span[contains(text(),'page')]")
+    page.should have_no_selector(:xpath, "//a[contains(text(), 'Previous')]//following-sibling::span[contains(text(),'page')]")
+  else
+    page.should have_selector(:xpath, "//a[contains(text(), 'Previous')]//following-sibling::span[contains(text(),'page')]")
+    page.should have_selector(:xpath, "//a[contains(text(), 'Previous')]//following-sibling::span[contains(text(),'page')]/..//following-sibling::span[@class='page-numbers'][contains(text(), '#{page_number-1} of')]")
+
+  end
+end
+
+Then(/^I see the same number of category links as before$/) do
+  expect(CatalogueHelpers.get_category_links(page).length).to be == @category_link_count
 end

--- a/features/step_definitions/catalogue_steps.rb
+++ b/features/step_definitions/catalogue_steps.rb
@@ -53,7 +53,7 @@ Then /^I click a random category link$/ do
   link_el.click
 end
 
-Then(/^I see fewer search results than before$/) do
+Then(/^I see fewer search results than noted$/) do
   expect(CatalogueHelpers.get_service_count(page)).to be < @service_count
 end
 
@@ -80,6 +80,6 @@ Then(/^I am taken to page (\d+) of results$/) do |page_number|
   end
 end
 
-Then(/^I see the same number of category links as before$/) do
+Then(/^I see the same number of category links as noted/) do
   expect(CatalogueHelpers.get_category_links(page).length).to be == @category_link_count
 end

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -184,9 +184,9 @@ end
 Then /^I (don't |)see the '(.*)' (button|link)$/ do |negative, selector_text, selector_type|
   page.should have_selector(:link_or_button, selector_text) if negative.empty?
   page.should_not have_selector(:link_or_button, selector_text) unless negative.empty?
-  end
+end
 
-  Then /^I am on #{MAYBE_VAR} page$/ do |page_name|
+Then /^I am on #{MAYBE_VAR} page$/ do |page_name|
   page.should have_selector('h1', text: normalize_whitespace(page_name))
 end
 

--- a/features/support/catalogue_helpers.rb
+++ b/features/support/catalogue_helpers.rb
@@ -3,4 +3,8 @@ module CatalogueHelpers
     page.find(:xpath, "//*[@class='search-summary-count']").text.to_i
   end
 
+  def self.get_category_links(page)
+    page.all(:css, ".lot-filters ul ul :link")
+  end
+
 end

--- a/features/support/catalogue_helpers.rb
+++ b/features/support/catalogue_helpers.rb
@@ -1,0 +1,6 @@
+module CatalogueHelpers
+  def self.get_service_count(page)
+    page.find(:xpath, "//*[@class='search-summary-count']").text.to_i
+  end
+
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -6,7 +6,7 @@ require 'capybara/poltergeist'
 require 'capybara-screenshot/cucumber'
 
 RSpec.configure do |config|
-  config.expect_with(:rspec) { |c| c.syntax = :should }
+  config.expect_with(:rspec) { |c| c.syntax = [:should, :expect] }
 end
 
 if (ENV['BROWSER'] == 'true')


### PR DESCRIPTION
Tests to replace those lost in G9 (e.g. see <https://github.com/alphagov/digitalmarketplace-functional-tests/pull/267>).

One of the tests fails because of a bug, so maybe we shouldn't land this yet ;)

We are just picking random filters and random categories, so these are not exhaustive tests like those they replace. But we think that known-input known-output exhaustive testing really belongs as unit tests in the buyer frontend rather than here.
