### PR TITLE
Make link text specific to fix bug with two links found

### DIFF
--- a/features/supplier/view_and_edit_services.feature
+++ b/features/supplier/view_and_edit_services.feature
@@ -10,7 +10,7 @@ Background:
 Scenario Outline: Supplier coming from dashboard to view the detail page for one of their services
   Given that supplier has a service on the <lot_slug> lot
   And I am on the /suppliers page
-  When I click 'View'
+  When I click 'View services'
   Then I am on the 'Current services' page
   When I click '<service_name>'
   Then I am on the '<service_name>' page


### PR DESCRIPTION
The tests were finding two links with the text "View", the first
being our "View services" link but also the "View your account"
link in the header. To stop this being an issue, we change our test
to be more explicit about the link it is trying to find.