### PR TITLE
Fail `make rerun` if rerun file is empty or doesn't exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ run: setup
 	[ -f config/${DM_ENVIRONMENT}.sh ] && . config/${DM_ENVIRONMENT}.sh ; bundle exec cucumber --tags ~@skip --tags ~@skip-${DM_ENVIRONMENT} ${ARGS}
 
 rerun:
+	[[ -s reports/rerun ]]
 	[ -f config/${DM_ENVIRONMENT}.sh ] && . config/${DM_ENVIRONMENT}.sh ; bundle exec cucumber -p rerun
 
 run-parallel: setup


### PR DESCRIPTION
`make rerun` used without a rerun file will always succeed after
executing 0 scenarios. Since we're chaining it after `make run`
failures it will mask any error that doesn't produce a rerun file
(eg `bundle install` errors or other events that interrupt the
step before generating a rerun report).

To avoid this we only rerun cucumber if the rerun file exists and
is not empty.