### PR TITLE
Jenkins update steps for user frontend

### DIFF
--- a/features/admin/admin_journey.feature
+++ b/features/admin/admin_journey.feature
@@ -10,11 +10,11 @@ Scenario: Setup for tests
   And The user 'DM Functional Test Supplier User 3' is locked
 
 Scenario: As an admin user I wish be able to log in and to log out of Digital Marketplace
-  Given I am on the 'Administrator' login page
+  Given I am on the login page
   When I login as a 'Administrator' user
   Then I am presented with the admin search page
   When I click 'Log out'
-  Then I am logged out of Digital Marketplace as a 'Administrator' user
+  Then I am logged out of Digital Marketplace
 
 Scenario: As an admin user who has logged in to Digital Marketplace, I wish to search for a service by service ID
   Given I have logged in to Digital Marketplace as a 'Administrator' user

--- a/features/step_definitions/journey_test_steps.rb
+++ b/features/step_definitions/journey_test_steps.rb
@@ -47,6 +47,11 @@ end
 
 And /The supplier user '(.*)' '(.*)' login to Digital Marketplace$/ do |user_name,ability|
   visit("#{dm_frontend_domain}/user/login")
+  
+  if page.has_button?("Log out")
+    page.click_button("Log out")
+  end
+
   email_address = dm_supplier_user_email()
   if user_name == 'DM Functional Test Supplier User 2'
     page.fill_in('email_address', :with => dm_supplier_user2_email())

--- a/features/step_definitions/journey_test_steps.rb
+++ b/features/step_definitions/journey_test_steps.rb
@@ -10,15 +10,15 @@ Given /I am on the '(.*)' login page$/ do |value|
     url = "#{dm_frontend_domain}/admin/login"
     page_header = "#{value} login"
   when "Digital Marketplace"
-    url = "#{dm_frontend_domain}/login"
+    url = "#{dm_frontend_domain}/user/login"
     page_header = "Log in to the Digital Marketplace"
   else
     fail("Unrecognised login page: '#{value}'")
   end
 
   visit(url)
-  if page.has_link?("Log out")
-    page.click_link("Log out")
+  if page.has_button?("Log out")
+    page.click_button("Log out")
   end
 
   visit(url)
@@ -54,7 +54,7 @@ When /I login as a '(.*)' user$/ do |user_type|
 end
 
 And /The supplier user '(.*)' '(.*)' login to Digital Marketplace$/ do |user_name,ability|
-  visit("#{dm_frontend_domain}/login")
+  visit("#{dm_frontend_domain}/user/login")
   email_address = dm_supplier_user_email()
   if user_name == 'DM Functional Test Supplier User 2'
     page.fill_in('email_address', :with => dm_supplier_user2_email())
@@ -194,11 +194,11 @@ end
 
 When /I click the '(.*)' link in the '(.*)' column for the supplier '(.*)'/ do |link_name, column_name, supplier_name|
   @supplierName = supplier_name
-  
+
   table_row_first_cell = page.first(:css, "td.summary-item-field-first") {|elem| elem.text == supplier_name}
   row = table_row_first_cell.find(:xpath, 'ancestor-or-self::*[tr][1]')
   column_index = page.all(:css, "thead tr th").find_index {|elem| elem.text == column_name}
-  
+
   column = row.all(:css, "td").at(column_index)
   link = column.find_link(link_name)
   if match = link['href'].match(%r"/admin/suppliers/(\d+)/")
@@ -653,7 +653,7 @@ Then /I am presented with the '(.*)' '(.*)' dashboard page(?: for '(.*)')?$/ do 
     fail("User type \"#{user_type}\" does not exist")
   end
   page.should have_content(user_type_name)
-  page.should have_link('Log out')
+  page.should have_button('Log out')
   current_url.should end_with("#{dm_frontend_domain}/#{user_type}s")
   page.should have_selector(:xpath, "//*[@id='global-breadcrumb']/nav/*[@role='breadcrumbs']/li[1]//*[contains(text(), 'Digital Marketplace')]")
 end
@@ -1298,7 +1298,7 @@ When /^I click the last download agreement link$/ do
 end
 
 Then /^I am presented with the \/"(.*?)" page\/$/ do |page_name|
-  current_url.should end_with("#{dm_frontend_domain}/reset-password")
+  current_url.should end_with("#{dm_frontend_domain}/user/reset-password")
   page.should have_content(page_name)
   page.should have_field("Email address")
   page.should have_button("Send reset email")

