### PR TITLE
Add staging/production variant of smoketest

### DIFF
--- a/features/smoke-tests/buyer/catalogue.feature
+++ b/features/smoke-tests/buyer/catalogue.feature
@@ -2,6 +2,7 @@
 @catalogue
 Feature: Passive catalogue buyer journey
 
+@skip-preview @skip-staging @skip-local
 Scenario: User can see the main links on the homepage
   Given I am on the homepage
   Then I see the 'Find cloud hosting, software and support' link
@@ -12,6 +13,18 @@ Scenario: User can see the main links on the homepage
   And I see the 'Find a user research lab' link
   And I see the 'View Digital Outcomes and Specialists opportunities' link
   And I see the 'Create a supplier account' link
+
+@skip-production
+Scenario: User can see the main links on the homepage
+  Given I am on the homepage
+  Then I see the 'Find cloud hosting, software and support' link
+  And I see the 'Buy physical datacentre space' link
+  And I see the 'Find an individual specialist' link
+  And I see the 'Find a team to provide an outcome' link
+  And I see the 'Find user research participants' link
+  And I see the 'Find a user research lab' link
+  And I see the 'View Digital Outcomes and Specialists opportunities' link
+  And I see the 'Become a supplier' link
 
 Scenario: User can click through to g-cloud page
   Given I am on the homepage


### PR DESCRIPTION
Text is changing on the homepage link, but we need the smoketest to continue running on production while this new feature is tested on staging.

So this should be a very temporary stop-gap to keep the board green.