### PR TITLE
Update delete_all_draft_briefs to exclude awarded briefs

### DIFF
--- a/features/step_definitions/setup_steps.rb
+++ b/features/step_definitions/setup_steps.rb
@@ -300,7 +300,7 @@ def delete_all_draft_briefs (user_id)
     brief_id = brief["id"]
     updated_by = {updated_by: "Functional tests"}
 
-    unless ["live", "closed", "withdrawn", "unsuccessful", "cancelled"].include? brief["status"]
+    unless ["live", "closed", "withdrawn", "unsuccessful", "cancelled", "awarded"].include? brief["status"]
       puts "deleting draft: #{brief_id}"
       response = call_api(:delete, "/briefs/#{brief_id}", payload: updated_by)
       response.code.should be(200), response.body


### PR DESCRIPTION
## Summary
Tests failed when trying to delete all draft briefs because some awarded briefs exsited.
https://ci.marketplace.team/job/functional-tests-preview-legacy/781/functional_test_report/