### PR TITLE
Remove skip-staging tags and old local/preview test versions

### DIFF
--- a/features/buyer/award_flow_requirements.feature
+++ b/features/buyer/award_flow_requirements.feature
@@ -41,25 +41,6 @@ Scenario: Award flow - Award a requirement to a winning supplier
   And I see a temporary-message banner message containing 'Company size'
 
 
-@skip-local @skip-preview
-Scenario: Award Flow - Cancel a requirement
-
-  Given I choose 'No' radio button
-  And I click the 'Save and continue' button
-  Then I am on the 'Why didn't you award a contract for %s?' page with brief 'title'
-
-  When I choose 'The requirement has been cancelled' radio button
-  And I click the 'Update requirement' button
-  Then I am on the '%s' page with brief 'title'
-  And I see a success banner message containing 'updated'
-
-  When I go to that brief page
-  Then I see a temporary-message banner message containing 'This opportunity was cancelled'
-  And I see a temporary-message banner message containing 'The buyer cancelled this opportunity, for example because they no longer '
-  And I see a temporary-message banner message containing 'have the budget. They may publish an updated version later.'
-
-
-@skip-staging
 Scenario: Award Flow - Cancel requirements
 
   Given I choose 'No' radio button
@@ -77,25 +58,6 @@ Scenario: Award Flow - Cancel requirements
   And I see a temporary-message banner message containing 'have the budget. They may publish an updated version later.'
 
 
-@skip-local @skip-preview
-Scenario: Award flow - Mark a requirement unsuccessful
-
-  Given I choose 'No' radio button
-  And I click the 'Save and continue' button
-  Then I am on the 'Why didn't you award a contract for %s?' page with brief 'title'
-
-  When I choose 'There were no suitable suppliers' radio button
-  And I click the 'Update requirement' button
-  Then I am on the '%s' page with brief 'title'
-  And I see a success banner message containing 'updated'
-
-  When I go to that brief page
-  Then I see a temporary-message banner message containing 'No suitable suppliers applied'
-  And I see a temporary-message banner message containing 'The buyer didn't award this contract because no suppliers met their '
-  And I see a temporary-message banner message containing 'requirements. They may publish an updated version later.'
-
-
-@skip-staging
 Scenario: Award flow - Mark requirements as unsuccessful
 
   Given I choose 'No' radio button

--- a/features/buyer/cancel_requirements.feature
+++ b/features/buyer/cancel_requirements.feature
@@ -5,7 +5,6 @@ Feature: Cancel a requirement outside the award flow
   I want to cancel my requirements after applications have closed, because I didn't go ahead with the procurement
 
 
-@skip-staging
 Scenario: Cancel requirements
   Given I am logged in as the buyer of a closed brief
 
@@ -33,35 +32,6 @@ Scenario: Cancel requirements
   And I see a temporary-message banner message containing 'They may publish an updated version later.'
 
 
-@skip-local @skip-preview
-Scenario: Cancel a requirement
-  Given I am logged in as the buyer of a closed brief
-
-  When I click the 'View your account' link
-  And I click the 'View your requirements' link
-  Then I see that the 'Closed requirements' summary table has 1 or more entries
-
-  When I go to that brief overview page
-  Then I see the 'Cancel requirement' link
-
-  When I click the 'Cancel requirement' link
-  Then I am on the 'Why do you need to cancel %s' page with brief 'title'
-
-  When I choose the 'The requirement has been cancelled' radio button
-  And I click the 'Update requirement' button
-  Then I see 'The contract was not awarded' text on the page
-  And I see 'the requirement was cancelled.' text on the page
-  And I see a success banner message containing 'updated'
-  And I see the 'View suppliers who applied' link
-
-  When I go to that brief page
-  Then I see a temporary-message banner message containing 'This opportunity was cancelled'
-  And I see a temporary-message banner message containing 'The buyer cancelled this opportunity,'
-  And I see a temporary-message banner message containing 'for example because they no longer have the budget.'
-  And I see a temporary-message banner message containing 'They may publish an updated version later.'
-
-
-@skip-staging
 Scenario: Cancel requirements where no suitable suppliers applied
   Given I am logged in as the buyer of a closed brief
 
@@ -77,33 +47,6 @@ Scenario: Cancel requirements where no suitable suppliers applied
 
   When I choose the 'There were no suitable suppliers' radio button
   And I click the 'Update requirements' button
-  Then I see 'The contract was not awarded' text on the page
-  And I see 'no suitable suppliers applied.' text on the page
-  And I see a success banner message containing 'updated'
-  And I see the 'View suppliers who applied' link
-
-  When I go to that brief page
-  Then I see a temporary-message banner message containing 'No suitable suppliers applied'
-  And I see a temporary-message banner message containing 'The buyer didn't award this contract because no suppliers met their requirements.'
-  And I see a temporary-message banner message containing 'They may publish an updated version later.'
-
-
-@skip-local @skip-preview
-Scenario: Cancel a requirement where no suitable suppliers applied
-  Given I am logged in as the buyer of a closed brief
-
-  When I click the 'View your account' link
-  And I click the 'View your requirements' link
-  Then I see that the 'Closed requirements' summary table has 1 or more entries
-
-  When I go to that brief overview page
-  Then I see the 'Cancel requirement' link
-
-  When I click the 'Cancel requirement' link
-  Then I am on the 'Why do you need to cancel %s' page with brief 'title'
-
-  When I choose the 'There were no suitable suppliers' radio button
-  And I click the 'Update requirement' button
   Then I see 'The contract was not awarded' text on the page
   And I see 'no suitable suppliers applied.' text on the page
   And I see a success banner message containing 'updated'

--- a/features/buyer/requirements.feature
+++ b/features/buyer/requirements.feature
@@ -183,7 +183,6 @@ Scenario: Delete a draft requirement
   Then I see a success banner message containing 'were deleted'
 
 
-@skip-staging
 Scenario: Withdraw live requirements
   Given I am logged in as the buyer of a live brief
 


### PR DESCRIPTION
Once the withdraw journey (Briefs FE) and the copy changes (`requirement` to `requirements`) are deployed to staging, this PR can be merged.