### PR TITLE
Smoketests check that things appearing in search results actually exist

### DIFF
--- a/features/smoke-tests/buyer/catalogue.feature
+++ b/features/smoke-tests/buyer/catalogue.feature
@@ -34,6 +34,8 @@ Scenario: User is able to search by service id and have result returned.
   Then I see that service.id in the search summary text
   And I see that service.id as the value of the 'q' field
   And I see that service in the search results
+  When I click that service.serviceName
+  Then I am on that service.serviceName page
 
 Scenario: User is able to search by service name and have result returned.
   Given I am on the /g-cloud/search page
@@ -43,6 +45,8 @@ Scenario: User is able to search by service name and have result returned.
   Then I see that quoted service.serviceName in the search summary text
   And I see that quoted service.serviceName as the value of the 'q' field
   And I see that service in the search results
+  When I click that service.serviceName
+  Then I am on that service.serviceName page
 
 Scenario: User is able to navigate to service detail page via selecting the service from the search results
   Given I am on the /g-cloud/search page
@@ -59,6 +63,8 @@ Scenario: User is able to search by keywords field on the search results page to
   Then I see that service.id in the search summary text
   And I see that service.id as the value of the 'q' field
   And I see that service in the search results
+  When I click that service.serviceName
+  Then I am on that service.serviceName page
 
 Scenario: User is able to click on a random category
   Given I am on the /g-cloud page


### PR DESCRIPTION
For this A&A ticket: https://trello.com/c/OWq2L2iV/184-functional-tests-dont-check-that-things-appearing-in-search-results-actually-exist-ie-you-dont-get-a-404-when-clicking-on-the-se

Which is from this Tech Debt ticket: https://trello.com/c/gUrDOIiR/53-functional-tests-dont-check-that-things-appearing-in-search-results-actually-exist-ie-you-dont-get-a-404-when-clicking-on-the-se

Just adds extra steps to click on the search result returned and check the page reached matches the service clicked on.

### Works for me locally

![screen shot 2017-12-08 at 18 15 09](https://user-images.githubusercontent.com/6525554/33779201-d946a7ca-dc43-11e7-97c2-d4273c98fcf9.png)
