### PR TITLE
Update xpath to only find the next table

### DIFF
--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -251,7 +251,7 @@ Then /^I see the '(.*)' summary table filled with:$/ do |table_heading, table|
 end
 
 Then /^I see '(.*)' in the '(.*)' summary table$/ do |content, table_heading|
-  result_table_location = "//*[@class='summary-item-heading'][normalize-space(text())=\"#{table_heading}\"]/following-sibling::table[1]"
+  result_table_location = "//*[@class='summary-item-heading'][normalize-space(text())=\"#{table_heading}\"]/following-sibling::*[1]"
   result_table_rows_location = result_table_location + "/tbody/tr[@class='summary-item-row']"
   result_table_rows = all(:xpath, result_table_rows_location)
   result_table_rows.any? {|row| row.text.include? content}.should be true


### PR DESCRIPTION
result_table_location = "//*[@class='summary-item-heading'][normalize-space(text())=\"#{table_heading}\"]/following-sibling::table[1]

will find the next sibling table on the page. Because we don't render a table element for empty tables this means that it will find the next 'non-empty table'

For example if out buyers homepage looks like this:

```
Unpublished requirements
You don’t have any unpublished requirements

Published requirements
You don’t have any published requirements

Closed requirements
Name	Closed	Responses
Some requirement	Wednesday 15 March 2017	View responses
```

And we look for the 'Published requirements' table we will find the next sibling table of the Published requirements header.
The next sibling _table_ is actually the closed requirements table.

The new xpath finds the next sibling _anything_