### PR TITLE
Add routing for /buyers/direct-award and high-level test

### DIFF
--- a/features/buyer/direct-award.feature
+++ b/features/buyer/direct-award.feature
@@ -1,0 +1,12 @@
+@skip-staging @skip-production
+@direct-award
+Feature: Direct Award flows
+
+Scenario: User can save a search into a new Direct Award Project
+  Given I am logged in as a buyer user
+  And I am on the /g-cloud/search page
+  And I click 'Save your search'
+  Then I am on the 'Save your search' page
+  And I enter 'my cloud procurement' in the 'Name a new procurement project' field
+  And I click 'Create project and save search'
+  Then I am on the 'Project - my cloud procurement' page

--- a/features/smoke-tests/buyer/direct-award.feature
+++ b/features/smoke-tests/buyer/direct-award.feature
@@ -1,0 +1,10 @@
+@skip-staging @skip-production
+@smoke-tests
+@direct-award-passive
+Feature: Direct Award passive assurance
+
+Scenario: User is required to login to save a search
+  Given I am on the /g-cloud/search page
+  Then I see the 'Save your search' button
+  And I click 'Save your search'
+  Then I am on the 'Log in to the Digital Marketplace' page

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -21,6 +21,10 @@ http {
             proxy_pass http://localhost:5002;
         }
 
+        location /buyers/direct-award {
+            proxy_pass http://localhost:5002;
+        }
+
         location /admin {
             proxy_pass http://localhost:5004;
         }


### PR DESCRIPTION
## Summary
Updates dev bootstrap script to add routing for `/buyers/direct-award` to the buyer-frontend app.

## Corresponding PR
https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/581

## Ticket
https://trello.com/c/Hlq5mzAy/619-save-a-search-and-create-a-project