### PR TITLE
User frontend update

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -148,6 +148,9 @@ services:
 
   nginx:
     image: "digitalmarketplace/local-nginx:latest"
+    build:
+      context: ./
+      dockerfile: ./local-nginx.docker
     ports:
       - "80:80"
     depends_on:

--- a/features/smoke-tests/users/login.feature
+++ b/features/smoke-tests/users/login.feature
@@ -29,9 +29,10 @@ Scenario: Buyer user can log in
 
 @with-production-admin-user
 Scenario: Admin user can log in
-  Given I am on the /admin page
+  Given I am on the homepage
   And I have a production admin user
-  Then I am on the 'Administrator login' page
+  When I click 'Log in'
+  Then I am on the 'Log in to the Digital Marketplace' page
   When I enter that user.emailAddress in the 'Email address' field
   And I enter that user.password in the 'Password' field
   And I click the 'Log in' button
@@ -39,9 +40,10 @@ Scenario: Admin user can log in
 
 @with-production-admin-ccs-category-user
 Scenario: Admin CCS Category user can log in
-  Given I am on the /admin page
+  Given I am on the homepage
   And I have a production admin-ccs-category user
-  Then I am on the 'Administrator login' page
+  When I click 'Log in'
+  Then I am on the 'Log in to the Digital Marketplace' page
   When I enter that user.emailAddress in the 'Email address' field
   And I enter that user.password in the 'Password' field
   And I click the 'Log in' button
@@ -49,9 +51,10 @@ Scenario: Admin CCS Category user can log in
 
 @with-production-admin-ccs-sourcing-user
 Scenario: Admin CCS Sourcing user can log in
-  Given I am on the /admin page
+  Given I am on the homepage
   And I have a production admin-ccs-sourcing user
-  Then I am on the 'Administrator login' page
+  When I click 'Log in'
+  Then I am on the 'Log in to the Digital Marketplace' page
   When I enter that user.emailAddress in the 'Email address' field
   And I enter that user.password in the 'Password' field
   And I click the 'Log in' button

--- a/features/step_definitions/login_steps.rb
+++ b/features/step_definitions/login_steps.rb
@@ -37,14 +37,14 @@ Given /^I have a ([a-z-]+) user(?: with supplier id (\d*))?$/ do |user_role, sup
 end
 
 Given /^I am logged in as (?:a|the) (production )?(\w+) user$/ do |production, user_role|
-  login_page = if user_role.start_with? 'admin' then '/admin/login' else '/login' end
+  login_page = '/user/login'
   steps %Q{
     Given I have a #{production}#{user_role} user
     And I am on the #{login_page} page
     When I enter that user.emailAddress in the 'Email address' field
     And I enter that user.password in the 'Password' field
     And I click the 'Log in' button
-    Then I see the 'Log out' link
+    Then I see the 'Log out' button
   }
 end
 
@@ -61,10 +61,10 @@ Given /^that (supplier|buyer) is logged in$/ do |user_role|
   user = user_role == 'supplier' ? @supplier_user : @buyer
 
   steps %Q{
-    And I am on the /login page
+    And I am on the /user/login page
     When I enter '#{user['emailAddress']}' in the 'Email address' field
     And I enter '#{user['password']}' in the 'Password' field
     And I click the 'Log in' button
-    Then I see the 'Log out' link
+    Then I see the 'Log out' button
   }
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -64,5 +64,5 @@ def dm_pagination_limit()
   (ENV['DM_PAGINATION_LIMIT'] || 100).to_i
 end
 
+Capybara.asset_host = dm_frontend_domain
 Capybara.save_path = "reports/"
-Capybara::Screenshot.prune_strategy = { keep: 100 }

--- a/features/support/form_helpers.rb
+++ b/features/support/form_helpers.rb
@@ -48,7 +48,7 @@ module FormHelper
   end
 
   def get_parent_label(el)
-    el.find_xpath('parent::label')[0]
+    el.find_xpath("//label[@for='#{el[:id]}']")[0]
   end
 
   def find_fields(locator=nil, options={})


### PR DESCRIPTION
This is built on top of this PR which should probably get merged first
 [https://github.com/alphagov/digitalmarketplace-functional-tests/pull/337](https://github.com/alphagov/digitalmarketplace-functional-tests/pull/337)

### Point login steps at user-frontend
The login endpoint is now in the new user-frontend

### Login admins using user frontend login app
The admin specific login page is being done away with and admin's will
instead log in through the user-frontend app.

