### PR TITLE
Fix direct award content from recent buyer-fe PR

### DIFF
--- a/features/step_definitions/direct_award_steps.rb
+++ b/features/step_definitions/direct_award_steps.rb
@@ -2,7 +2,7 @@ When(/^I have created and saved a search$/) do
   steps %Q{
     Given I am on the /g-cloud/search page
     And I click 'Save search'
-    Then I am on the 'Save your search' page
+    Then I am on the 'Choose where to save your search' page
     And I enter 'my cloud project' in the 'Name your search' field
     And I click 'Save and continue'
   }


### PR DESCRIPTION
## Summary
Content for the save a search page was changed in https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/640. This updates it to match.