### PR TITLE
NEW: (Admin) Functional tests for inviting a supplier contributor

### DIFF
--- a/features/admin/invite_supplier_contributor.feature
+++ b/features/admin/invite_supplier_contributor.feature
@@ -25,3 +25,14 @@ Scenario Outline: Correct users cannot update the supplier name
     | role                    |
     | admin-ccs-sourcing      |
     | admin-manager           |
+
+Scenario Outline: Correct users cannot update the supplier name
+  Given I am logged in as the production <role> user
+  When I am on the /admin/suppliers?supplier_name_prefix=DM+Functional+Test+Supplier+1 page
+  And I click the summary table 'Users' link for 'DM Functional Test Supplier 1'
+  Then I don't see the 'Send invitation' button
+
+  Examples:
+    | role                    |
+    | admin-framework-manager |
+    | admin-ccs-category      |

--- a/features/admin/invite_supplier_contributor.feature
+++ b/features/admin/invite_supplier_contributor.feature
@@ -1,0 +1,17 @@
+@invite-supplier-contributor
+Feature: Invite a contributor to a supplier account
+
+Scenario Outline: Correct users can invite a contributors to a supplier account
+  Given I am logged in as the production <role> user
+  And I have a supplier with:
+    | name          | DM Functional Test Supplier 1 |
+  And I click the 'Edit supplier accounts or view services' link
+  And I enter 'DM Functional Test Supplier 1' in the 'supplier_name_prefix' field and click its associated 'Search' button
+  And I click the summary table 'Users' link for 'DM Functional Test Supplier 1'
+  When I enter 'simulate-delivered@notifications.service.gov.uk' in the 'Email address' field
+  And I click the 'Send invitation' button
+  Then I see a success banner message containing 'User invited'
+
+  Examples:
+    | role                    |
+    | admin                   |

--- a/features/admin/invite_supplier_contributor.feature
+++ b/features/admin/invite_supplier_contributor.feature
@@ -15,3 +15,13 @@ Scenario Outline: Correct users can invite a contributors to a supplier account
   Examples:
     | role                    |
     | admin                   |
+
+Scenario Outline: Correct users cannot update the supplier name
+  Given I am logged in as the production <role> user
+  When I am on the /admin/suppliers?supplier_name_prefix=DM+Functional+Test+Supplier+1 page
+  Then I don't see the 'Users' link
+
+  Examples:
+    | role                    |
+    | admin-ccs-sourcing      |
+    | admin-manager           |

--- a/features/admin/invite_supplier_contributor.feature
+++ b/features/admin/invite_supplier_contributor.feature
@@ -16,7 +16,7 @@ Scenario Outline: Correct users can invite a contributors to a supplier account
     | role                    |
     | admin                   |
 
-Scenario Outline: Correct users cannot update the supplier name
+Scenario Outline: Prohibited user roles cannot manage supplier users
   Given I am logged in as the production <role> user
   When I am on the /admin/suppliers?supplier_name_prefix=DM+Functional+Test+Supplier+1 page
   Then I don't see the 'Users' link
@@ -26,7 +26,7 @@ Scenario Outline: Correct users cannot update the supplier name
     | admin-ccs-sourcing      |
     | admin-manager           |
 
-Scenario Outline: Correct users cannot update the supplier name
+Scenario Outline: Prohibited user roles cannot invite users to a supplier
   Given I am logged in as the production <role> user
   When I am on the /admin/suppliers?supplier_name_prefix=DM+Functional+Test+Supplier+1 page
   And I click the summary table 'Users' link for 'DM Functional Test Supplier 1'

--- a/features/step_definitions/login_steps.rb
+++ b/features/step_definitions/login_steps.rb
@@ -49,6 +49,14 @@ Given 'I have a supplier with:' do |table|
   @supplier = get_or_create_supplier(table.rows_hash)
 end
 
