### PR TITLE
Allow permissions with hyphens

### DIFF
--- a/features/step_definitions/login_steps.rb
+++ b/features/step_definitions/login_steps.rb
@@ -36,7 +36,7 @@ Given /^I have a ([a-z-]+) user(?: with supplier id (\d*))?$/ do |user_role, sup
   @user
 end
 
-Given /^I am logged in as (?:a|the) (production )?(\w+) user$/ do |production, user_role|
+Given /^I am logged in as (?:a|the) (production )?([\w\-]+) user$/ do |production, user_role|
   login_page = '/user/login'
   steps %Q{
     Given I have a #{production}#{user_role} user


### PR DESCRIPTION
We require this for porting across the admin tests for
admin-ccs-sourcing
admin-ccs-category
admin-manager
admin-framework-manager