### PR TITLE
Include new user app proxy location in local nginx conf

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -40,5 +40,9 @@ http {
         location /buyers {
             proxy_pass http://localhost:5005;
         }
+
+        location /user {
+            proxy_pass http://localhost:5007;
+        }
     }
 }


### PR DESCRIPTION
For those of us who don't use Docker images locally, or who only need to spin up one or two apps at a time (but still need to log in!). Without this the login pages will 404 at `localhost` if the port number is not supplied.

Requires re-running `./nginx/bootstrap.sh` to apply the new config on your local machine.