### PR TITLE
Update docker containers for functional tests to use es54

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -143,7 +143,7 @@ services:
       - POSTGRES_DB=digitalmarketplace
 
   elasticsearch:
-    image: "elasticsearch:1.7"
+    image: "elasticsearch:5.4"
     ports:
       - "9200:9200"
 


### PR DESCRIPTION
## Summary
We run Elasticsearch 5.4 on our live environments now, so let's use the same in our local ones.

## Ticket
https://trello.com/c/wxoYb6sT/9-investigate-how-to-upgrade-elastic-search-so-it-is-ready-to-move-to-paas