### PR TITLE
Add default.nix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 reports/
 config/
 sql/data/
+local.nix

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,24 @@
+{
+  pkgs ? import <nixpkgs> {}
+}:
+{
+  digitalMarketplaceFunctionalTestsEnv = (pkgs.bundlerEnv {
+      name = "digitalmarketplace-functional-tests-bundler-env";
+
+      ruby = pkgs.ruby;
+      gemfile = ./Gemfile;
+      lockfile = ./Gemfile.lock;
+      gemset = ./gemset.nix;
+    }).env.overrideAttrs (oldAttrs: oldAttrs // {
+    name = "digitalmarketplace-functional-tests-env";
+    buildInputs = [
+      pkgs.bundler
+      pkgs.bundix
+      pkgs.libxml2
+      pkgs.phantomjs
+    ];
+
+    # if we don't have this, we get unicode troubles in a --pure nix-shell
+    LANG="en_GB.UTF-8";
+  });
+}

--- a/default.nix
+++ b/default.nix
@@ -28,7 +28,7 @@ in (with args; {
       LANG="en_GB.UTF-8";
 
       shellHook = ''
-        export PS1="\[\e[0;34m\](nix-shell\[\e[0m\]:\[\e[0;34m\]${shortName})\[\e[0;32m\]\u@\h\[\e[0m\]:\[\e[0m\]\[\e[0;34m\]\w\[\e[0m\]\$ "
+        export PS1="\[\e[0;36m\](nix-shell\[\e[0m\]:\[\e[0;36m\]${shortName})\[\e[0;32m\]\u@\h\[\e[0m\]:\[\e[0m\]\[\e[0;36m\]\w\[\e[0m\]\$ "
       '';
     })
   ).overrideAttrs (if builtins.pathExists localOverridesPath then (import localOverridesPath args) else (x: x));

--- a/default.nix
+++ b/default.nix
@@ -14,8 +14,9 @@ in (with args; {
       gemfile = ./Gemfile;
       lockfile = ./Gemfile.lock;
       gemset = ./gemset.nix;
-    }).env.overrideAttrs (oldAttrs: oldAttrs // {
+    }).env.overrideAttrs (oldAttrs: oldAttrs // rec {
       name = "digitalmarketplace-functional-tests-env";
+      shortName = "dm-func-tst";
       buildInputs = [
         pkgs.bundler
         pkgs.bundix
@@ -25,6 +26,10 @@ in (with args; {
 
       # if we don't have this, we get unicode troubles in a --pure nix-shell
       LANG="en_GB.UTF-8";
+
+      shellHook = ''
+        export PS1="\[\e[0;34m\](nix-shell\[\e[0m\]:\[\e[0;34m\]${shortName})\[\e[0;32m\]\u@\h\[\e[0m\]:\[\e[0m\]\[\e[0;34m\]\w\[\e[0m\]\$ "
+      '';
     })
   ).overrideAttrs (if builtins.pathExists localOverridesPath then (import localOverridesPath args) else (x: x));
 })

--- a/default.nix
+++ b/default.nix
@@ -1,8 +1,13 @@
-{
-  pkgs ? import <nixpkgs> {}
-}:
-{
-  digitalMarketplaceFunctionalTestsEnv = (pkgs.bundlerEnv {
+argsOuter@{...}:
+let
+  # specifying args defaults in this slightly non-standard way to allow us to include the default values in `args`
+  args = rec {
+    pkgs = import <nixpkgs> {};
+    localOverridesPath = ./local.nix;
+  } // argsOuter;
+in (with args; {
+  digitalMarketplaceFunctionalTestsEnv = (
+    (pkgs.bundlerEnv {
       name = "digitalmarketplace-functional-tests-bundler-env";
 
       ruby = pkgs.ruby;
@@ -10,15 +15,16 @@
       lockfile = ./Gemfile.lock;
       gemset = ./gemset.nix;
     }).env.overrideAttrs (oldAttrs: oldAttrs // {
-    name = "digitalmarketplace-functional-tests-env";
-    buildInputs = [
-      pkgs.bundler
-      pkgs.bundix
-      pkgs.libxml2
-      pkgs.phantomjs
-    ];
+      name = "digitalmarketplace-functional-tests-env";
+      buildInputs = [
+        pkgs.bundler
+        pkgs.bundix
+        pkgs.libxml2
+        pkgs.phantomjs
+      ];
 
-    # if we don't have this, we get unicode troubles in a --pure nix-shell
-    LANG="en_GB.UTF-8";
-  });
-}
+      # if we don't have this, we get unicode troubles in a --pure nix-shell
+      LANG="en_GB.UTF-8";
+    })
+  ).overrideAttrs (if builtins.pathExists localOverridesPath then (import localOverridesPath args) else (x: x));
+})