--- a/features/step_definitions/journey_test_steps.rb
+++ b/features/step_definitions/journey_test_steps.rb
@@ -122,7 +122,7 @@ Then /I am presented with the admin search page$/ do
   # temporarily disabled
   #page.should have_link('Service updates')
   page.should have_link('Service status changes')
-  page.should have_link('Log out')
+  page.should have_button('Log out')
   page.should have_content('Find a service by service ID')
   page.should have_content('Find suppliers by name prefix')
   page.should have_content('Find users by email address')
@@ -771,7 +771,7 @@ Then /I am presented with the '(.*)' page for the supplier '(.*)'$/ do |page_nam
     end
     current_url.should end_with("#{dm_frontend_domain}/admin/suppliers/#{page_name.downcase}?supplier_id=#{@servicesupplierID}")
   end
-  page.should have_link('Log out')
+  page.should have_button('Log out')
   page.should have_selector(:xpath, ".//*[@id='global-breadcrumb']/nav/*[@role='breadcrumbs']/li[1]//*[contains(text(), 'Admin home')]")
   page.should have_selector(:xpath, ".//*[@id='global-breadcrumb']/nav/*[@role='breadcrumbs']/li[2][contains(text(), '#{supplier_name}')]")
 end
@@ -790,7 +790,7 @@ end
 
 Then /I am presented with the 'Suppliers' page for all suppliers starting with '(.*)'$/ do |name_prefix|
   page.should have_content('Suppliers')
-  page.should have_link('Log out')
+  page.should have_button('Log out')
   URI.decode_www_form(URI.parse(current_url).query).assoc('supplier_name_prefix').last.should == name_prefix
 
   table_row_first_cells = page.all(:css, "td.summary-item-field-first")
@@ -1143,7 +1143,7 @@ Then /The page for the '(.*)' user is presented$/ do |user|
   }[user]
 
   page.should have_content("#{user_email}")
-  page.should have_link('Log out')
+  page.should have_button('Log out')
   current_url.should end_with("#{dm_frontend_domain}/admin/users?email_address=#{user_email.downcase.split('@').first}%40#{user_email.downcase.split('@').last}")
   page.should have_selector(:xpath, ".//*[@id='global-breadcrumb']/nav/*[@role='breadcrumbs']/li[1]//*[contains(text(), 'Admin home')]")
 end
@@ -1246,12 +1246,12 @@ Then /I am presented with the Service status changes page for changes made '(.*)
   # temporarily disabled
   #page.should have_link('Service updates')
   page.should have_link('Service status changes')
-  page.should have_link('Log out')
+  page.should have_button('Log out')
 end
 
 Then /I am presented with the '(.*)' page with the changed supplier name '(.*)' listed on the page$/ do |page_name,supplier_name|
   page.should have_content("#{page_name}")
-  page.should have_link('Log out')
+  page.should have_button('Log out')
   current_url.should end_with("#{dm_frontend_domain}/admin/#{page_name.downcase}?supplier_id=#{@supplierID}")
   page.should have_selector(:xpath, "//table/tbody/tr/td/span[contains(text(),'#{supplier_name}')]")
 end

--- a/features/step_definitions/journey_test_steps.rb
+++ b/features/step_definitions/journey_test_steps.rb
@@ -4,18 +4,10 @@ require "rest_client"
 
 store = OpenStruct.new
 
-Given /I am on the '(.*)' login page$/ do |value|
-  case value
-  when "Administrator"
-    url = "#{dm_frontend_domain}/admin/login"
-    page_header = "#{value} login"
-  when "Digital Marketplace"
-    url = "#{dm_frontend_domain}/user/login"
-    page_header = "Log in to the Digital Marketplace"
-  else
-    fail("Unrecognised login page: '#{value}'")
-  end
-
+Given /I am on the login page$/ do
+  url = "#{dm_frontend_domain}/user/login"
+  page_header = "Log in to the Digital Marketplace"
+  
   visit(url)
   if page.has_button?("Log out")
     page.click_button("Log out")
@@ -332,7 +324,7 @@ end
 
 Given /I have logged in to Digital Marketplace as a '(.*)' user$/ do |user_type|
   steps %Q{
-    Given I am on the '#{login_page_type(user_type)}' login page
+    Given I am on the login page
     When I login as a '#{user_type}' user
   }
 end
@@ -356,12 +348,7 @@ Given /^I am logged in as '(.*)' and am on the '(.*)' service summary page$/ do 
   end
 end
 
