### PR TITLE
Opportunities search changes corresponding to new ES implementation

### DIFF
--- a/features/smoke-tests/supplier/opportunities.feature
+++ b/features/smoke-tests/supplier/opportunities.feature
@@ -59,30 +59,85 @@ Scenario Outline: User can filter by individual location
     | International (outside the UK) |
     | Off-site                       |
 
-Scenario Outline: User can filter by both status and lot
+Scenario Outline: User gets no results for impossible combinations of location and lot
+  Given I am on the /digital-outcomes-and-specialists/opportunities page
+  And I click '<lot>'
+  And I check '<location>' checkbox
+  And I wait for the page to reload
+  Then I see no results
+  # now we backtrack a bit to check the lot "link" has been made unclickable when showing it has no results
+  When I click 'Clear filters'
+  And I wait for the page to reload
+  And I click 'All categories'
+  And I check '<location>' checkbox
+  And I wait for the page to reload
+  Then I don't see the '<lot>' link
+
+  Examples:
+    | lot                        | location                       |
+    | Digital specialists        | International (outside the UK) |
+    | Digital outcomes           | International (outside the UK) |
+    | User research participants | Off-site                       |
+
+Scenario Outline: User can filter by both status, lot and location together
   Given I am on the /digital-outcomes-and-specialists/opportunities page
   When I note the result_count
   And I click '<lot>'
+  Then I see that the stated number of results does not exceed that result_count
+  And I note the result_count
+  When I check '<status>' checkbox
   And I wait for the page to reload
   Then I see that the stated number of results does not exceed that result_count
   And I note the result_count
-  And I check '<status>' checkbox
-  And I wait for the page to reload
-  Then I see that the stated number of results does not exceed that result_count
   And I see all the opportunities on the page are on the '<lot>' lot
   And I see all the opportunities on the page are of the '<status>' status
+  When I check '<location>' checkbox
+  And I wait for the page to reload
+  Then I see that the stated number of results does not exceed that result_count
+  And I note the result_count
+  And I see all the opportunities on the page are on the '<lot>' lot
+  And I see all the opportunities on the page are of the '<status>' status
+  And I see all the opportunities on the page are in the '<location>' location
 
   Examples:
-    | lot                        | status       |
-    | Digital specialists        | Open         |
-    | Digital outcomes           | Open         |
-    | User research participants | Open         |
-    | Digital specialists        | Closed       |
-    | Digital outcomes           | Closed       |
-    | User research participants | Closed       |
-    | Digital specialists        | Awarded      |
-    | Digital outcomes           | Unsuccessful |
-    | User research participants | Cancelled    |
+    | lot                        | status       | location                       |
+    | Digital specialists        | Open         | Scotland                       |
+    | Digital outcomes           | Open         | International (outside the UK) |
+    | User research participants | Open         | Off-site                       |
+    | Digital specialists        | Closed       | South West England             |
+    | Digital outcomes           | Closed       | International (outside the UK) |
+    | User research participants | Closed       | Off-site                       |
+    | Digital specialists        | Awarded      | London                         |
+    | Digital outcomes           | Unsuccessful | International (outside the UK) |
+    | User research participants | Cancelled    | Off-site                       |
+    | Digital specialists        | Closed       | Wales                          |
+    | Digital outcomes           | Cancelled    | Yorkshire and the Humber       |
+    | User research participants | Awarded      | Northern Ireland               |
+
+Scenario: Specialist roles are selectable for Digital specialists
+  Given I am on the /digital-outcomes-and-specialists/opportunities page
+  Then I don't see a 'Designer' checkbox
+  And I don't see any 'specialistRole' checkboxes
+  When I click 'Digital specialists'
+  And I note the result_count
+  And I check 'Designer' checkbox
+  And I wait for the page to reload
+  Then I see that the stated number of results does not exceed that result_count
+  And I see all the opportunities on the page are on the 'Digital specialists' lot
+  And I see all the opportunities on the page are for the 'Designer' role
+
+Scenario Outline: Specialist roles are not selectable for non-Digital specialists lots
+  Given I am on the /digital-outcomes-and-specialists/opportunities page
+  Then I don't see a 'Designer' checkbox
+  And I don't see any 'specialistRole' checkboxes
+  When I click '<lot>'
+  Then I don't see a 'Designer' checkbox
+  And I don't see any 'specialistRole' checkboxes
+
+  Examples:
+    | lot                        |
+    | Digital outcomes           |
+    | User research participants |
 
 Scenario: Checking all statuses returns all results
   Given I am on the /digital-outcomes-and-specialists/opportunities page