--- a/gemset.nix
+++ b/gemset.nix
@@ -1,0 +1,354 @@
+{
+  addressable = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0mpn7sbjl477h56gmxsjqb89r5s3w7vx5af994ssgc3iamvgzgvs";
+      type = "gem";
+    };
+    version = "2.4.0";
+  };
+  builder = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "14fii7ab8qszrvsvhz6z2z3i4dw0h41a62fjr2h1j8m41vbrmyv2";
+      type = "gem";
+    };
+    version = "3.2.2";
+  };
+  capybara = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1dxab3nkdivdm9a2gw0a9giibgskrljnz095hq5xkwl41b24vbgn";
+      type = "gem";
+    };
+    version = "2.10.1";
+  };
+  capybara-screenshot = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1xy79lf3rwn3602r4hqm9s8a03bhlf6hzwdi6345dzrkmhwwj2ij";
+      type = "gem";
+    };
+    version = "1.0.14";
+  };
+  childprocess = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1is253wm9k2s325nfryjnzdqv9flq8bm4y2076mhdrncxamrh7r2";
+      type = "gem";
+    };
+    version = "0.5.9";
+  };
+  cliver = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "096f4rj7virwvqxhkavy0v55rax10r4jqf8cymbvn4n631948xc7";
+      type = "gem";
+    };
+    version = "0.3.2";
+  };
+  cucumber = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1k4j31a93r0zhvyq2mm2k8irppbvkzbsg44r3mf023959v18fzih";
+      type = "gem";
+    };
+    version = "2.4.0";
+  };
+  cucumber-core = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0qj2fsqvp94nggnikbnrfvnmzr1pl6ifmdsxj69kdw1kkab30jjr";
+      type = "gem";
+    };
+    version = "1.5.0";
+  };
+  cucumber-wire = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "09ymvqb0sbw2if1nxg8rcj33sf0va88ancq5nmp8g01dfwzwma2f";
+      type = "gem";
+    };
+    version = "0.0.1";
+  };
+  diff-lcs = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1vf9civd41bnqi6brr5d9jifdw73j9khc6fkhfl1f8r9cpkdvlx1";
+      type = "gem";
+    };
+    version = "1.2.5";
+  };
+  domain_name = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0rg7gvp45xmb5qz8ydp7ivw05hhplh6k7mbawrpvkysl2c77w5xx";
+      type = "gem";
+    };
+    version = "0.5.20160826";
+  };
+  ffi = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1nkcrmxqr0vb1y4rwliclwlj2ajsi4ddpdx2gvzjy0xbkk5iqzfp";
+      type = "gem";
+    };
+    version = "1.9.14";
+  };
+  gherkin = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1ripjv97hg746xszx9isal8z8vrlb98asc2rdxl291b3hr6pj0pr";
+      type = "gem";
+    };
+    version = "4.0.0";
+  };
+  http-cookie = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "004cgs4xg5n6byjs7qld0xhsjq3n6ydfh897myr2mibvh6fjc49g";
+      type = "gem";
+    };
+    version = "1.0.3";
+  };
+  json = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1lhinj9vj7mw59jqid0bjn2hlfcnq02bnvsx9iv81nl2han603s0";
+      type = "gem";
+    };
+    version = "2.0.2";
+  };
+  launchy = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "190lfbiy1vwxhbgn4nl4dcbzxvm049jwc158r2x7kq3g5khjrxa2";
+      type = "gem";
+    };
+    version = "2.4.3";
+  };
+  mime-types = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0087z9kbnlqhci7fxh9f6il63hj1k02icq2rs0c6cppmqchr753m";
+      type = "gem";
+    };
+    version = "3.1";
+  };
+  mime-types-data = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "04my3746hwa4yvbx1ranhfaqkgf6vavi1kyijjnw8w3dy37vqhkm";
+      type = "gem";
+    };
+    version = "3.2016.0521";
+  };
+  mini_portile2 = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1y25adxb1hgg1wb2rn20g3vl07qziq6fz364jc5694611zz863hb";
+      type = "gem";
+    };
+    version = "2.1.0";
+  };
+  multi_json = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1wpc23ls6v2xbk3l1qncsbz16npvmw8p0b38l8czdzri18mp51xk";
+      type = "gem";
+    };
+    version = "1.12.1";
+  };
+  multi_test = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1sx356q81plr67hg16jfwz9hcqvnk03bd9n75pmdw8pfxjfy1yxd";
+      type = "gem";
+    };
+    version = "0.1.2";
+  };
+  netrc = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0gzfmcywp1da8nzfqsql2zqi648mfnx6qwkig3cv36n9m0yy676y";
+      type = "gem";
+    };
+    version = "0.11.0";
+  };
+  nokogiri = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "045xdg0w7nnsr2f2gb7v7bgx53xbc9dxf0jwzmh2pr3jyrzlm0cj";
+      type = "gem";
+    };
+    version = "1.6.8.1";
+  };
+  phantomjs = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0y8pbbyq9dirxb7igkb2s5limz2895qmr41c09fjhx6k6fxcz4mk";
+      type = "gem";
+    };
+    version = "2.1.1.0";
+  };
+  poltergeist = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "098zgqhhphazxsikrj5mpsrij0l726wig26nn04bmm4r7n0zi5yl";
+      type = "gem";
+    };
+    version = "1.11.0";
+  };
+  power_assert = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0fpc9fxkr1pwk46v8v2sbcsqjaj7m2a1w8piz6w89mm93z6ak6zq";
+      type = "gem";
+    };
+    version = "0.3.1";
+  };
+  rack = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "053bqbrxr5gjw5k3rrmh6i35s83kgdycxv292lid072vpwrq1xv1";
+      type = "gem";
+    };
+    version = "2.0.1";
+  };
+  rack-test = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0h6x5jq24makgv2fq5qqgjlrk74dxfy62jif9blk43llw8ib2q7z";
+      type = "gem";
+    };
+    version = "0.6.3";
+  };
+  rake = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0cnjmbcyhm4hacpjn337mg1pnaw6hj09f74clwgh6znx8wam9xla";
+      type = "gem";
+    };
+    version = "11.3.0";
+  };
+  rest-client = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1v2jp2ilpb2rm97yknxcnay9lfagcm4k82pfsmmcm9v290xm1ib7";
+      type = "gem";
+    };
+    version = "2.0.0";
+  };
+  rspec = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "16g3mmih999f0b6vcz2c3qsc7ks5zy4lj1rzjh8hf6wk531nvc6s";
+      type = "gem";
+    };
+    version = "3.5.0";
+  };
+  rspec-core = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1nacs062qbr98fx6czf1vwppn1js956nv2c8vfwj6i65axdfs46i";
+      type = "gem";
+    };
+    version = "3.5.4";
+  };
+  rspec-expectations = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0bbqfrb1x8gmwf8x2xhhwvvlhwbbafq4isbvlibxi6jk602f09gs";
+      type = "gem";
+    };
+    version = "3.5.0";
+  };
+  rspec-mocks = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0nl3ksivh9wwrjjd47z5dggrwx40v6gpb3a0gzbp1gs06a5dmk24";
+      type = "gem";
+    };
+    version = "3.5.0";
+  };
+  rspec-support = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "10vf3k3d472y573mag2kzfsfrf6rv355s13kadnpryk8d36yq5r0";
+      type = "gem";
+    };
+    version = "3.5.0";
+  };
+  rubyzip = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "10a9p1m68lpn8pwqp972lv61140flvahm3g9yzbxzjks2z3qlb2s";
+      type = "gem";
+    };
+    version = "1.2.0";
+  };
+  selenium-webdriver = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "063fbypf0sq3jijjz4zvjjy5pahpyvx0xjwj11cpbzq1ksd6jf55";
+      type = "gem";
+    };
+    version = "3.0.0";
+  };
+  test-unit = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1c6grgvwapy6vxkbpmflf9f7xlpxi4ck99mw4jlimpryp8lrnnah";
+      type = "gem";
+    };
+    version = "3.2.1";
+  };
+  unf = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0bh2cf73i2ffh4fcpdn9ir4mhq8zi50ik0zqa1braahzadx536a9";
+      type = "gem";
+    };
+    version = "0.1.4";
+  };
+  unf_ext = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "04d13bp6lyg695x94whjwsmzc2ms72d94vx861nx1y40k3817yp8";
+      type = "gem";
+    };
+    version = "0.0.7.2";
+  };
+  websocket = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "0s8c24pys61wmg7frv9jzqss5i41z1nhz7g1rb4ll4pwxbrakvf0";
+      type = "gem";
+    };
+    version = "1.2.3";
+  };
+  websocket-driver = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "1m37q24mxykvixcj8sv0jz7y2a88spysxg5rp4zf4p1q7mbblshy";
+      type = "gem";
+    };
+    version = "0.6.4";
+  };
+  websocket-extensions = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "07qnsafl6203a2zclxl20hy4jq11c471cgvd0bj5r9fx1qqw06br";
+      type = "gem";
+    };
+    version = "0.1.2";
+  };
+  xpath = {
+    source = {
+      remotes = ["https://rubygems.org"];
+      sha256 = "04kcr127l34p7221z13blyl0dvh0bmxwx326j72idayri36a394w";
+      type = "gem";
+    };
+    version = "2.0.0";
+  };
+}

