### PR TITLE
Awarding a requirement to a winning supplier

### DIFF
--- a/features/buyer/award_requirements.feature
+++ b/features/buyer/award_requirements.feature
@@ -1,4 +1,4 @@
-@award
+@award @skip-staging
 Feature: Award a requirement
   In order to ensure the procurement process is fair and transparent
   As a buyer within government

--- a/features/buyer/award_requirements.feature
+++ b/features/buyer/award_requirements.feature
@@ -1,0 +1,36 @@
+@award
+Feature: Award a requirement
+  In order to ensure the procurement process is fair and transparent
+  As a buyer within government
+  I want to be able to publish the result of my procurement process
+
+
+Background: Ensure we can log in as a buyer with a closed brief
+  Given I am logged in as the buyer of a closed brief with responses
+  When I click the 'View your account' link
+  Then I see that the 'Closed requirements' summary table has 1 or more entries
+
+
+Scenario: Award a requirement to a winning supplier
+  Given I click the 'View your account' link
+  Then I see the 'Tell us who won this contract' link
+  When I click a link with class name 'award-contract-link'
+  Then I am on the 'Who won' page
+  When I choose a random 'brief_response' radio button
+  When I click the 'Save and continue' button
+  Then I am on the 'Tell us about your contract' page
+  When I enter '1' in the 'input-awardedContractStartDate-day' field
+  When I enter '1' in the 'input-awardedContractStartDate-month' field
+  When I enter '2020' in the 'input-awardedContractStartDate-year' field
+  When I enter '20000.00' in the 'input-awardedContractValue' field
+  When I click the 'Submit' button
+  And I see a success banner message containing 'updated'
+
+  When I go to that brief overview page
+  Then I see the 'View and shortlist suppliers' link
+
+  When I go to that brief page
+  Then I see a temporary-message banner message containing 'Awarded to'
+  And I see a temporary-message banner message containing 'Start date: Wednesday 1 January 2020'
+  And I see a temporary-message banner message containing 'Value: £20,000'
+  And I see a temporary-message banner message containing 'Company size'

--- a/features/buyer/requirements.feature
+++ b/features/buyer/requirements.feature
@@ -199,15 +199,30 @@ Scenario: There is no 'Publish requirements' button for an incomplete requiremen
 
 
 Scenario: Ensure we can log in as a buyer with a closed brief
-  Given I am logged in as the buyer of a closed brief
+  Given I am logged in as the buyer of a closed brief with responses
   When I click the 'View your account' link
   Then I see that the 'Closed requirements' summary table has 1 or more entries
 
 
-@award
+@requirements @award
 Scenario: Award a requirement to a winning supplier
   Given I am logged in as the buyer of a closed brief with responses
   When I click the 'View your account' link
   Then I see the 'Tell us who won this contract' link
   When I click a link with class name 'award-contract-link'
   Then I am on the 'Who won' page
+  When I choose a random 'brief_response' radio button
+  When I click the 'Save and continue' button
+  Then I am on the 'Tell us about your contract' page
+  When I enter '1' in the 'input-awardedContractStartDate-day' field
+  When I enter '1' in the 'input-awardedContractStartDate-month' field
+  When I enter '2020' in the 'input-awardedContractStartDate-year' field
+  When I enter '20000.00' in the 'input-awardedContractValue' field
+  When I click the 'Submit' button
+  And I see a success banner message containing 'updated'
+
+  When I go to that brief overview page
+  Then I see the 'View and shortlist suppliers' link
+
+  When I go to that brief page
+  Then I see a temporary-message banner message containing 'This opportunity is closed for applications'

--- a/features/buyer/requirements.feature
+++ b/features/buyer/requirements.feature
@@ -196,3 +196,9 @@ Scenario: There is no 'Publish requirements' button for an incomplete requiremen
   And I have created an individual specialist requirement
   When I click 'Review and publish your requirements'
   Then I don't see the 'Publish requirements' button
+
+
+Scenario: Ensure we can log in as a buyer with a closed brief
+  Given I am logged in as the buyer of a closed brief
+  When I click the 'View your account' link
+  Then I see that the 'Closed requirements' summary table has 1 or more entries

--- a/features/buyer/requirements.feature
+++ b/features/buyer/requirements.feature
@@ -196,35 +196,3 @@ Scenario: There is no 'Publish requirements' button for an incomplete requiremen
   And I have created an individual specialist requirement
   When I click 'Review and publish your requirements'
   Then I don't see the 'Publish requirements' button
