### PR TITLE
Make containers log to stdout

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - ./compose-scripts:/compose-scripts
     command: >
       bash -c 'ln -sf /dev/stdout /var/log/digitalmarketplace/application.log &&
+      sed -i -e "s/stdout_logfile_maxbytes = [0-9]*/stdout_logfile_maxbytes = 0/g" /etc/supervisord.conf &&
       /compose-scripts/wait-for-postgres.py && python application.py db upgrade &&
       supervisord --configuration /etc/supervisord.conf'
     depends_on:
@@ -27,6 +28,7 @@ services:
       - ELASTICSEARCH_HOST=http://elasticsearch:9200
     command: >
       bash -c 'ln -sf /dev/stdout /var/log/digitalmarketplace/application.log &&
+      sed -i -e "s/stdout_logfile_maxbytes = [0-9]*/stdout_logfile_maxbytes = 0/g" /etc/supervisord.conf &&
       supervisord --configuration /etc/supervisord.conf'
     depends_on:
       - elasticsearch
@@ -45,6 +47,7 @@ services:
       - ./compose-scripts:/compose-scripts
     command: >
       bash -c 'ln -sf /dev/stdout /var/log/digitalmarketplace/application.log &&
+      sed -i -e "s/stdout_logfile_maxbytes = [0-9]*/stdout_logfile_maxbytes = 0/g" /etc/supervisord.conf &&
       /compose-scripts/wait-for-api.sh && supervisord --configuration /etc/supervisord.conf'
     depends_on:
       - api
@@ -64,6 +67,7 @@ services:
       - ./compose-scripts:/compose-scripts
     command: >
       bash -c 'ln -sf /dev/stdout /var/log/digitalmarketplace/application.log &&
+      sed -i -e "s/stdout_logfile_maxbytes = [0-9]*/stdout_logfile_maxbytes = 0/g" /etc/supervisord.conf &&
       /compose-scripts/wait-for-api.sh && supervisord --configuration /etc/supervisord.conf'
     depends_on:
       - api
@@ -83,6 +87,7 @@ services:
       - ./compose-scripts:/compose-scripts
     command: >
       bash -c 'ln -sf /dev/stdout /var/log/digitalmarketplace/application.log &&
+      sed -i -e "s/stdout_logfile_maxbytes = [0-9]*/stdout_logfile_maxbytes = 0/g" /etc/supervisord.conf &&
       /compose-scripts/wait-for-api.sh && supervisord --configuration /etc/supervisord.conf'
     depends_on:
       - api
@@ -101,6 +106,7 @@ services:
       - ./compose-scripts:/compose-scripts
     command: >
       bash -c 'ln -sf /dev/stdout /var/log/digitalmarketplace/application.log &&
+      sed -i -e "s/stdout_logfile_maxbytes = [0-9]*/stdout_logfile_maxbytes = 0/g" /etc/supervisord.conf &&
       /compose-scripts/wait-for-api.sh && supervisord --configuration /etc/supervisord.conf'
     depends_on:
       - api
@@ -122,6 +128,7 @@ services:
       - ./compose-scripts:/compose-scripts
     command: >
       bash -c 'ln -sf /dev/stdout /var/log/digitalmarketplace/application.log &&
+      sed -i -e "s/stdout_logfile_maxbytes = [0-9]*/stdout_logfile_maxbytes = 0/g" /etc/supervisord.conf &&
       /compose-scripts/wait-for-api.sh && supervisord --configuration /etc/supervisord.conf'
     depends_on:
       - api
@@ -142,6 +149,7 @@ services:
       - ./compose-scripts:/compose-scripts
     command: >
       bash -c 'ln -sf /dev/stdout /var/log/digitalmarketplace/application.log &&
+      sed -i -e "s/stdout_logfile_maxbytes = [0-9]*/stdout_logfile_maxbytes = 0/g" /etc/supervisord.conf &&
       /compose-scripts/wait-for-api.sh && supervisord --configuration /etc/supervisord.conf'
     depends_on:
       - api

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,9 @@ services:
     volumes:
       - ./compose-scripts:/compose-scripts
     command: >
-      bash -c "/compose-scripts/wait-for-postgres.py && python application.py db upgrade
-      && supervisord --configuration /etc/supervisord.conf"
+      bash -c 'ln -sf /dev/stdout /var/log/digitalmarketplace/application.log &&
+      /compose-scripts/wait-for-postgres.py && python application.py db upgrade &&
+      supervisord --configuration /etc/supervisord.conf'
     depends_on:
       - postgres
 
@@ -24,7 +25,9 @@ services:
     environment:
       - DM_ENVIRONMENT=development
       - ELASTICSEARCH_HOST=http://elasticsearch:9200
