### PR TITLE
Split requirements tests by stage for buyer dashboard

### DIFF
--- a/features/buyer/award_requirements.feature
+++ b/features/buyer/award_requirements.feature
@@ -4,10 +4,42 @@ Feature: Award a requirement
   As a buyer within government
   I want to be able to publish the result of my procurement process
 
+@skip-local @skip-preview
 Scenario: Award a requirement to a winning supplier
   Given I am logged in as the buyer of a closed brief with responses
 
   When I click the 'View your account' link
+  Then I see that the 'Closed requirements' summary table has 1 or more entries
+
+  When I click the 'Tell us who won this contract' link for that brief
+  Then I am on the 'Who won' page
+
+  When I choose a random 'brief_response' radio button
+  And I click the 'Save and continue' button
+  Then I am on the 'Tell us about your contract' page
+
+  When I enter '1' in the 'input-awardedContractStartDate-day' field
+  And I enter '1' in the 'input-awardedContractStartDate-month' field
+  And I enter '2020' in the 'input-awardedContractStartDate-year' field
+  And I enter '20000.00' in the 'input-awardedContractValue' field
+  And I click the 'Submit' button
+  Then I see a success banner message containing 'updated'
+
+  When I go to that brief overview page
+  Then I see the 'View and shortlist suppliers' link
+
+  When I go to that brief page
+  Then I see a temporary-message banner message containing 'Awarded to'
+  And I see a temporary-message banner message containing 'Start date: Wednesday 1 January 2020'
+  And I see a temporary-message banner message containing 'Value: £20,000'
+  And I see a temporary-message banner message containing 'Company size'
+
+@skip-staging @skip-production
+Scenario: Award a requirement to a winning supplier
+  Given I am logged in as the buyer of a closed brief with responses
+
+  When I click the 'View your account' link
+  And I click the 'View your requirements' link
   Then I see that the 'Closed requirements' summary table has 1 or more entries
 
   When I click the 'Tell us who won this contract' link for that brief

--- a/features/buyer/requirements.feature
+++ b/features/buyer/requirements.feature
@@ -137,6 +137,7 @@ Scenario: Create user research participants
    And I don't see the 'Review and publish your requirements' link
 
 
+@skip-local @skip-preview
 Scenario Outline: Copy requirements
   Given I have a live digital outcomes and specialists framework
   And I have a buyer
@@ -155,7 +156,28 @@ Scenario Outline: Copy requirements
     | withdrawn |
     | draft     |
 
+@skip-staging @skip-production
+Scenario Outline: Copy requirements
+  Given I have a live digital outcomes and specialists framework
+  And I have a buyer
+  And that buyer is logged in
+  And I have a <status> digital-specialists brief
+  And I click the 'View your account' link
+  And I click the 'View your requirements' link
+  When I click the 'Make a copy' button
+  Then I am on the 'What you want to call your requirements' page
+  And I see 'Tea drinker copy' as the value of the 'title' field
+  When I click the 'Save and continue' button
+  Then I am on the 'Tea drinker copy' page
 
+  Examples:
+    | status    |
+    | live      |
+    | withdrawn |
+    | draft     |
+
+
+@skip-local @skip-preview
 Scenario Outline: View requirement in a dashboard
   Given I have a live digital outcomes and specialists framework
   And I have a buyer
@@ -163,6 +185,22 @@ Scenario Outline: View requirement in a dashboard
   And I have a <status> digital-specialists brief
   When I click 'View your account'
   Then I am on the /buyers page
+  And I see 'Tea drinker' in the '<table heading>' summary table
+
+  Examples:
+    | status    | table heading            |
+    | live      | Published requirements   |
+    | withdrawn | Closed requirements      |
+    | draft     | Unpublished requirements |
+
+@skip-staging @skip-production
+Scenario Outline: View requirement in a dashboard
+  Given I have a live digital outcomes and specialists framework
+  And I have a buyer
+  And that buyer is logged in
+  And I have a <status> digital-specialists brief
+  When I click 'View your account'
+  And I click 'View your requirements'
   And I see 'Tea drinker' in the '<table heading>' summary table
 
   Examples:


### PR DESCRIPTION
## Summary
As part of the Direct Award Project/Search flow, we are updating the buyer dashboard to be the home for both G-Cloud and DOS. While we maintain a featureflag for this on Preview, we need to maintain two sets of tests for local+preview (new functionality) vs staging+prod (existing functionality).

This splinters the functional tests that go through the buyer dashboard.