-
-
-Scenario: Ensure we can log in as a buyer with a closed brief
-  Given I am logged in as the buyer of a closed brief with responses
-  When I click the 'View your account' link
-  Then I see that the 'Closed requirements' summary table has 1 or more entries
-
-
-Scenario: Award a requirement to a winning supplier
-  Given I am logged in as the buyer of a closed brief with responses
-  When I click the 'View your account' link
-  Then I see the 'Tell us who won this contract' link
-  When I click a link with class name 'award-contract-link'
-  Then I am on the 'Who won' page
-  When I choose a random 'brief_response' radio button
-  When I click the 'Save and continue' button
-  Then I am on the 'Tell us about your contract' page
-  When I enter '1' in the 'input-awardedContractStartDate-day' field
-  When I enter '1' in the 'input-awardedContractStartDate-month' field
-  When I enter '2020' in the 'input-awardedContractStartDate-year' field
-  When I enter '20000.00' in the 'input-awardedContractValue' field
-  When I click the 'Submit' button
-  And I see a success banner message containing 'updated'
-
-  When I go to that brief overview page
-  Then I see the 'View and shortlist suppliers' link
-
-  When I go to that brief page
-  Then I see a temporary-message banner message containing 'Awarded to'
-  And I see a temporary-message banner message containing 'Start date: Wednesday 1 January 2020'
-  And I see a temporary-message banner message containing 'Value: £20,000'
-  And I see a temporary-message banner message containing 'Company size'

--- a/features/buyer/requirements.feature
+++ b/features/buyer/requirements.feature
@@ -202,3 +202,12 @@ Scenario: Ensure we can log in as a buyer with a closed brief
   Given I am logged in as the buyer of a closed brief
   When I click the 'View your account' link
   Then I see that the 'Closed requirements' summary table has 1 or more entries
+
+
+@award
+Scenario: Award a requirement to a winning supplier
+  Given I am logged in as the buyer of a closed brief with responses
+  When I click the 'View your account' link
+  Then I see the 'Tell us who won this contract' link
+  When I click a link with class name 'award-contract-link'
+  Then I am on the 'Who won' page

--- a/features/buyer/requirements.feature
+++ b/features/buyer/requirements.feature
@@ -204,7 +204,6 @@ Scenario: Ensure we can log in as a buyer with a closed brief
   Then I see that the 'Closed requirements' summary table has 1 or more entries
 
 
-@requirements @award
 Scenario: Award a requirement to a winning supplier
   Given I am logged in as the buyer of a closed brief with responses
   When I click the 'View your account' link
@@ -225,4 +224,7 @@ Scenario: Award a requirement to a winning supplier
   Then I see the 'View and shortlist suppliers' link
 
   When I go to that brief page
-  Then I see a temporary-message banner message containing 'This opportunity is closed for applications'
+  Then I see a temporary-message banner message containing 'Awarded to'
+  And I see a temporary-message banner message containing 'Start date: Wednesday 1 January 2020'
+  And I see a temporary-message banner message containing 'Value: £20,000'
+  And I see a temporary-message banner message containing 'Company size'

--- a/features/step_definitions/brief_response_steps.rb
+++ b/features/step_definitions/brief_response_steps.rb
@@ -30,6 +30,8 @@ end
 Given /^I am logged in as the buyer of a closed brief with responses$/ do
   submitted_brief_response = get_brief_responses('digital-outcomes-and-specialists-2', 'submitted', 'closed').sample
   closed_brief = get_brief(submitted_brief_response['brief']['id'])
+  @brief_id = closed_brief['id']
+  @lot_slug = closed_brief['lotSlug']
   @buyer = closed_brief['users'][0]
   @buyer.update({'password' => ENV["DM_PRODUCTION_BUYER_USER_PASSWORD"]})
   steps %Q{
@@ -39,6 +41,11 @@ end
 
 Given /^I go to that brief page$/ do
   url = "/digital-outcomes-and-specialists/opportunities/#{@brief_id}"
+  page.visit("#{dm_frontend_domain}#{url}")
+end
+
+Given /^I go to that brief overview page$/ do
+  url = "/buyers/frameworks/digital-outcomes-and-specialists-2/requirements/#{@lot_slug}/#{@brief_id}"
   page.visit("#{dm_frontend_domain}#{url}")
 end
 

--- a/features/step_definitions/brief_response_steps.rb
+++ b/features/step_definitions/brief_response_steps.rb
@@ -27,6 +27,16 @@ Given /^I am logged in as the buyer of a closed brief$/ do
   }
 end
 
+Given /^I am logged in as the buyer of a closed brief with responses$/ do
+  submitted_brief_response = get_brief_responses('digital-outcomes-and-specialists-2', 'submitted', 'closed').sample
+  closed_brief = get_brief(submitted_brief_response['brief']['id'])
+  @buyer = closed_brief['users'][0]
+  @buyer.update({'password' => ENV["DM_PRODUCTION_BUYER_USER_PASSWORD"]})
+  steps %Q{
+    Given that buyer is logged in
+  }
+end
+
 Given /^I go to that brief page$/ do
   url = "/digital-outcomes-and-specialists/opportunities/#{@brief_id}"
   page.visit("#{dm_frontend_domain}#{url}")

--- a/features/step_definitions/brief_response_steps.rb
+++ b/features/step_definitions/brief_response_steps.rb
@@ -18,6 +18,15 @@ Given /^I have a (draft|live|withdrawn) (.*) brief$/ do |status, lot_slug|
   @brief = brief
 end
 
