### PR TITLE
Skip reset password tests staging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ setup: install clean
 	mkdir -p reports/
 
 install:
-	bundle install
+	bundle install --path .bundle
 
 config/local.sh:
 	cp config/example.sh config/local.sh

--- a/features/user/reset_password.feature
+++ b/features/user/reset_password.feature
@@ -1,4 +1,4 @@
-@reset-password @notify
+@reset-password @notify @skip-staging
 Feature: Reset user password
 
 Scenario: Request password reset


### PR DESCRIPTION
Staging is set up to send emails and is using the production Notify
template, which will be set up to remove personalisation data.

Test Notify API key we're using doesn't seem to return live
notifications, and since the production template would remove the
reset password link from the message body the existing approach
won't work on staging. So we're only keeping the email tests on
preview.

### Store bundle gems locally to avoid conflicts on simultaneous install 

If two functional tests jobs try to run `bundle install` at the same
time one of them will likely fail during gem installation because the
gem is being updated by another job.

To avoid this, we configure bundler to install gems into a workspace
subdirectory instead of using the global gem path.