### PR TITLE
Add tests for cancel and unsuccessful brief flows

### DIFF
--- a/features/buyer/cancel_requirements.feature
+++ b/features/buyer/cancel_requirements.feature
@@ -22,7 +22,7 @@ Scenario: Cancel a requirement
   When I choose the 'The requirement has been cancelled' radio button
   And I click the 'Update requirement' button
   Then I see 'The contract was not awarded' text on the page
-  Then I see 'the requirement was cancelled.' text on the page
+  And I see 'the requirement was cancelled.' text on the page
   And I see a success banner message containing 'updated'
   And I see the 'View suppliers who applied' link
 
@@ -30,4 +30,31 @@ Scenario: Cancel a requirement
   Then I see a temporary-message banner message containing 'This opportunity was cancelled'
   And I see a temporary-message banner message containing 'The buyer cancelled this opportunity,'
   And I see a temporary-message banner message containing 'for example because they no longer have the budget.'
+  And I see a temporary-message banner message containing 'They may publish an updated version later.'
+
+
+@skip-staging
+Scenario: Cancel a requirement where no suitable suppliers applied
+  Given I am logged in as the buyer of a closed brief
+
+  When I click the 'View your account' link
+  And I click the 'View your requirements' link
+  Then I see that the 'Closed requirements' summary table has 1 or more entries
+
+  When I go to that brief overview page
+  Then I see the 'Cancel requirement' link
+
+  When I click the 'Cancel requirement' link
+  Then I am on the 'Why do you need to cancel' page
+
+  When I choose the 'There were no suitable suppliers' radio button
+  And I click the 'Update requirement' button
+  Then I see 'The contract was not awarded' text on the page
+  And I see 'no suitable suppliers applied.' text on the page
+  And I see a success banner message containing 'updated'
+  And I see the 'View suppliers who applied' link
+
+  When I go to that brief page
+  Then I see a temporary-message banner message containing 'No suitable suppliers applied'
+  And I see a temporary-message banner message containing 'The buyer didn't award this contract because no suppliers met their requirements.'
   And I see a temporary-message banner message containing 'They may publish an updated version later.'

--- a/features/buyer/cancel_requirements.feature
+++ b/features/buyer/cancel_requirements.feature
@@ -2,7 +2,7 @@
 Feature: Cancel a requirement
   In order to ensure the procurement process is fair and transparent
   As a buyer within government
-  I want to be able to publish the result of my procurement process
+  I want to cancel my requirement after applications have closed, because I didn't go ahead with the procurement
 
 
 @skip-staging

--- a/features/buyer/cancel_requirements.feature
+++ b/features/buyer/cancel_requirements.feature
@@ -1,0 +1,33 @@
+@cancel
+Feature: Cancel a requirement
+  In order to ensure the procurement process is fair and transparent
+  As a buyer within government
+  I want to be able to publish the result of my procurement process
+
+
+@skip-staging
+Scenario: Cancel a requirement
+  Given I am logged in as the buyer of a closed brief
+
+  When I click the 'View your account' link
+  And I click the 'View your requirements' link
+  Then I see that the 'Closed requirements' summary table has 1 or more entries
+
+  When I go to that brief overview page
+  Then I see the 'Cancel requirement' link
+
+  When I click the 'Cancel requirement' link
+  Then I am on the 'Why do you need to cancel' page
+
+  When I choose the 'The requirement has been cancelled' radio button
+  And I click the 'Update requirement' button
+  Then I see 'The contract was not awarded' text on the page
+  Then I see 'the requirement was cancelled.' text on the page
+  And I see a success banner message containing 'updated'
+  And I see the 'View suppliers who applied' link
+
+  When I go to that brief page
+  Then I see a temporary-message banner message containing 'This opportunity was cancelled'
+  And I see a temporary-message banner message containing 'The buyer cancelled this opportunity,'
+  And I see a temporary-message banner message containing 'for example because they no longer have the budget.'
+  And I see a temporary-message banner message containing 'They may publish an updated version later.'

