### PR TITLE
Update for new words on supplier details page

### DIFF
--- a/features/step_definitions/journey_test_steps.rb
+++ b/features/step_definitions/journey_test_steps.rb
@@ -475,11 +475,11 @@ Then /I am presented with the supplier details page with the changes that were m
   ).text().should have_content(@changed_fields['contact_contactName'])
   find(
     :xpath,
-    "//caption[contains(text(), '#{service_aspect}')]/..//*[contains(text(), 'Email address')]/../../td[2]/span"
+    "//caption[contains(text(), '#{service_aspect}')]/..//*[contains(text(), 'Contact email')]/../../td[2]/span"
   ).text().should have_content(@changed_fields['contact_email'])
   find(
     :xpath,
-    "//caption[contains(text(), '#{service_aspect}')]/..//*[contains(text(), 'Phone number')]/../../td[2]/span"
+    "//caption[contains(text(), '#{service_aspect}')]/..//*[contains(text(), 'Contact phone number')]/../../td[2]/span"
   ).text().should have_content(@changed_fields['contact_phoneNumber'])
   find(
     :xpath,


### PR DESCRIPTION
**TO BE MERGED AT THE SAME TIME AS SUPPLIER FRONTEND PR**

These changes should keep the legacy functional tests happy when this PR gets merged:
https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/735

Running locally against that supplier frontend branch:
![screen shot 2017-08-30 at 16 55 09](https://user-images.githubusercontent.com/6525554/29912049-3445f69a-8e28-11e7-8ad5-2b3d90b5e00a.png)
