### PR TITLE
Adapt legacy tests to handle reorganization of supplier dashboard

### DIFF
--- a/features/admin/admin_journey.feature
+++ b/features/admin/admin_journey.feature
@@ -102,14 +102,14 @@ Scenario: As an admin user who has logged in to Digital Marketplace, I wish to d
   When I click the 'Deactivate' button for the supplier user 'DM Functional Test Supplier User 2'
   Then The supplier user 'DM Functional Test Supplier User 2' is 'not active'
   And The supplier user 'DM Functional Test Supplier User 2' 'can not' login to Digital Marketplace
-  And The supplier user 'DM Functional Test Supplier User 2' 'is not' listed as a contributor on the dashboard of another user of the same supplier
+  And The supplier user 'DM Functional Test Supplier User 2' 'is not' listed as a contributor on the contributors page of another user of the same supplier
 
 Scenario: As an admin user who has logged in to Digital Marketplace, I wish to activate a deactivated supplier user
   Given I am logged in as 'Administrator' and navigated to the 'Users' page for supplier 'DM Functional Test Supplier'
   When I click the 'Activate' button for the supplier user 'DM Functional Test Supplier User 2'
   Then The supplier user 'DM Functional Test Supplier User 2' is 'active'
   And The supplier user 'DM Functional Test Supplier User 2' 'can' login to Digital Marketplace
-  And The supplier user 'DM Functional Test Supplier User 2' 'is' listed as a contributor on the dashboard of another user of the same supplier
+  And The supplier user 'DM Functional Test Supplier User 2' 'is' listed as a contributor on the contributors page of another user of the same supplier
 
 Scenario: As an admin user who has logged in to Digital Marketplace, I wish unlock a locked supplier
   Given I am logged in as 'Administrator' and navigated to the 'Users' page for supplier 'DM Functional Test Supplier'

--- a/features/step_definitions/journey_test_steps.rb
+++ b/features/step_definitions/journey_test_steps.rb
@@ -55,10 +55,13 @@ end
 
 And /The supplier user '(.*)' '(.*)' login to Digital Marketplace$/ do |user_name,ability|
   visit("#{dm_frontend_domain}/login")
+  email_address = dm_supplier_user_email()
   if user_name == 'DM Functional Test Supplier User 2'
     page.fill_in('email_address', :with => dm_supplier_user2_email())
+    email_address = dm_supplier_user2_email()
   elsif user_name == 'DM Functional Test Supplier User 3'
     page.fill_in('email_address', :with => dm_supplier_user3_email())
+    email_address = dm_supplier_user3_email()
   end
 
   page.fill_in('password', :with => dm_supplier_password())
@@ -67,7 +70,7 @@ And /The supplier user '(.*)' '(.*)' login to Digital Marketplace$/ do |user_nam
   if ability == 'can not'
     page.should have_content('Make sure you\'ve entered the right email address and password.')
   elsif ability == 'can'
-    step "Then I am presented with the 'DM Functional Test Supplier' 'Supplier' dashboard page"
+    step "Then I am presented with the 'DM Functional Test Supplier' 'Supplier' dashboard page for '#{email_address}'"
   end
 end
 
@@ -651,18 +654,18 @@ Then /I am presented with the service details page for that service$/ do
   page.should have_content(@existing_values['serviceprice'])
 end
 
-Then /I am presented with the '(.*)' '(.*)' dashboard page$/ do |user_type_name, user_type|
+Then /I am presented with the '(.*)' '(.*)' dashboard page(?: for '(.*)')?$/ do |user_type_name, user_type, email_override|
   user_type = user_type.downcase
   case user_type
   when "buyer"
     ['Unpublished requirements', 'Published requirements'].each do |header|
       page.should have_selector(:xpath, ".//h2[@class='summary-item-heading'][contains(text(), '#{header}')]")
     end
-    page.should have_content(dm_buyer_email())
+    page.should have_content(email_override || dm_buyer_email())
   when "supplier"
     @existing_values = @existing_values || Hash.new
     @existing_values['summarypageurl'] = current_url
-    page.should have_content(dm_supplier_user_email())
+    page.should have_content(email_override || dm_supplier_user_email())
   else
     fail("User type \"#{user_type}\" does not exist")
   end

--- a/features/step_definitions/journey_test_steps.rb
+++ b/features/step_definitions/journey_test_steps.rb
@@ -464,7 +464,7 @@ And /I add '(.*)' as a '(.*)'$/ do |value,item_to_add|
   @changed_fields[item_to_add] = value
 end
 
