### PR TITLE
Increase max allowed upload size

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -14,6 +14,8 @@ http {
         listen       80;
         server_name  localhost;
 
+        client_max_body_size 20M;
+
         gzip         on;
         gzip_types   text/css application/javascript;
 


### PR DESCRIPTION
The default max upload size is small (<5MB) so we can't properly test
upload size validation locally as nginx errors before our apps.

Increasing the size here allows for a more reasitic dev environment.