### PR TITLE
Find radio button labels using id

### DIFF
--- a/features/support/helpers.rb
+++ b/features/support/helpers.rb
@@ -42,7 +42,7 @@ def return_element(type, locator_or_element, options={})
   end
 
   # If the label for this radio/checkbox is not visible, it is effectively hidden from the user
-  element.find_xpath('parent::label')[0].visible?.should be(true), "Expected label for #{type} \"#{element.value}\" to be visible"
+  page.all(:xpath, "//label[@for='#{element[:id]}']")[0].visible?.should be(true), "Expected label for #{type} \"#{element.value}\" to be visible"
 
   return element
 end


### PR DESCRIPTION
Due to an update in the frontend toolkit, radio button inputs are no
longer nested inside their labels. The input and the label are now both
in a div, and the label linked to the input via it's id.

We were checking that radio button's label were visible, and finding the
label by selecting the radio buttons parent. This no longer works.

Instead, we can use the radio buttons id and find all labels whos `for`
attribute is the radio button's id.