### PR TITLE
Add a `wait` step to reset email password scenario

### DIFF
--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -312,3 +312,7 @@ And /^I wait for the page to reload/ do
     loop until page.evaluate_script('jQuery.active').zero?
   end
 end
+
+And /^I wait (\d+) seconds/ do |seconds|
+  sleep seconds.to_i
+end

--- a/features/user/reset_password.feature
+++ b/features/user/reset_password.feature
@@ -8,6 +8,7 @@ Scenario: Request password reset
   And I click 'Send reset email' button
   Then I see a success banner message containing 'send a link to reset the password'
   And I receive a 'reset-password' email for that user.emailAddress
+  And I wait 2 seconds to ensure the reset token is valid
   And I click the link in that email
   Then I am on the 'Reset password' page
   When I enter that user.password in the 'Password' field


### PR DESCRIPTION
Preview notify tests are too quick. We create a user and request
password reset immediately. It looks like the date fernet puts inside
the token is stored with a second resolution (so it doesn’t have
milli/microseconds), but the API response does. So if the user creation
and token generation happen within the same second (which it looks like
they do quite often) the check thinks that the token was created before
the user and declares it expired.