### PR TITLE
Add optional lot slug param to "I have a live framework" step

### DIFF
--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -20,12 +20,15 @@ Given /^I am on the (.* )?(\/.*) page$/ do |app, url|
   end
 end
 
-Given /^I have a live (.*) framework$/ do |metaframework_slug|
+Given /^I have a live (.*) framework(?: with the (.*) lot)?$/ do |metaframework_slug, lot_slug|
   response = call_api(:get, "/frameworks")
   response.code.should be(200), _error(response, "Failed getting frameworks")
   frameworks = JSON.parse(response.body)['frameworks']
   frameworks.delete_if {|framework| framework['framework'] != metaframework_slug || framework['status'] != 'live'}
-  frameworks.empty?.should be(false), _error(response, "No live #{metaframework_slug} frameworks found")
+  if lot_slug
+    frameworks.delete_if {|framework| framework['lots'].select { |lot| lot["slug"] == lot_slug}.to_a.empty?}
+  end
+  frameworks.empty?.should be(false), _error(response, "No live '#{metaframework_slug}' frameworks found with lot '#{lot_slug}'")
   @framework = frameworks[0]
   puts @framework['slug']
 end

--- a/features/supplier/view_and_edit_g_cloud_services.feature
+++ b/features/supplier/view_and_edit_g_cloud_services.feature
@@ -2,7 +2,7 @@
 Feature: G-Cloud supplier can view and edit their G-Cloud services
 
 Background:
-  Given I have a live g-cloud framework
+  Given I have a live g-cloud framework with the cloud-support lot
   And I have a supplier
   And that supplier is logged in
   And that supplier has applied to be on that framework


### PR DESCRIPTION
This is required because our "edit G-Cloud services" scenario only works for the cloud-support lot, so if (eg on Preview) there are earlier G-Clouds than G9 live then it shouldn't attempt to use those frameworks, but instead only use a framework with the necessary lot.

I have checked the failing tests locally with various framework states and this seems to work.
~Full functional tests are currently running - I will update with full results here when they complete. ~

Run with both G7 and G9 "live" (as on Preview currently)
:sparkles::sparkles::sparkles::sparkles::sparkles::sparkles::sparkles::sparkles::sparkles::sparkles::sparkles::sparkles::sparkles::sparkles::sparkles::sparkles::sparkles::sparkles:
![screen shot 2017-10-13 at 11 30 07](https://user-images.githubusercontent.com/6525554/31542458-f383be36-b009-11e7-90c7-4fba5a311aca.png)
:sparkles::sparkles::sparkles::sparkles::sparkles::sparkles::sparkles::sparkles::sparkles::sparkles::sparkles::sparkles::sparkles::sparkles::sparkles::sparkles::sparkles::sparkles:

Justifying local failures:
1 & 2 - I have no closed briefs with responses
3 - my "s" supplier page isn't paginated
4 - I don't have the Mandrill mailing list ID set up