### PR TITLE
Add skip environment tags for link text that is being deployed

### DIFF
--- a/features/supplier/view_and_edit_services.feature
+++ b/features/supplier/view_and_edit_services.feature
@@ -7,10 +7,30 @@ Background:
   And that supplier is logged in
   And that supplier is on that framework
 
+@skip-staging
 Scenario Outline: Supplier coming from dashboard to view the detail page for one of their services
   Given that supplier has a service on the <lot_slug> lot
   And I am on the /suppliers page
   When I click 'View services'
+  Then I am on the 'Current services' page
+  When I click '<service_name>'
+  Then I am on the '<service_name>' page
+  And I don't see the 'Edit' link
+  And I don't see 'Remove this service' text on the page
+  And I see '<expected_content>' in the '<summary_table_name>' summary table
+
+  Examples:
+    | lot_slug                   | service_name               | summary_table_name          | expected_content |
+    | digital-specialists        | Digital specialists        | Individual specialist roles | Developer        |
+    | digital-outcomes           | Digital outcomes           | Team capabilities           | Agile coaching   |
+    | user-research-participants | User research participants | Recruitment approach        | Entirely offline |
+    | user-research-studios      | GDSvieux Innovation Lab    | Lab address                 | GDSbury          |
+
+@skip-preview @skip-local
+Scenario Outline: Supplier coming from dashboard to view the detail page for one of their services
+  Given that supplier has a service on the <lot_slug> lot
+  And I am on the /suppliers page
+  When I click 'View'
   Then I am on the 'Current services' page
   When I click '<service_name>'
   Then I am on the '<service_name>' page


### PR DESCRIPTION
This is the supplier frontend PR that broke the tests - https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/714