### PR TITLE
Update content for save search button

### DIFF
--- a/features/buyer/direct-award.feature
+++ b/features/buyer/direct-award.feature
@@ -5,8 +5,8 @@ Feature: Direct Award flows
 Scenario: User can save a search into a new Direct Award Project
   Given I am logged in as a buyer user
   And I am on the /g-cloud/search page
-  And I click 'Save your search'
-  Then I am on the 'Save your search' page
+  And I click 'Save search'
+  Then I am on the 'Save search' page
   And I enter 'my cloud project' in the 'Name a new project' field
   And I click 'Create project and save search'
   Then I am on the 'my cloud project' page

--- a/features/smoke-tests/buyer/direct-award.feature
+++ b/features/smoke-tests/buyer/direct-award.feature
@@ -5,6 +5,6 @@ Feature: Direct Award passive assurance
 
 Scenario: User is required to login to save a search
   Given I am on the /g-cloud/search page
-  Then I see the 'Save your search' button
-  And I click 'Save your search'
+  Then I see the 'Save search' button
+  And I click 'Save search'
   Then I am on the 'Log in to the Digital Marketplace' page


### PR DESCRIPTION
## Summary
A recent update to the 'Save search' button on the G-Cloud Direct Award flow has changed the content, so we need to update it here.