### PR TITLE
Add location to local nginx conf for direct-award

### DIFF
--- a/nginx/docker_nginx.conf
+++ b/nginx/docker_nginx.conf
@@ -30,6 +30,12 @@ http {
             proxy_pass http://user-frontend:80;
         }
 
+        location /buyers/direct-award {
+            proxy_set_header Authorization "Basic ZGV2LXVzZXI6cGFzc3dvcmQxMjM0NQ==";
+            proxy_set_header Host localhost;
+            proxy_pass http://buyer-frontend:80;
+        }
+
         location /buyers {
 
             proxy_set_header Authorization "Basic ZGV2LXVzZXI6cGFzc3dvcmQxMjM0NQ==";


### PR DESCRIPTION
The new direct award stuff sits behind `/buyers/direct-award` but lives
in the buyer app. Without this new location, requests to that URL are
sent to the briefs app.