### PR TITLE
Fix test fail when there is a service with 'Next' in the name.

### DIFF
--- a/features/smoke-tests/buyer/catalogue.feature
+++ b/features/smoke-tests/buyer/catalogue.feature
@@ -89,9 +89,9 @@ Scenario: User is able to paginate through search results and all of the navigat
   And I click that lot.name
   Then I am on the 'Search results' page
   And I note the number of category links
-  And I click 'Next'
+  And I click the Next Page link
   Then I am taken to page 2 of results
   And I see the same number of category links as noted
-  When I click 'Previous'
+  When I click the Previous Page link
   Then I am taken to page 1 of results
   And I see the same number of category links as noted

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -114,6 +114,17 @@ When /I click #{MAYBE_VAR} ?(button|link)?$/ do |button_link_name, elem_type|
   end
 end
 
+When /I click the (Next|Previous) Page link$/ do |next_or_previous|
+  # can't use above as we have services with the word 'next' in the name :(
+  klass = ''
+  if next_or_previous == 'Next'
+    klass = '.next'
+  elsif next_or_previous == 'Previous'
+    klass = '.previous'
+  end
+  page.find(:css, "#{klass} :link").click()
+end
+
 When /I check #{MAYBE_VAR} checkbox$/ do |checkbox_label|
   check_checkbox(checkbox_label)
 end


### PR DESCRIPTION
Being explicit with which links we want to click on, because of some services having the word 'next' in their name (!)

https://trello.com/c/5t96gz0Z/400-functional-tests