### PR TITLE
Use supplier user id for signing framework agreement

### DIFF
--- a/features/step_definitions/brief_response_steps.rb
+++ b/features/step_definitions/brief_response_steps.rb
@@ -32,7 +32,7 @@ Given 'we accept that suppliers application to the framework' do
 end
 
 Given 'that supplier returns a signed framework agreement for the framework' do
-  sign_framework_agreement(@framework['slug'], @supplier['id'])
+  sign_framework_agreement(@framework['slug'], @supplier['id'], @supplier_user['id'])
 end
 
 Given /^that supplier has a service on the (.*) lot(?: for the (.*) role)?$/ do |lot_slug, role_type|

--- a/features/supplier/view_and_edit_services.feature
+++ b/features/supplier/view_and_edit_services.feature
@@ -5,9 +5,9 @@ Background:
   Given I have a live digital outcomes and specialists framework
   And I have a supplier
   And that supplier is logged in
-  And 'that supplier has applied to be on that framework'
-  And 'we accept that suppliers application to the framework'
-  And 'that supplier returns a signed framework agreement for the framework'
+  And that supplier has applied to be on that framework
+  And we accept that suppliers application to the framework
+  And that supplier returns a signed framework agreement for the framework
 
 @skip-staging
 Scenario Outline: Supplier coming from dashboard to view the detail page for one of their services

--- a/features/support/api_helpers.rb
+++ b/features/support/api_helpers.rb
@@ -122,7 +122,7 @@ def submit_supplier_declaration(framework_slug, supplier_id, declaration)
   JSON.parse(response.body)['declaration']
 end
 
-def sign_framework_agreement(framework_slug, supplier_id)
+def sign_framework_agreement(framework_slug, supplier_id, supplier_user_id)
   path = "/agreements"
   response = call_api(:post, path, payload: {
     updated_by: "functional tests",
@@ -146,7 +146,7 @@ def sign_framework_agreement(framework_slug, supplier_id)
       signedAgreementDetails: {
         signerName: "answer_required",
         signerRole: "answer_required",
-        uploaderUserId: 1
+        uploaderUserId: supplier_user_id
       }
     }
   })


### PR DESCRIPTION
### Use supplier_user_id when signing framework

The api helper to sign a framework agreement was using a hard coded ID
of `1` for the `uploaderUserId`. This is fine if there is a user with an ID
of `1`. If not it fails to sign the framework agreement and the functional
test fail at a later point.

This occurred when moving cleaned up data from prod to staging.

Passing in the supplier user id an argument to the helper solves this
issue.

### Remove quotes from steps that prevents them running

There were quotes around some steps in the `view_and_edit_services`
scenarios. This means they weren't matching with the step definitions
and so weren't being run, just skipped. This is different to a failure
and so may have been missed.

Tests seem to pass with them being run so I'm correcting here.