--- a/local.example.nix
+++ b/local.example.nix
@@ -1,0 +1,22 @@
+# default.nix calls out to the file local.nix if it exists, expecting a function which it will call, applying first
+# the args passed to the original default.nix and then `oldAttrs`, the attrset originally applied to mkDerivation.
+#
+# the function should return an attrset altered to the local user's desires, as they would wish to be applied to
+# mkDerivation to produce the env
+
+args: oldAttrs: oldAttrs // {
+  # here we add some of our favourite packages to the environment which aren't necessarily to everyone's tastes
+  buildInputs = oldAttrs.buildInputs ++ [
+    args.pkgs.vim
+    args.pythonPackages.ipython
+  ];
+
+  shellHook =  oldAttrs.shellHook + ''
+    # PS1 can't be set as a normal derivation attr as it gets clobbered early on in the upstream shellHook script
+    export PS1="⚡$PS1⚡"
+
+    # inject some whimsy into our session - note here we access a package which we don't actually end up
+    # explicitly exposing to the final environment
+    ${args.pkgs.fortune}/bin/fortune
+  '';
+}


### PR DESCRIPTION
See https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/719 for general discussion.

In this repo we take a slightly different approach. I've use a nix tool called `bundix` to generate a nix file (`gemset.nix`) from the `Gemfile` and `Gemfile.lock`. This means that the gems get installed as actual nix packages, inheriting some of the benefits of doing so (notably not *all*). `bundix` is included in this env to make it possible for people to regenerate `gemset.nix`.

Disadvantages of this approach are that the nix file needs to be kept in sync with the `Gemfile.lock` to remain useful and it's not always obvious when things have slipped slightly out of sync. Also you're no longer using the same tool to install your language-level dependencies everywhere so it may not be obvious when subtle problems creep in which don't affect the nix environment, but do affect a direct-bundler environment.

If we really loved this approach, it *is* possible to do the same thing for python projects `requirements.txt` files using a tool called `pypi2nix` (I'm not super-keen on it personally).