### PR TITLE
Add briefs-frontend status check to the smoke tests

### DIFF
--- a/features/smoke-tests/apps_status.feature
+++ b/features/smoke-tests/apps_status.feature
@@ -19,6 +19,12 @@ Feature: Apps /_status is ok
     Then I see 'ok' as the value of the 'status' JSON field
     And Display the value of the 'version' JSON field as 'Release version'
 
+  @status @briefs-frontend
+  Scenario: Check the briefs frontend /_status
+    Given I am on the frontend /buyers/_status page
+    Then I see 'ok' as the value of the 'status' JSON field
+    And Display the value of the 'version' JSON field as 'Release version'
+
   @status @supplier-frontend
   Scenario: Check the suppliers frontend /_status
     Given I am on the frontend /suppliers/_status page


### PR DESCRIPTION
Outputs the briefs frontend release version before running the rest of the test suite.