+Given /^I am logged in as the buyer of a closed brief$/ do
+  closed_brief = get_briefs('digital-outcomes-and-specialists-2', 'closed').sample
+  @buyer = closed_brief['users'][0]
+  @buyer.update({'password' => ENV["DM_PRODUCTION_BUYER_USER_PASSWORD"]})
+  steps %Q{
+    Given that buyer is logged in
+  }
+end
+
 Given /^I go to that brief page$/ do
   url = "/digital-outcomes-and-specialists/opportunities/#{@brief_id}"
   page.visit("#{dm_frontend_domain}#{url}")

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -251,7 +251,7 @@ Then /^I see the '(.*)' summary table filled with:$/ do |table_heading, table|
 end
 
 Then /^I see '(.*)' in the '(.*)' summary table$/ do |content, table_heading|
-  result_table_location = "//*[@class='summary-item-heading'][normalize-space(text())=\"#{table_heading}\"]/following-sibling::table[1]"
+  result_table_location = "//*[@class='summary-item-heading'][normalize-space(text())=\"#{table_heading}\"]/following-sibling::*[1]"
   result_table_rows_location = result_table_location + "/tbody/tr[@class='summary-item-row']"
   result_table_rows = all(:xpath, result_table_rows_location)
   result_table_rows.any? {|row| row.text.include? content}.should be true

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -257,6 +257,20 @@ Then /^I see '(.*)' in the '(.*)' summary table$/ do |content, table_heading|
   result_table_rows.any? {|row| row.text.include? content}.should be true
 end
 
+Then /^I see that the '(.*)' summary table has (\d+)(?: or (more|fewer))? entr(?:y|ies)$/ do |table_heading, expected_number_of_rows, comparison|
+  result_table_location = "//*[@class='summary-item-heading'][normalize-space(text())=\"#{table_heading}\"]/following-sibling::*[1]"
+  result_table_rows_location = result_table_location + "/tbody/tr[@class='summary-item-row']"
+  number_of_table_rows = all(:xpath, result_table_rows_location).length
+  case comparison
+    when 'more'
+      number_of_table_rows.should >= expected_number_of_rows.to_i
+    when 'fewer'
+      number_of_table_rows.should <= expected_number_of_rows.to_i
+    else
+      puts number_of_table_rows.should == expected_number_of_rows.to_i
+  end
+end
+
 Then /^I see the closing date of the brief in the '(.*)' summary table$/ do |table_heading|
   closing_date = DateTime.strptime(@brief['createdAt'], '%Y-%m-%dT%H:%M:%S') + 14
   step "I see '#{closing_date.strftime('%A %-d %B %Y')}' in the '#{table_heading}' summary table"

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -115,6 +115,10 @@ When /I click #{MAYBE_VAR} ?(button|link)?$/ do |button_link_name, elem_type|
   end
 end
 
+When /I click a (button|link) with class name #{MAYBE_VAR}$/ do |elem_type, button_link_class|
+  page.all("." + button_link_class)[1].click
+end
+
 When /I click the (Next|Previous) Page link$/ do |next_or_previous|
   # can't use above as we have services with the word 'next' in the name :(
   klass = ''

--- a/features/support/api_helpers.rb
+++ b/features/support/api_helpers.rb
@@ -152,6 +152,12 @@ def sign_framework_agreement(framework_slug, supplier_id, supplier_user_id)
   })
 end
 
+def get_briefs(framework_slug, status)
+  params = {status: status, framework: framework_slug, with_users: 'True'}
+  response = call_api(:get, '/briefs', params: params)
+  JSON.parse(response.body)['briefs']
+end
+
 def create_brief(framework_slug, lot_slug, user_id)
   brief_data = {
     updated_by: "functional tests"

--- a/features/support/api_helpers.rb
+++ b/features/support/api_helpers.rb
@@ -152,10 +152,22 @@ def sign_framework_agreement(framework_slug, supplier_id, supplier_user_id)
   })
 end
 
+def get_brief(brief_id)
+  response = call_api(:get, "/briefs/#{brief_id}")
+  JSON.parse(response.body)['briefs']
+end
+
 def get_briefs(framework_slug, status)
   params = {status: status, framework: framework_slug, with_users: 'True'}
   response = call_api(:get, '/briefs', params: params)
   JSON.parse(response.body)['briefs']
+end
+
+def get_brief_responses(framework_slug, brief_response_status, brief_status)
+  params = {status: brief_response_status, framework: framework_slug}
+  response = call_api(:get, '/brief-responses', params: params)
+  brief_response_list = JSON.parse(response.body)['briefResponses']
+  brief_response_list.select { |x| x['brief']['status'] == brief_status }
 end
 
 def create_brief(framework_slug, lot_slug, user_id)


### PR DESCRIPTION
Trello ticket: https://trello.com/c/kGVfzXuH/749-3-collect-award-status-on-buyer-dashboard

Covers the 'yes' path for the awards flow:
- Click on the 'Tell us who won this contract' link
- Choose a supplier from the list
- Enter contract details
- View success banner on dashboard
- Overview page still shows 'view and shortlist suppliers' link
- Public brief page still shows header as per a closed brief

Once the award details display ticket is merged we can add the relevant steps.

This branch also includes some helper methods to find a closed Brief (with at least one BriefResponse), so we can successfully award it.