--- a/features/smoke-tests/supplier/opportunities.feature
+++ b/features/smoke-tests/supplier/opportunities.feature
@@ -41,9 +41,6 @@ Scenario Outline: User can filter by individual status
     | status       |
     | Open         |
     | Closed       |
-    | Awarded      |
-    | Unsuccessful |
-    | Cancelled    |
 
 Scenario Outline: User can filter by individual location
   Given I am on the /digital-outcomes-and-specialists/opportunities page
@@ -107,12 +104,12 @@ Scenario Outline: User can filter by both status, lot and location together
     | Digital specialists        | Closed       | South West England             |
     | Digital outcomes           | Closed       | International (outside the UK) |
     | User research participants | Closed       | Off-site                       |
-    | Digital specialists        | Awarded      | London                         |
-    | Digital outcomes           | Unsuccessful | International (outside the UK) |
-    | User research participants | Cancelled    | Off-site                       |
+    | Digital specialists        | Open         | London                         |
+    | Digital outcomes           | Closed       | International (outside the UK) |
+    | User research participants | Open         | Off-site                       |
     | Digital specialists        | Closed       | Wales                          |
-    | Digital outcomes           | Cancelled    | Yorkshire and the Humber       |
-    | User research participants | Awarded      | Northern Ireland               |
+    | Digital outcomes           | Open         | Yorkshire and the Humber       |
+    | User research participants | Closed       | Northern Ireland               |
 
 Scenario: Specialist roles are selectable for Digital specialists
   Given I am on the /digital-outcomes-and-specialists/opportunities page

--- a/features/smoke-tests/supplier/opportunities.feature
+++ b/features/smoke-tests/supplier/opportunities.feature
@@ -19,8 +19,7 @@ Scenario: User is able to navigate to opportunity detail page via selecting the 
 Scenario Outline: User can filter by individual lot
   Given I am on the /digital-outcomes-and-specialists/opportunities page
   When I note the result_count
-  And I check '<lot>' checkbox
-  And I click the 'Filter' button
+  And I click '<lot>'
   Then I see that the stated number of results does not exceed that result_count
   And I see all the opportunities on the page are on the '<lot>' lot
 
@@ -34,46 +33,43 @@ Scenario Outline: User can filter by individual status
   Given I am on the /digital-outcomes-and-specialists/opportunities page
   When I note the result_count
   And I check '<status>' checkbox
-  And I click the 'Filter' button
+  And I wait for the page to reload
   Then I see that the stated number of results does not exceed that result_count
   And I see all the opportunities on the page are of the '<status>' status
 
   Examples:
-    | status |
-    | Open   |
-    | Closed |
+    | status       |
+    | Open         |
+    | Closed       |
+    | Awarded      |
+    | Unsuccessful |
+    | Cancelled    |
 
 Scenario Outline: User can filter by both status and lot
   Given I am on the /digital-outcomes-and-specialists/opportunities page
   When I note the result_count
-  And I check '<lot>' checkbox
+  And I click '<lot>'
   And I check '<status>' checkbox
-  And I click the 'Filter' button
+  And I wait for the page to reload
   Then I see that the stated number of results does not exceed that result_count
   And I see all the opportunities on the page are on the '<lot>' lot
   And I see all the opportunities on the page are of the '<status>' status
 
   Examples:
