### PR TITLE
Supplier creation and email list sign-up flow tests

### DIFF
--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -192,6 +192,10 @@ Then /^I see a (success|warning|destructive|temporary-message) banner message co
   banner_message.should have_content(message)
 end
 
+Then /^I don't see a banner message$/ do
+  page.should_not have_selector(:xpath, "//*[contains(@class, 'banner-')][contains(@class, '-action')]")
+end
+
 Then /^I see #{MAYBE_VAR} breadcrumb$/ do |breadcrumb_text|
   breadcrumb = page.all(:xpath, "//div[@id='global-breadcrumb']/nav//li").last
   breadcrumb.text().should == breadcrumb_text

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -242,6 +242,21 @@ Then(/^I see #{MAYBE_VAR} as the page header context$/) do |value|
   first(:xpath, "//header//*[@class='context']").text.should  == normalize_whitespace(value)
 end
 
+When /I click the summary table Edit link for '(.*)'$/ do |field_to_edit|
+  edit_link = page.find(:xpath, "//tr/*/span[contains(text(), '#{field_to_edit}')]/../..//a[text()]")
+  edit_link.text().should have_content('Edit')
+  edit_link.click
+end
+
+When /I update the value of '(.*)' to '(.*)' using the summary table Edit link/ do |field_to_edit, new_value|
+  summary_page = current_url
+
+  step "I click the summary table Edit link for '#{field_to_edit}'"
+  step "I enter '#{new_value}' in the '#{field_to_edit}' field and click its associated 'Continue' button"
+
+  page.visit(summary_page)
+end
+
 Then /^I see the '(.*)' summary table filled with:$/ do |table_heading, table|
   result_table_location = "//*[@class='summary-item-heading'][normalize-space(text())=\"#{table_heading}\"]/following-sibling::table[1]"
   result_table_rows_location = result_table_location + "/tbody/tr[@class='summary-item-row']"

--- a/features/step_definitions/supplier_steps.rb
+++ b/features/step_definitions/supplier_steps.rb
@@ -1,0 +1,10 @@
+Given 'There is at least one framework that can be applied to' do
+  response = call_api(:get, "/frameworks")
+  response.code.should be(200), _error(response, "Failed getting frameworks")
+  frameworks = JSON.parse(response.body)['frameworks']
+  frameworks.delete_if {|framework| not ['coming', 'open'].include?(framework['status'])}
+  if frameworks.empty?
+    puts 'Cannot create supplier if no coming or open frameworks'
+    skip_this_scenario
+  end
+end

--- a/features/step_definitions/supplier_steps.rb
+++ b/features/step_definitions/supplier_steps.rb
@@ -4,7 +4,18 @@ Given 'There is at least one framework that can be applied to' do
   frameworks = JSON.parse(response.body)['frameworks']
   frameworks.delete_if {|framework| not ['coming', 'open'].include?(framework['status'])}
   if frameworks.empty?
-    puts 'Cannot create supplier if no coming or open frameworks'
+    puts 'SKIPPING as there are no coming or open frameworks'
+    skip_this_scenario
+  end
+end
+
+Given 'There is at most one framework that can be applied to' do
+  response = call_api(:get, "/frameworks")
+  response.code.should be(200), _error(response, "Failed getting frameworks")
+  frameworks = JSON.parse(response.body)['frameworks']
+  frameworks.delete_if {|framework| not ['coming', 'open'].include?(framework['status'])}
+  if frameworks.length > 1
+    puts 'SKIPPING as there is more than one framework coming or open'
     skip_this_scenario
   end
 end

--- a/features/supplier/subscribe_mailing_list.feature
+++ b/features/supplier/subscribe_mailing_list.feature
@@ -1,26 +1,31 @@
 @supplier-subscribe-mailing-list
-Feature: suppliers can subscribe to the open framework notification mailing list without an account
+Feature: Subscribe to the open framework notification mailing list without an account
 
-Scenario: Successful mailing-list subscription
-    Given I am on the /suppliers/mailing-list page
-    Then I am on the 'Sign up for Digital Marketplace email alerts' page
-    And I don't see a banner message
-    When I enter 'functional-test-example-email@gov.uk' in the 'email_address' field
-    And I click 'Subscribe'
-    Then I am on the 'Digital Marketplace' page
-    And I see a success banner message containing 'You will receive email notifications to functional-test-example-email@gov.uk when applications are opening.'
+Background:
+  # This initial check only makes sense while we only have two frameworks - i.e. G-Cloud and Digital Outcomes and Specialists
+  Given There is at most one framework that can be applied to
+  # Navigate to the mailing list page from the home page
+  And I am on the homepage
+  And I click 'Become a supplier'
+  Then I am on the 'Become a supplier' page
+  And I click 'Get notifications when applications are opening'
+  Then I am on the 'Sign up for Digital Marketplace email alerts' page
+  And I don't see a banner message
+
+Scenario: Successful mailing-list subscription from the home page
+  When I enter 'functional-test-example-email@gov.uk' in the 'email_address' field
+  And I click 'Subscribe'
+  Then I am on the 'Digital Marketplace' page
+  And I see a success banner message containing 'You will receive email notifications to functional-test-example-email@gov.uk when applications are opening.'
 
 Scenario: Initially-rejected mailing-list subscription
-    Given I am on the /suppliers/mailing-list page
-    Then I am on the 'Sign up for Digital Marketplace email alerts' page
-    And I don't see a banner message
-    # example@example.com should be rejected by mailchimp as an obvious fake address
-    When I enter 'example@example.com' in the 'email_address' field
-    And I click 'Subscribe'
-    Then I am on the 'Sign up for Digital Marketplace email alerts' page
-    And I see a destructive banner message containing 'The service is unavailable at the moment. If the problem continues please contact enquiries@digitalmarketplace.service.gov.uk.'
-    # but this page should still be a valid, working form
-    And I see 'example@example.com' as the value of the 'email_address' field
-    When I enter 'functional-test-example-email@gov.uk' in the 'email_address' field
-    And I click 'Subscribe'
-    Then I am on the 'Digital Marketplace' page
+  # example@example.com should be rejected by mailchimp as an obvious fake address
+  When I enter 'example@example.com' in the 'email_address' field
+  And I click 'Subscribe'
+  Then I am on the 'Sign up for Digital Marketplace email alerts' page
+  And I see a destructive banner message containing 'The service is unavailable at the moment. If the problem continues please contact enquiries@digitalmarketplace.service.gov.uk'
+  # but this page should still be a valid, working form
+  And I see 'example@example.com' as the value of the 'email_address' field
+  When I enter 'functional-test-example-email@gov.uk' in the 'email_address' field
+  And I click 'Subscribe'
+  Then I am on the 'Digital Marketplace' page

--- a/features/supplier/subscribe_mailing_list.feature
+++ b/features/supplier/subscribe_mailing_list.feature
@@ -1,0 +1,26 @@
+@supplier-subscribe-mailing-list
+Feature: suppliers can subscribe to the open framework notification mailing list without an account
+
+Scenario: Successful mailing-list subscription
+    Given I am on the /suppliers/mailing-list page
+    Then I am on the 'Sign up for Digital Marketplace email alerts' page
+    And I don't see a banner message
+    When I enter 'functional-test-example-email@gov.uk' in the 'email_address' field
+    And I click 'Subscribe'
+    Then I am on the 'Digital Marketplace' page
+    And I see a success banner message containing 'You will receive email notifications to functional-test-example-email@gov.uk when applications are opening.'
+
+Scenario: Initially-rejected mailing-list subscription
+    Given I am on the /suppliers/mailing-list page
+    Then I am on the 'Sign up for Digital Marketplace email alerts' page
+    And I don't see a banner message
+    # example@example.com should be rejected by mailchimp as an obvious fake address
+    When I enter 'example@example.com' in the 'email_address' field
+    And I click 'Subscribe'
+    Then I am on the 'Sign up for Digital Marketplace email alerts' page
+    And I see a destructive banner message containing 'The service is unavailable at the moment. If the problem continues please contact enquiries@digitalmarketplace.service.gov.uk.'
+    # but this page should still be a valid, working form
+    And I see 'example@example.com' as the value of the 'email_address' field
+    When I enter 'functional-test-example-email@gov.uk' in the 'email_address' field
+    And I click 'Subscribe'
+    Then I am on the 'Digital Marketplace' page

--- a/features/supplier/supplier_creation.feature
+++ b/features/supplier/supplier_creation.feature
@@ -1,0 +1,73 @@
+@supplier-creation
+Feature: Create new supplier account
+
+Background:
+  Given There is at least one framework that can be applied to
+
+Scenario: User steps through supplier account creation process
+  Given I am on the homepage
+  When I click 'Become a supplier'
+  Then I am on the 'Become a supplier' page
+
+  When I click 'Create a supplier account'
+  Then I am on the 'Create a supplier account' page
+
+  When I click 'Start'
+  Then I am on the 'DUNS number' page
+
+  When I enter '000000001' in the 'duns_number' field
+  And I click 'Continue'
+  Then I am on the 'Companies House number (optional)' page
+
+  When I enter 'SC000001' in the 'companies_house_number' field
+  And I click 'Continue'
+  Then I am on the 'Company name' page
+
+  When I enter 'This is a test company name' in the 'company_name' field
+  And I click 'Continue'
+  Then I am on the 'Company contact details' page
+
+  When I enter 'Company contact name' in the 'contact_name' field
+  Then I enter 'test.company.email@test.com' in the 'email_address' field
+  Then I enter '0123456789' in the 'phone_number' field
+  And I click 'Continue'
+  Then I am on the 'Create login' page
+
+  When I enter 'test.supplier.email@test.com' in the 'email_address' field
+  And I click 'Continue'
+  Then I am on the 'Check your information' page
+  And I see the 'Your company details' summary table filled with:
+    | field                  | value                       |
+    | DUNS number            | 000000001                   |
+    | Companies House number | SC000001                    |
+    | Company name           | This is a test company name |
+    | Contact name           | Company contact name        |
+    | Contact email          | test.company.email@test.com |
+    | Contact phone number   | 0123456789                  |
+  And I see the 'Your login details' summary table filled with:
+    | field                  | value                        |
+    | Email address          | test.supplier.email@test.com |
+
+  When I update the value of 'DUNS number' to '000000002' using the summary table Edit link
+  And I update the value of 'Companies House number' to 'SC000002' using the summary table Edit link
+  And I update the value of 'Company name' to 'Changed test company name' using the summary table Edit link
+  And I update the value of 'Contact name' to 'Changed contact name' using the summary table Edit link
+  And I update the value of 'Contact email' to 'test.changed.email@test.com' using the summary table Edit link
+  And I update the value of 'Contact phone number' to '9876543210' using the summary table Edit link
+  Then I see the 'Your company details' summary table filled with:
+    | field                  | value                       |
+    | DUNS number            | 000000002                   |
+    | Companies House number | SC000002                    |
+    | Company name           | Changed test company name   |
+    | Contact name           | Changed contact name        |
+    | Contact email          | test.changed.email@test.com |
+    | Contact phone number   | 9876543210                  |
+
+  When I click the summary table Edit link for 'Email address'
+  And I enter 'changed.test.email@test.com' in the 'Your email address' field and click its associated 'Continue' button
+  Then I see the 'Your login details' summary table filled with:
+    | field                  | value                        |
+    | Email address          | changed.test.email@test.com  |
+
+  # We can't ever click the "Create account" button to check the final page because this will create a supplier entry
+  # with DUNS number 000000001 and the test will never pass again.


### PR DESCRIPTION
These are tests to cover the new supplier creation/sign up for notifications flow.

The supplier creation scenario replaces one in the legacy tests, which I'll make a PR to delete soon.

The subscribe to mailing list scenario is new.

I've introduced a couple of `Background` checks that will skip running these scenarios if the framework states on the environment are such that the link being tested is not shown on the "Become a supplier" page.  It's a bit weird to regularly skip tests, but seemed the only way to deal with these conditionally shown links.