--- a/features/buyer/cancel_requirements.feature
+++ b/features/buyer/cancel_requirements.feature
@@ -58,3 +58,56 @@ Scenario: Cancel a requirement where no suitable suppliers applied
   Then I see a temporary-message banner message containing 'No suitable suppliers applied'
   And I see a temporary-message banner message containing 'The buyer didn't award this contract because no suppliers met their requirements.'
   And I see a temporary-message banner message containing 'They may publish an updated version later.'
+
+
+@skip-local @skip-preview
+Scenario: Cancel a requirement
+  Given I am logged in as the buyer of a closed brief
+
+  When I click the 'View your account' link
+  Then I see that the 'Closed requirements' summary table has 1 or more entries
+
+  When I go to that brief overview page
+  Then I see the 'Cancel requirement' link
+
+  When I click the 'Cancel requirement' link
+  Then I am on the 'Why do you need to cancel' page
+
+  When I choose the 'The requirement has been cancelled' radio button
+  And I click the 'Update requirement' button
+  Then I see 'The contract was not awarded' text on the page
+  And I see 'the requirement was cancelled.' text on the page
+  And I see a success banner message containing 'updated'
+  And I see the 'View suppliers who applied' link
+
+  When I go to that brief page
+  Then I see a temporary-message banner message containing 'This opportunity was cancelled'
+  And I see a temporary-message banner message containing 'The buyer cancelled this opportunity,'
+  And I see a temporary-message banner message containing 'for example because they no longer have the budget.'
+  And I see a temporary-message banner message containing 'They may publish an updated version later.'
+
+
+@skip-local @skip-preview
+Scenario: Cancel a requirement where no suitable suppliers applied
+  Given I am logged in as the buyer of a closed brief
+
+  When I click the 'View your account' link
+  Then I see that the 'Closed requirements' summary table has 1 or more entries
+
+  When I go to that brief overview page
+  Then I see the 'Cancel requirement' link
+
+  When I click the 'Cancel requirement' link
+  Then I am on the 'Why do you need to cancel' page
+
+  When I choose the 'There were no suitable suppliers' radio button
+  And I click the 'Update requirement' button
+  Then I see 'The contract was not awarded' text on the page
+  And I see 'no suitable suppliers applied.' text on the page
+  And I see a success banner message containing 'updated'
+  And I see the 'View suppliers who applied' link
+
+  When I go to that brief page
+  Then I see a temporary-message banner message containing 'No suitable suppliers applied'
+  And I see a temporary-message banner message containing 'The buyer didn't award this contract because no suppliers met their requirements.'
+  And I see a temporary-message banner message containing 'They may publish an updated version later.'

--- a/features/step_definitions/brief_response_steps.rb
+++ b/features/step_definitions/brief_response_steps.rb
@@ -21,6 +21,9 @@ end
 Given /^I am logged in as the buyer of a closed brief$/ do
   closed_brief = get_briefs('digital-outcomes-and-specialists-2', 'closed').sample
   @buyer = closed_brief['users'][0]
+  @brief_id = closed_brief['id']
+  @lot_slug = closed_brief['lotSlug']
+  @framework_slug = closed_brief['frameworkSlug']
   @buyer.update({'password' => ENV["DM_PRODUCTION_BUYER_USER_PASSWORD"]})
   steps %Q{
     Given that buyer is logged in

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -291,10 +291,10 @@ Then /^I see the '(.*)' radio button is checked(?: for the '(.*)' question)?$/ d
 end
 
 Then /^I (don't |)see '(.*)' text on the page/ do |negative, expected_text|
-  expected_text_occurences = all(:xpath, "//*[normalize-space() = \"#{expected_text}\"]").length
+  has_content = page.has_content?(expected_text)
   if negative.empty?
-    expected_text_occurences.should >= 1
-  else expected_text_occurences.should == 0
+    has_content.should be true
+  else has_content.should be false
   end
 end
 


### PR DESCRIPTION
This is related to following trello tickets:
Flow: https://trello.com/c/Umt24W6d/816-3-collect-status-when-buyer-has-cancelled-procurement-no-journey-frontend

Banners: https://trello.com/c/Umt24W6d/816-3-collect-status-when-buyer-has-cancelled-procurement-no-journey-frontend