-Then /I am logged out of Digital Marketplace as a '(.*)' user$/ do |user_type|
-  case user_type
-  when "Administrator"
-    page.should have_content('You have been logged out')
-    page.should have_content('Administrator login')
-  when "Buyer" , "Supplier"
+Then /I am logged out of Digital Marketplace$/ do
   page.has_link?("Log in")
   page.has_link?('Create supplier account')
   page.should have_content('Log in to the Digital Marketplace')
@@ -369,9 +356,6 @@ Then /I am logged out of Digital Marketplace as a '(.*)' user$/ do |user_type|
   page.should have_content('Password')
   page.has_button?('Log in')
   page.has_link?('Forgotten password')
-  else
-    fail("User type \"#{user_type}\" does not exist")
-  end
 end
 
 Then /I am presented with the '(.*)' '(.*)' page for that service$/ do |action,service_aspect|

--- a/features/step_definitions/setup_steps.rb
+++ b/features/step_definitions/setup_steps.rb
@@ -229,6 +229,10 @@ end
 
 And /^The user 'DM Functional Test Supplier User 3' is locked$/ do
   visit("#{dm_frontend_domain}/user/login")
+  
+  if page.has_button?("Log out")
+    page.click_button("Log out")
+  end
 
   response = call_api(:get, "/users", params: {email_address: dm_supplier_user3_email()})
   failedlogincount = JSON.parse(response.body)["users"][0]["failedLoginCount"]

--- a/features/step_definitions/setup_steps.rb
+++ b/features/step_definitions/setup_steps.rb
@@ -228,7 +228,7 @@ And /^Test supplier users are not locked$/ do
 end
 
 And /^The user 'DM Functional Test Supplier User 3' is locked$/ do
-  visit("#{dm_frontend_domain}/login")
+  visit("#{dm_frontend_domain}/user/login")
 
   response = call_api(:get, "/users", params: {email_address: dm_supplier_user3_email()})
   failedlogincount = JSON.parse(response.body)["users"][0]["failedLoginCount"]

--- a/features/supplier/supplier_journey.feature
+++ b/features/supplier/supplier_journey.feature
@@ -8,11 +8,11 @@ Scenario: Setup for tests
   And Test supplier users are active
 
 Scenario: As supplier user I wish be able to log in and to log out of Digital Marketplace
-  Given I am on the 'Digital Marketplace' login page
+  Given I am on the login page
   When I login as a 'Supplier' user
   Then I am presented with the 'DM Functional Test Supplier' 'Supplier' dashboard page
   When I click 'Log out'
-  Then I am logged out of Digital Marketplace as a 'Supplier' user
+  Then I am logged out of Digital Marketplace
 
 Scenario: As a logged in supplier user, I can see my active contributors on the contributors page
   Given I am logged in as 'DM Functional Test Supplier' 'Supplier' user and am on the dashboard page
@@ -27,7 +27,7 @@ Scenario: As a logged in supplier user, I can navigate to the contributors page 
   Then I see a confirmation message after having removed supplier user 'DM Functional Test Supplier User 2'
   And I should not see the supplier user 'DM Functional Test Supplier User 2' on the supplier dashboard page
   When I click 'Log out'
-  Then I am logged out of Digital Marketplace as a 'Supplier' user
+  Then I am logged out of Digital Marketplace
   And The supplier user 'DM Functional Test Supplier User 2' 'can not' login to Digital Marketplace
   Then The supplier user 'DM Functional Test Supplier User 2' is 'not active' on the admin Users page
 
@@ -71,7 +71,7 @@ Scenario: Supplier user has 5 failed login attempts and is locked. Login is not 
   And The supplier user 'DM Functional Test Supplier User 3' 'can not' login to Digital Marketplace
 
 Scenario: Supplier has forgotten password and requests for a password reset
-  Given I am on the 'Digital Marketplace' login page
+  Given I am on the login page
   When I click 'Forgotten password'
   Then I am presented with the /"Reset password" page/
 


### PR DESCRIPTION
### Update steps to use the new user-frontend app
The new user-frontend app handles log in and out. It has new URL's.

### Make checks for login and logout pages generic
The login page is now shared across all user types, so we don't need
specific steps for the login and logout pages.

### Log out admins before logging in suppliers
Session cookies are now shared between admins and other user types. This
means that the functional tests will need to log the admin out if they
want to check that another user is on the login page before attempting
to log in.

### Check log out is a button not a link
Log out is now a button and not a link. A bunch of checks needed
updating to test this correctly.




