### PR TITLE
Move locked account functional test scenario from legacy to master

### DIFF
--- a/features/step_definitions/login_steps.rb
+++ b/features/step_definitions/login_steps.rb
@@ -68,3 +68,25 @@ Given /^that (supplier|buyer) is logged in$/ do |user_role|
     Then I see the 'Log out' button
   }
 end
+
+When /^The wrong password is entered (\d+) times for that user$/ do |tries|
+  tries.to_i.times do |n|
+    steps %Q{
+      Given I am on the /user/login page
+      When I enter '#{@user['emailAddress']}' in the 'Email address' field
+      And I enter 'the_wrong_password' in the 'Password' field
+      And I click the 'Log in' button
+    }
+  end
+end
+
+Then /^That user can not log in using their correct password$/ do
+  steps %Q{
+    Given I am on the /user/login page
+    When I enter '#{@user['emailAddress']}' in the 'Email address' field
+    And I enter '#{@user['password']}' in the 'Password' field
+    And I click the 'Log in' button
+    Then I see a destructive banner message containing 'Accounts are locked after 5 failed attempts'
+    And I don't see the 'Log out' button
+  }
+end

--- a/features/user/lock_account.feature
+++ b/features/user/lock_account.feature
@@ -1,0 +1,8 @@
+@lock-account
+Feature: Users are locked if they enter the wrong password too many times
+
+Scenario: User has 5 failed login attempts and is locked out of their account
+  Given I have a supplier
+  When The wrong password is entered 5 times for that user
+  Then That user can not log in using their correct password
+  # TODO: And the user is shown as 'locked' on the admin users page

--- a/features/user/reset_password.feature
+++ b/features/user/reset_password.feature
@@ -1,10 +1,18 @@
 @reset-password @notify @skip-staging
 Feature: Reset user password
 
-Scenario: Request password reset
+Background:
   Given I have a buyer user
   And I wait 2 seconds to ensure the reset token is created after the user
-  And I am on the /user/reset-password page
+
+Scenario: User has forgotten their password and requests a password reset
+  When I am on the homepage
+  And I click 'Log in'
+  Then I am on the 'Log in to the Digital Marketplace' page
+
+  When I click 'Forgotten password'
+  Then I am on the 'Reset password' page
+
   When I enter that user.emailAddress in the 'Email address' field
   And I click 'Send reset email' button
   Then I see a success banner message containing 'send a link to reset the password'


### PR DESCRIPTION
There are more to go before we can completely delete the "Legacy" tests here: https://github.com/alphagov/digitalmarketplace-functional-tests/blob/jenkins/features/supplier/supplier_journey.feature

But... it's the end of the mission so I'm going to PR these on their own now.  Slowly slowly we will whittle it away...

I also adjusted the password reset Scenario to perform the journey from the homepage, rather than just starting directly at the page itself.

This feels like a useful thing for functional tests to do - we want reassurance that links between different frontend apps are all working OK, and that users can do the thing without needing to know a particular URL.