### PR TITLE
Copy change for awarded Brief overview link

### DIFF
--- a/features/buyer/award_requirements.feature
+++ b/features/buyer/award_requirements.feature
@@ -57,7 +57,7 @@ Scenario: Award a requirement to a winning supplier
   Then I see a success banner message containing 'updated'
 
   When I go to that brief overview page
-  Then I see the 'View and shortlist suppliers' link
+  Then I see the 'View suppliers who applied' link
 
   When I go to that brief page
   Then I see a temporary-message banner message containing 'Awarded to'


### PR DESCRIPTION
We've changed the wording on one of the overview page links for awarded Briefs, which was breaking the test. 

The test was already duplicated with `@skip-<stage>` tags - this PR changes the copy for the `@skip-staging @skip-production` test.