### PR TITLE
Withdraw a brief scenario

### DIFF
--- a/features/buyer/award_flow_requirements.feature
+++ b/features/buyer/award_flow_requirements.feature
@@ -47,8 +47,8 @@ Scenario: Award Flow - Cancel a requirement
   And I click the 'Save and continue' button
   Then I am on the 'Why didn't you award a contract for %s?' page with brief 'title'
 
-  When I choose 'The requirement has been cancelled' radio button
-  And I click the 'Update requirement' button
+  When I choose 'Your requirements have been cancelled' radio button
+  And I click the 'Update requirements' button
   Then I am on the '%s' page with brief 'title'
   And I see a success banner message containing 'updated'
 
@@ -65,7 +65,7 @@ Scenario: Award flow - Mark a requirement unsuccessful
   Then I am on the 'Why didn't you award a contract for %s?' page with brief 'title'
 
   When I choose 'There were no suitable suppliers' radio button
-  And I click the 'Update requirement' button
+  And I click the 'Update requirements' button
   Then I am on the '%s' page with brief 'title'
   And I see a success banner message containing 'updated'
 

--- a/features/buyer/cancel_requirements.feature
+++ b/features/buyer/cancel_requirements.feature
@@ -2,7 +2,7 @@
 Feature: Cancel a requirement outside the award flow
   In order to ensure the procurement process is fair and transparent
   As a buyer within government
-  I want to cancel my requirement after applications have closed, because I didn't go ahead with the procurement
+  I want to cancel my requirements after applications have closed, because I didn't go ahead with the procurement
 
 
 Scenario: Cancel a requirement
@@ -13,15 +13,15 @@ Scenario: Cancel a requirement
   Then I see that the 'Closed requirements' summary table has 1 or more entries
 
   When I go to that brief overview page
-  Then I see the 'Cancel requirement' link
+  Then I see the 'Cancel requirements' link
 
-  When I click the 'Cancel requirement' link
+  When I click the 'Cancel requirements' link
   Then I am on the 'Why do you need to cancel %s' page with brief 'title'
 
-  When I choose the 'The requirement has been cancelled' radio button
-  And I click the 'Update requirement' button
+  When I choose the 'Your requirements have been cancelled' radio button
+  And I click the 'Update requirements' button
   Then I see 'The contract was not awarded' text on the page
-  And I see 'the requirement was cancelled.' text on the page
+  And I see 'the requirements were cancelled.' text on the page
   And I see a success banner message containing 'updated'
   And I see the 'View suppliers who applied' link
 
@@ -40,13 +40,13 @@ Scenario: Cancel a requirement where no suitable suppliers applied
   Then I see that the 'Closed requirements' summary table has 1 or more entries
 
   When I go to that brief overview page
-  Then I see the 'Cancel requirement' link
+  Then I see the 'Cancel requirements' link
 
-  When I click the 'Cancel requirement' link
+  When I click the 'Cancel requirements' link
   Then I am on the 'Why do you need to cancel %s' page with brief 'title'
 
   When I choose the 'There were no suitable suppliers' radio button
-  And I click the 'Update requirement' button
+  And I click the 'Update requirements' button
   Then I see 'The contract was not awarded' text on the page
   And I see 'no suitable suppliers applied.' text on the page
   And I see a success banner message containing 'updated'

--- a/features/buyer/requirements.feature
+++ b/features/buyer/requirements.feature
@@ -183,6 +183,21 @@ Scenario: Delete a draft requirement
   Then I see a success banner message containing 'were deleted'
 
 
+Scenario: Withdraw a live requirement
+  Given I am logged in as the buyer of a live brief
+
+  When I click the 'View your account' link
+  And I click the 'View your requirements' link
+  Then I see that the 'Published requirements' summary table has 1 or more entries
+
+  When I go to that brief overview page
+  Then I see the 'Withdraw requirements' link
+  And I click 'Withdraw requirements'
+  Then I see a destructive banner message containing 'Are you sure you want to withdraw these requirements?'
+  When I click 'Withdraw requirements'
+  Then I see a success banner message containing 'withdrawn your requirements'
+
+
 Scenario: Edit a draft requirement
   Given I am logged in as a buyer user
   And I have created an individual specialist requirement


### PR DESCRIPTION
Trello ticket: https://trello.com/c/7kq7pSTr/83-allow-buyers-withdraw-open-opportunities

- Adds a new scenario to allow buyers to withdraw their requirements.
- Updates existing scenarios with recent copy changes ('requirement' is now pluralised in a number of new places on the Briefs FE - see https://github.com/alphagov/digitalmarketplace-briefs-frontend/pull/48)