-    command: bash -c 'supervisord --configuration /etc/supervisord.conf'
+    command: >
+      bash -c 'ln -sf /dev/stdout /var/log/digitalmarketplace/application.log &&
+      supervisord --configuration /etc/supervisord.conf'
     depends_on:
       - elasticsearch
 
@@ -40,7 +43,9 @@ services:
       - PROXY_AUTH_CREDENTIALS=dev-user:$$apr1$$rx3G14WQ$$I2zOn60wfMGCrxjC8NbdP0
     volumes:
       - ./compose-scripts:/compose-scripts
-    command: bash -c '/compose-scripts/wait-for-api.sh && supervisord --configuration /etc/supervisord.conf'
+    command: >
+      bash -c 'ln -sf /dev/stdout /var/log/digitalmarketplace/application.log &&
+      /compose-scripts/wait-for-api.sh && supervisord --configuration /etc/supervisord.conf'
     depends_on:
       - api
 
@@ -57,7 +62,9 @@ services:
       - PROXY_AUTH_CREDENTIALS=dev-user:$$apr1$$rx3G14WQ$$I2zOn60wfMGCrxjC8NbdP0
     volumes:
       - ./compose-scripts:/compose-scripts
-    command: bash -c '/compose-scripts/wait-for-api.sh && supervisord --configuration /etc/supervisord.conf'
+    command: >
+      bash -c 'ln -sf /dev/stdout /var/log/digitalmarketplace/application.log &&
+      /compose-scripts/wait-for-api.sh && supervisord --configuration /etc/supervisord.conf'
     depends_on:
       - api
       - search-api
@@ -74,7 +81,9 @@ services:
       - PROXY_AUTH_CREDENTIALS=dev-user:$$apr1$$rx3G14WQ$$I2zOn60wfMGCrxjC8NbdP0
     volumes:
       - ./compose-scripts:/compose-scripts
-    command: bash -c '/compose-scripts/wait-for-api.sh && supervisord --configuration /etc/supervisord.conf'
+    command: >
+      bash -c 'ln -sf /dev/stdout /var/log/digitalmarketplace/application.log &&
+      /compose-scripts/wait-for-api.sh && supervisord --configuration /etc/supervisord.conf'
     depends_on:
       - api
 
@@ -90,7 +99,9 @@ services:
       - PROXY_AUTH_CREDENTIALS=dev-user:$$apr1$$rx3G14WQ$$I2zOn60wfMGCrxjC8NbdP0
     volumes:
       - ./compose-scripts:/compose-scripts
-    command: bash -c '/compose-scripts/wait-for-api.sh && supervisord --configuration /etc/supervisord.conf'
+    command: >
+      bash -c 'ln -sf /dev/stdout /var/log/digitalmarketplace/application.log &&
+      /compose-scripts/wait-for-api.sh && supervisord --configuration /etc/supervisord.conf'
     depends_on:
       - api
 
@@ -109,7 +120,9 @@ services:
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
     volumes:
       - ./compose-scripts:/compose-scripts
-    command: bash -c '/compose-scripts/wait-for-api.sh && supervisord --configuration /etc/supervisord.conf'
+    command: >
+      bash -c 'ln -sf /dev/stdout /var/log/digitalmarketplace/application.log &&
+      /compose-scripts/wait-for-api.sh && supervisord --configuration /etc/supervisord.conf'
     depends_on:
       - api
 
@@ -127,7 +140,9 @@ services:
       - DM_NOTIFY_API_KEY=${DM_NOTIFY_API_KEY}
     volumes:
       - ./compose-scripts:/compose-scripts
-    command: bash -c '/compose-scripts/wait-for-api.sh && supervisord --configuration /etc/supervisord.conf'
+    command: >
+      bash -c 'ln -sf /dev/stdout /var/log/digitalmarketplace/application.log &&
+      /compose-scripts/wait-for-api.sh && supervisord --configuration /etc/supervisord.conf'
     depends_on:
       - api
 


### PR DESCRIPTION
### Symlink `/dev/stdout` to logfile
As the containers are the same as the ones we use in production,
application logs are written to file, specifically to
`/var/log/digitalmarketplace/application.log`.

By symlinking `/dev/stdout` to the logfile, application logs which are
written to that file will actually be sent to stdout of the container,
and displayed in the terminal.

### Prevent log rotation when running containers
Supervisord is set up to rotate log files. It rotates them when the file
reaches 50000000 bytes.

As the log file it's looking at is now /dev/stdout this is an issue.
Everytime a log line is written to the log file (stdout) supervisord
attempts to seek the file. Which is an illegal operation on /dev/stdout.
This causes a stack trace to be output after every log line. See here
for more info: Supervisor/supervisor#935

By setting the logfile maxbytes to 0, we turn off log rotation which
resolves the issue.