-Then /I am presented with the dashboard page with the changes that were made to the '(.*)'$/ do |service_aspect|
+Then /I am presented with the supplier details page with the changes that were made to the '(.*)'$/ do |service_aspect|
   find(
     :xpath,
     "//caption[contains(text(), '#{service_aspect}')]/..//*[contains(text(), 'Supplier summary')]/../../td[2]/span"
@@ -871,10 +871,9 @@ Then /I am presented with the 'Suppliers' page for all suppliers starting with '
   # end
 end
 
-Then /I can see active users associated with '(.*)' on the dashboard$/ do |supplier_name|
-  page.should have_selector(:xpath, "//*[@class='summary-item-heading'][contains(text(), 'Contributors')]")
+Then /I can see active users associated with '(.*)' on the page$/ do |supplier_name|
   ['Name', 'Email address'].each do |header|
-    page.should have_selector(:xpath, "//caption[contains(text(), 'Contributors')]/..//th/span[contains(text(), '#{header}')]")
+    page.should have_selector(:xpath, "//caption[contains(normalize-space(string()), 'Contributors')]/..//th[contains(normalize-space(string()), '#{header}')]")
   end
   [
     'DM Functional Test Supplier User 1', dm_supplier_user_email(),
@@ -1095,8 +1094,11 @@ Then /The supplier user '(.*)' is '(.*)' on the admin Users page$/ do |user_name
   }
 end
 
-And /The supplier user '(.*)' '(.*)' listed as a contributor on the dashboard of another user of the same supplier$/ do |user_name,value|
- step "I am logged in as 'DM Functional Test Supplier' 'Supplier' user and am on the dashboard page"
+And /The supplier user '(.*)' '(.*)' listed as a contributor on the contributors page of another user of the same supplier$/ do |user_name,value|
+ steps %Q{
+    Given I am logged in as 'DM Functional Test Supplier' 'Supplier' user and am on the dashboard page
+    And I click 'Contributors'
+ }
 
   if value == 'is not'
     page.should have_no_selector(:xpath, "//*[@class='summary-item-field-first']/span[contains(text(), 'DM Functional Test Supplier User 2')]")

--- a/features/supplier/supplier_journey.feature
+++ b/features/supplier/supplier_journey.feature
@@ -14,13 +14,14 @@ Scenario: As supplier user I wish be able to log in and to log out of Digital Ma
   When I click 'Log out'
   Then I am logged out of Digital Marketplace as a 'Supplier' user
 
-Scenario: As a logged in supplier user, I can see my active contributors on the dashboard
+Scenario: As a logged in supplier user, I can see my active contributors on the contributors page
   Given I am logged in as 'DM Functional Test Supplier' 'Supplier' user and am on the dashboard page
-  Then I can see active users associated with 'DM Functional Test Supplier' on the dashboard
+  When I click 'Contributors'
+  Then I can see active users associated with 'DM Functional Test Supplier' on the page
 
 Scenario: As a logged in supplier user, I can navigate to the contributors page from my dashboard and I can remove one
   Given I am logged in as 'DM Functional Test Supplier' 'Supplier' user and am on the dashboard page
-  When I click 'Invite or remove'
+  When I click 'Contributors'
   Then I am presented with the supplier 'DM Functional Test Supplier' 'Invite or remove contributors' page
   When I remove the supplier user 'DM Functional Test Supplier User 2'
   Then I see a confirmation message after having removed supplier user 'DM Functional Test Supplier User 2'
@@ -32,7 +33,9 @@ Scenario: As a logged in supplier user, I can navigate to the contributors page 
 
 Scenario: As a logged in supplier user, I can edit my supplier information
   Given I am logged in as 'DM Functional Test Supplier' 'Supplier' user and am on the dashboard page
-  When I navigate to the 'Edit' 'Supplier information' page
+  When I click 'Supplier details'
+  Then I am presented with the supplier 'DM Functional Test Supplier' 'Supplier details' page
+  And I click 'Edit'
   And I change 'input-description' to 'Supplier changed the service description'
   And I change 'input-clients-3' to 'Supplier changed the third client'
   And I remove client number 2
@@ -46,7 +49,7 @@ Scenario: As a logged in supplier user, I can edit my supplier information
   And I change 'contact_country-input' to 'Supplier changed the country'
   And I change 'contact_postcode-input' to 'PCC'
   And I click 'Save and return'
-  Then I am presented with the dashboard page with the changes that were made to the 'Supplier information'
+  Then I am presented with the supplier details page with the changes that were made to the 'Supplier details'
 
 @wip
 Scenario: As a logged in supplier user, I can edit the description of a service


### PR DESCRIPTION
Though I realize the general policy is to allow legacy functional tests to break and disable them, doing so with these changes would have probably caused quite a few downstream tests to break. So for instance one thing I did was fix the "user can login" test to check for the correct email address...