+Given 'that supplier has a user with:' do |table|
+  # To be used in conjunction with the above 2 methods to create multiple users on a supplier with specific attributes
+  custom_user_data = table.rows_hash
+  user_data = {"supplier_id"=>@supplier['id']}
+  custom_user_data.update(user_data)
+  @supplier_user = get_or_create_user(custom_user_data)
+end
+
 Given /^that (supplier|buyer) is logged in$/ do |user_role|
   user = user_role == 'supplier' ? @supplier_user : @buyer_user
 

--- a/features/step_definitions/login_steps.rb
+++ b/features/step_definitions/login_steps.rb
@@ -45,6 +45,10 @@ Given 'I have a supplier' do
   @supplier = create_supplier
 end
 
+Given 'I have a supplier with:' do |table|
+  @supplier = get_or_create_supplier(table.rows_hash)
+end
+
 Given /^that (supplier|buyer) is logged in$/ do |user_role|
   user = user_role == 'supplier' ? @supplier_user : @buyer_user
 

--- a/features/step_definitions/login_steps.rb
+++ b/features/step_definitions/login_steps.rb
@@ -35,6 +35,10 @@ Given 'I have a supplier user' do
   @supplier_user = create_user('supplier', {"supplierId"=>@supplier['id']})
 end
 
+Given 'I have a supplier' do
+  @supplier = create_supplier
+end
+
 Given /^that (supplier|buyer) is logged in$/ do |user_role|
   user = user_role == 'supplier' ? @supplier_user : @buyer_user
 

--- a/features/step_definitions/login_steps.rb
+++ b/features/step_definitions/login_steps.rb
@@ -35,6 +35,12 @@ Given 'I have a supplier user' do
   @supplier_user = create_user('supplier', {"supplierId"=>@supplier['id']})
 end
 
+Given "I have a '(.*)' user with:" do |role|table|
+  custom_user_data = table.rows_hash
+  custom_user_data['role'] = role
+  instance_variable_set("@#{role}_user", get_or_create_user(custom_user_data))
+end
+
 Given 'I have a supplier' do
   @supplier = create_supplier
 end

--- a/features/step_definitions/login_steps.rb
+++ b/features/step_definitions/login_steps.rb
@@ -32,7 +32,7 @@ end
 
 Given 'I have a supplier user' do
   @supplier = create_supplier
-  @supplier_user = create_user('supplier', @supplier['id'])
+  @supplier_user = create_user('supplier', {"supplierId"=>@supplier['id']})
 end
 
 Given /^that (supplier|buyer) is logged in$/ do |user_role|

--- a/features/support/api_helpers.rb
+++ b/features/support/api_helpers.rb
@@ -333,3 +333,27 @@ def create_user(user_role, custom_user_data={})
   puts "Email address: #{@user['emailAddress']}"
   @user
 end
+
+def get_or_create_supplier(custom_supplier_data)
+  # This method is used to search for a supplier, and if it does not exist create that supplier. It will return
+  # that supplier and also set it to the global @supplier var.
+  # The possible argument combinations for the getting of a supplier are dependent on the available end points for
+  # suppliers.
+  # Therefore this method supports:
+  # id: being the supplier_id of the supplier (and should not be used with any other args as it's a primary key)
+  # name: name prefix of the supplier. This may result in unpredictable behaviour if the provided name is not unique.
+  # Should the supplier not be found we will attempt a post create with the provided supplier data.
+  if custom_supplier_data["id"] != nil
+    response = call_api(:get, "/suppliers/#{custom_supplier_data['id']}")
+    @supplier = JSON.parse(response.body)["suppliers"]
+    return @supplier
+  end
+  if custom_supplier_data["name"] != nil
+    response = call_api(:get, '/suppliers', params: {prefix: custom_supplier_data['name']})
+    @supplier = JSON.parse(response.body)['suppliers'][0]
+  end
+  if not @supplier
+    @supplier = create_supplier(custom_supplier_data)
+  end
+  return @supplier
+end

