### PR TITLE
Use the scripts docker image to reindex services

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ docker-up:
 
 index-services:
 	$(if ${FRAMEWORKS},,$(error Must specify FRAMEWORKS))
-	docker run --net=host digitalmarketplace/scripts index-services.py dev --api-token=myToken --search-api-token=myToken --frameworks=${FRAMEWORKS}
+	docker run --net=host digitalmarketplace/scripts scripts/index-services.py dev --api-token=myToken --search-api-token=myToken --frameworks=${FRAMEWORKS}
 
 
 .PHONY: smoke-tests run rerun setup install clean docker-up index-services

--- a/Makefile
+++ b/Makefile
@@ -32,15 +32,8 @@ docker-up:
 	docker-compose up
 
 index-services:
-	$(if ${DM_SCRIPTS_REPO},,$(error Must specify DM_SCRIPTS_REPO))
 	$(if ${FRAMEWORKS},,$(error Must specify FRAMEWORKS))
-	cd ${DM_SCRIPTS_REPO} && \
-	virtualenv indexingvenv && \
-	source indexingvenv/bin/activate && \
-	pip install -r requirements.txt && \
-	./scripts/index-services.py dev --api-token=myToken --search-api-token=myToken --frameworks=${FRAMEWORKS} && \
-	deactivate && \
-	rm -fr indexingvenv
+	docker run --net=host digitalmarketplace/scripts index-services.py dev --api-token=myToken --search-api-token=myToken --frameworks=${FRAMEWORKS}
 
 
 .PHONY: smoke-tests run rerun setup install clean docker-up index-services


### PR DESCRIPTION
Replaces the virtualenv setup with running the container. It doesn't automatically update the scripts image to the latest version to avoid accidentally overwriting local changes, so you might need to run `docker pull digitalmarketplace/scripts` if it's out of date.

(But the index-services scripts doesn't change too often.)