### PR TITLE
Frontend toolkit v23 label fix

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -148,6 +148,9 @@ services:
 
   nginx:
     image: "digitalmarketplace/local-nginx:latest"
+    build:
+      context: ./
+      dockerfile: ./local-nginx.docker
     ports:
       - "80:80"
     depends_on:

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -64,5 +64,5 @@ def dm_pagination_limit()
   (ENV['DM_PAGINATION_LIMIT'] || 100).to_i
 end
 
+Capybara.asset_host = dm_frontend_domain
 Capybara.save_path = "reports/"
-Capybara::Screenshot.prune_strategy = { keep: 100 }

--- a/features/support/form_helpers.rb
+++ b/features/support/form_helpers.rb
@@ -48,7 +48,7 @@ module FormHelper
   end
 
   def get_parent_label(el)
-    el.find_xpath('parent::label')[0]
+    el.find_xpath("//label[@for='#{el[:id]}']")[0]
   end
 
   def find_fields(locator=nil, options={})


### PR DESCRIPTION
## Add build instructions for local nginx to the compose file

There's no make step defined for building the nginx image locally, but since we have a docker compose file in this repo we can us it to run the image build.

Adding `build` to the container definition allows running `docker-compose build` to rerun `docker build` on all defined images. Docker will automatically tag the images with the tag from `image:`.

## Disable capybara screenshot pruning and add host prefix to HTML paths

Our make steps delete the report/ folder before each run, so we can disable capybara's builtin prune logic (by default capybara should keep all screenshots indefinitely).

Setting `asset_host` makes capybara prepend it to all asset paths in HTML snapshots, so the page can be viewed with all assets as long as `dm_frontend_domain` is available (ie frontend apps are up locally when viewing results from local functional tests).

## Update field search for frontend-toolkit v23 input/label layout

New version of frontend-toolkit form layouts put the `<input>` tag before the `<label>` instead of nesting it inside the tag.

We need to update the XPath expressions we use to find the label related to a given input. Instead of using the parent element, we look for the label that has a `for` attribute set to current input's
id.