### PR TITLE
Intentionally break smoke tests so we can test jenkins job

### DIFF
--- a/features/smoke-tests/supplier/opportunities.feature
+++ b/features/smoke-tests/supplier/opportunities.feature
@@ -3,7 +3,7 @@ Feature: Passive opportunity supplier journey
 
 Scenario: User can see the main links on the homepage
   Given I am on the homepage
-  Then I see the 'View Digital Outcomes and Specialists opportunities' link
+  Then I see the 'INTENTIONALLY BROKEN View Digital Outcomes and Specialists opportunities' link
 
 Scenario: User can click through to opportunities page
   Given I am on the homepage


### PR DESCRIPTION
Our jenkins job is not alerting when smoke tests fail. By introducing
this failure, we can then change our jenkins job until the errors
start appearing again on slack. Once the errors are back then this
commit can be reverted.