### PR TITLE
admin dashboard: temporarily disable link to "Service updates"

### DIFF
--- a/features/step_definitions/journey_test_steps.rb
+++ b/features/step_definitions/journey_test_steps.rb
@@ -1265,7 +1265,8 @@ Then /I am presented with the Service status changes page for changes made '(.*)
 
   page.should have_selector(:xpath, "//*[@id='global-breadcrumb']/nav/*[@role='breadcrumbs']/li[1]//*[contains(text(), 'Admin home')]")
   page.should have_selector(:xpath, "//*[@id='global-breadcrumb']/nav/*[@role='breadcrumbs']/li[2][contains(text(), 'Audits')]")
-  page.should have_link('Service updates')
+  # temporarily disabled
+  #page.should have_link('Service updates')
   page.should have_link('Service status changes')
   page.should have_link('Log out')
 end


### PR DESCRIPTION
Link has been removed until we decide to "announce" this feature.