-    | lot                        | status   |
-    | Digital specialists        | Open     |
-    | Digital outcomes           | Open     |
-    | User research participants | Open     |
-    | Digital specialists        | Closed   |
-    | Digital outcomes           | Closed   |
-    | User research participants | Closed   |
-
-Scenario: Checking all lots returns all results
-  Given I am on the /digital-outcomes-and-specialists/opportunities page
-  When I note the result_count
-  And I check all 'lot' checkboxes
-  And I click the 'Filter' button
-  Then I see that the stated number of results equals that result_count
+    | lot                        | status       |
+    | Digital specialists        | Open         |
+    | Digital outcomes           | Open         |
+    | User research participants | Open         |
+    | Digital specialists        | Closed       |
+    | Digital outcomes           | Closed       |
+    | User research participants | Closed       |
+    | Digital specialists        | Awarded      |
+    | Digital outcomes           | Unsuccessful |
+    | User research participants | Cancelled    |
 
 Scenario: Checking all statuses returns all results
   Given I am on the /digital-outcomes-and-specialists/opportunities page
   When I note the result_count
   And I check all 'status' checkboxes
-  And I click the 'Filter' button
+  And I wait for the page to reload
   Then I see that the stated number of results equals that result_count
-
-

--- a/features/smoke-tests/supplier/opportunities.feature
+++ b/features/smoke-tests/supplier/opportunities.feature
@@ -45,10 +45,27 @@ Scenario Outline: User can filter by individual status
     | Unsuccessful |
     | Cancelled    |
 
+Scenario Outline: User can filter by individual location
+  Given I am on the /digital-outcomes-and-specialists/opportunities page
+  When I note the result_count
+  And I check '<location>' checkbox
+  And I wait for the page to reload
+  Then I see that the stated number of results does not exceed that result_count
+  And I see all the opportunities on the page are in the '<location>' location
+
+  Examples:
+    | location                       |
+    | Scotland                       |
+    | International (outside the UK) |
+    | Off-site                       |
+
 Scenario Outline: User can filter by both status and lot
   Given I am on the /digital-outcomes-and-specialists/opportunities page
   When I note the result_count
   And I click '<lot>'
+  And I wait for the page to reload
+  Then I see that the stated number of results does not exceed that result_count
+  And I note the result_count
   And I check '<status>' checkbox
   And I wait for the page to reload
   Then I see that the stated number of results does not exceed that result_count

--- a/features/smoke-tests/supplier/opportunities.feature
+++ b/features/smoke-tests/supplier/opportunities.feature
@@ -1,4 +1,4 @@
-@smoke-tests @opportunities
+@smoke-tests @opportunities @skip-staging @skip-production
 Feature: Passive opportunity supplier journey
 
 Scenario: User can see the main links on the homepage

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -178,6 +178,14 @@ When /I check all '(.*)' checkboxes$/ do |checkbox_name|
   end
 end
 
+Then /I don't see a '(.*)' checkbox$/ do |checkbox_name|
+  all_fields(checkbox_name, {type: 'checkbox'}).length.should == 0
+end
+
+Then /I don't see any '(.*)' checkboxes$/ do |checkbox_fieldname|
+  page.should have_selector(:xpath, "//input[@type='checkbox'][@name='#{checkbox_fieldname}']", :count => 0)
+end
+
 When /^I enter a random value in the '(.*)' field( and click its associated '(.*)' button)?$/ do |field_name, maybe_click_statement, click_button_name|
   @fields||= {}
   @fields[field_name] = SecureRandom.hex

--- a/features/step_definitions/opportunities_steps.rb
+++ b/features/step_definitions/opportunities_steps.rb
@@ -40,6 +40,14 @@ Then (/^I see all the opportunities on the page are on the '(.*)' lot$/) do |lot
   lots_found.each { |x| x.text.should == lot }
 end
 
