### PR TITLE
Move wait to between user and token creation

### DIFF
--- a/features/user/reset_password.feature
+++ b/features/user/reset_password.feature
@@ -3,12 +3,12 @@ Feature: Reset user password
 
 Scenario: Request password reset
   Given I have a buyer user
+  And I wait 2 seconds to ensure the reset token is created after the user
   And I am on the /user/reset-password page
   When I enter that user.emailAddress in the 'Email address' field
   And I click 'Send reset email' button
   Then I see a success banner message containing 'send a link to reset the password'
   And I receive a 'reset-password' email for that user.emailAddress
-  And I wait 2 seconds to ensure the reset token is valid
   And I click the link in that email
   Then I am on the 'Reset password' page
   When I enter that user.password in the 'Password' field


### PR DESCRIPTION
We added a wait to ensure that there was a time difference between user
creation and token creation for password reset. When the token is
decrypted it checks that the token was created after the user.

Unfortunately I put the wait in the wrong place so we have the same
issue. Moving it hear ensures that the token is created after the user.