--- a/features/support/api_helpers.rb
+++ b/features/support/api_helpers.rb
@@ -312,19 +312,19 @@ def create_live_service(framework_slug, lot_slug, supplier_id, role=nil)
   JSON.parse(response.body)['services']
 end
 
-def create_user(user_role, supplier_id=nil)
+def create_user(user_role, custom_user_data={})
   randomString = SecureRandom.hex
   password = ENV["DM_PRODUCTION_#{user_role.upcase.gsub('-', '_')}_USER_PASSWORD"]
 
   user_data = {
-    "emailAddress" => randomString + '@example.gov.uk',
-    "name" => "#{user_role.capitalize} Name #{randomString}",
+    "emailAddress" => custom_user_data['emailAddress'] || custom_user_data['email_address'] || randomString + '@example.gov.uk',
+    "name" => custom_user_data['name'] || "#{user_role.capitalize} Name #{randomString}",
     "password" => password,
-    "role" => user_role,
+    "role" => custom_user_data['role'] || user_role,
     "phoneNumber" => (SecureRandom.random_number(10000000) + 10000000000).to_s,
   }
 
-  user_data['supplierId'] = supplier_id.to_i if user_role == 'supplier'
+  user_data['supplierId'] = custom_user_data['supplierId'] || custom_user_data['supplier_id'] || 0  if user_role == 'supplier'
 
   response = call_api(:post, "/users", payload: {users: user_data, updated_by: 'functional_tests'})
   response.code.should be(201), response.body

--- a/features/support/api_helpers.rb
+++ b/features/support/api_helpers.rb
@@ -247,23 +247,23 @@ def withdraw_brief(brief_id)
   JSON.parse(response.body)['briefs']
 end
 
-def create_supplier
+def create_supplier(custom_supplier_data={})
   random_string = SecureRandom.hex
-
-  response = call_api(:post, "/suppliers", payload: {
-    updated_by: "functional tests",
-    suppliers: {
-      name: 'functional test supplier ' + random_string,
-      dunsNumber: rand(9999999999).to_s,
-      contactInformation: [
-        {
-          contactName: random_string,
-          email: random_string + "-supplier@user.dmdev",
-          phoneNumber: '%010d' % rand(10 ** 11 -1),
-        }
-      ]
-    }
-  })
+  supplier_data = {
+    name: 'functional test supplier ' + random_string,
+    dunsNumber: rand(9999999999).to_s,
+    contactInformation: [{
+      contactName: random_string,
+      email: random_string + "-supplier@user.dmdev",
+      phoneNumber: '%010d' % rand(10 ** 11 -1),
+    }]
+  }
+  supplier_data.update(custom_supplier_data)
+  response = call_api(
+    :post,
+    "/suppliers",
+    payload: {updated_by: "functional tests", suppliers: supplier_data}
+  )
   response.code.should be(201), _error(response, "Failed to create supplier")
   JSON.parse(response.body)['suppliers']
 end


### PR DESCRIPTION

Update `create_supplier` helper method to accept customisation data to customise returned supplier
Update `create_user` helper method to accept customisation data to customise returned user
Update `I have a supplier user` step to pass arguments to `create_supplier` in new format

New `I have a supplier` step to create _only_ a supplier object
New `I have a user with` step to take advantage of new customisable users
New `I have a supplier with` step to take advantage of new customisable suppliers
New `that supplier has a user with` step to associate customised supplier with custom user, uses @supplier global var as per log in steps
New `get_or_create_supplier` helper method. Searches for existing supplier before creating
New `get_or_create_user` helper method to search for user before creating

NEW: (Admin user only) Functional test for inviting a supplier contributor
NEW: (Sourcing and Manager) Functional tests for inviting a supplier contributor
NEW: (Category and Framework Manager) Functional tests for inviting a supplier contributor