+Then (/^I see all the opportunities on the page are in the '(.*)' location/) do |lot|
+  locations_found = all(
+    :xpath,
+    '//*[@class="search-result"]//*[@class="search-result-important-metadata"][1]//*[@class="search-result-metadata-item"][2]'
+  )
+  locations_found.each { |x| x.text.should == lot }
+end
+
 Then (/^I see all the opportunities on the page are of the '(.*)' status$/) do |status|
   published_or_closed = all(
     :xpath,

--- a/features/step_definitions/opportunities_steps.rb
+++ b/features/step_definitions/opportunities_steps.rb
@@ -13,6 +13,7 @@ end
 
 When(/^I note the result_count$/) do
   @result_count = page.first(:css, ".search-summary-count").text.to_i
+  puts "Noted result_count: #{@result_count}"
 end
 
 Then (/^I see an opportunity in the search results$/) do
@@ -21,7 +22,9 @@ end
 
 Then (/^I see that the stated number of results does not exceed that (\w+)$/) do |variable_name|
   var = instance_variable_get("@#{variable_name}")
-  page.first(:css, ".search-summary-count").text.to_i.should <= var
+  @new_result_count = page.first(:css, ".search-summary-count").text.to_i
+  puts "Number of results: #{@new_result_count}"
+  @new_result_count.should <= var
 end
 
 Then (/^I see that the stated number of results equals that (\w+)$/) do |variable_name|
@@ -43,8 +46,8 @@ Then (/^I see all the opportunities on the page are of the '(.*)' status$/) do |
     '//*[@class="search-result"]//*[@class="search-result-metadata"][2]//*[@class="search-result-metadata-item"][1]'
   )
   published_or_closed.each do |x|
-    if status == 'Closed'
-      x.text.should == 'Closed'
+    if ['Closed', 'Unsuccessful', 'Cancelled'].include? status
+      x.text.should == status
     else
       x.text.include?("Published").should be true
     end

--- a/features/step_definitions/opportunities_steps.rb
+++ b/features/step_definitions/opportunities_steps.rb
@@ -40,20 +40,20 @@ Then (/^I see all the opportunities on the page are on the '(.*)' lot$/) do |lot
   lots_found.each { |x| x.text.should == lot }
 end
 
-Then (/^I see all the opportunities on the page are in the '(.*)' location/) do |lot|
+Then (/^I see all the opportunities on the page are in the '(.*)' location/) do |location|
   locations_found = all(
     :xpath,
     '//*[@class="search-result"]//*[@class="search-result-important-metadata"][1]//*[@class="search-result-metadata-item"][2]'
   )
-  locations_found.each { |x| x.text.should == lot }
+  locations_found.each { |x| x.text.should == location }
 end
 
-Then (/^I see all the opportunities on the page are for the '(.*)' role/) do |lot|
+Then (/^I see all the opportunities on the page are for the '(.*)' role/) do |role|
   locations_found = all(
     :xpath,
     '//*[@class="search-result"]//*[@class="search-result-metadata"][1]//*[@class="search-result-metadata-item"][2]'
   )
-  locations_found.each { |x| x.text.should == lot }
+  locations_found.each { |x| x.text.should == role }
 end
 
 Then (/^I see all the opportunities on the page are of the '(.*)' status$/) do |status|

--- a/features/step_definitions/opportunities_steps.rb
+++ b/features/step_definitions/opportunities_steps.rb
@@ -48,6 +48,14 @@ Then (/^I see all the opportunities on the page are in the '(.*)' location/) do 
   locations_found.each { |x| x.text.should == lot }
 end
 
+Then (/^I see all the opportunities on the page are for the '(.*)' role/) do |lot|
+  locations_found = all(
+    :xpath,
+    '//*[@class="search-result"]//*[@class="search-result-metadata"][1]//*[@class="search-result-metadata-item"][2]'
+  )
+  locations_found.each { |x| x.text.should == lot }
+end
+
 Then (/^I see all the opportunities on the page are of the '(.*)' status$/) do |status|
   published_or_closed = all(
     :xpath,
@@ -60,6 +68,11 @@ Then (/^I see all the opportunities on the page are of the '(.*)' status$/) do |
       x.text.include?("Published").should be true
     end
   end
+end
+
+Then (/^I see no results$/) do
+  page.first(:css, ".search-summary-count").text.to_i.should == 0
+  page.should have_selector(:css, '.search-result', :count => 0)
 end
 
 Then /^I see the details of the brief match what was published$/ do


### PR DESCRIPTION
This firstly fixes the tests to cover the changes corresponding to https://trello.com/c/KcqU7k20/101-suppliers-should-be-able-to-select-a-category-es-for-frontend and then extends them to exercise the new features.