### PR TITLE
Increase processes to four for parallel tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ rerun:
 	[ -f config/${DM_ENVIRONMENT}.sh ] && . config/${DM_ENVIRONMENT}.sh ; bundle exec cucumber -p rerun
 
 run-parallel: setup
-	[ -f config/${DM_ENVIRONMENT}.sh ] && . config/${DM_ENVIRONMENT}.sh ; bundle exec parallel_cucumber features/ -o "-t ~@skip -t ~@skip-${DM_ENVIRONMENT} ${ARGS} -p run-parallel"
+	[ -f config/${DM_ENVIRONMENT}.sh ] && . config/${DM_ENVIRONMENT}.sh ; bundle exec parallel_cucumber features/ -n 4 -o "-t ~@skip -t ~@skip-${DM_ENVIRONMENT} ${ARGS} -p run-parallel"
 
 setup: install clean
 	@echo "Environment:" ${DM_ENVIRONMENT}


### PR DESCRIPTION
The default value for the number of processes used when running the
parallel tests is the number of available cpu's. This seems to be two on
Jenkins. This reduces the test run to 6 mins from 9. Not bad.

The processes will be blocked a lot waiting for I/O which means it might
be worth increasing the number of processes to 4 to try and improve on
this reduction.