### PR TITLE
Set elasticsearch host on search-api docker compose service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       - "5001:80"
     environment:
       - DM_ENVIRONMENT=development
-      - DM_ELASTICSEARCH_URL=http://elasticsearch:9200
+      - ELASTICSEARCH_HOST=http://elasticsearch:9200
     command: bash -c 'supervisord --configuration /etc/supervisord.conf'
     depends_on:
       - elasticsearch


### PR DESCRIPTION
Since moving elasticsearch to PaaS we set `ELASTICSEARCH_HOST` instead of `DM_ELASTICSEARCH_URL`