### PR TITLE
Handle ambiguous matches when multiple services have the exact same name

### DIFF
--- a/features/smoke-tests/buyer/catalogue.feature
+++ b/features/smoke-tests/buyer/catalogue.feature
@@ -34,7 +34,7 @@ Scenario: User is able to search by service id and have result returned.
   Then I see that service.id in the search summary text
   And I see that service.id as the value of the 'q' field
   And I see that service in the search results
-  When I click that service.serviceName
+  When I click a link with text that service.serviceName
   Then I am on that service.serviceName page
 
 Scenario: User is able to search by service name and have result returned.
@@ -45,7 +45,7 @@ Scenario: User is able to search by service name and have result returned.
   Then I see that quoted service.serviceName in the search summary text
   And I see that quoted service.serviceName as the value of the 'q' field
   And I see that service in the search results
-  When I click that service.serviceName
+  When I click a link with text that service.serviceName
   Then I am on that service.serviceName page
 
 Scenario: User is able to navigate to service detail page via selecting the service from the search results
@@ -63,7 +63,7 @@ Scenario: User is able to search by keywords field on the search results page to
   Then I see that service.id in the search summary text
   And I see that service.id as the value of the 'q' field
   And I see that service in the search results
-  When I click that service.serviceName
+  When I click a link with text that service.serviceName
   Then I am on that service.serviceName page
 
 Scenario: User is able to click on a random category

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -132,6 +132,10 @@ When /I click a (button|link) with class name #{MAYBE_VAR}$/ do |elem_type, butt
   page.all("." + button_link_class)[0].click
 end
 
+When /I click a link with text #{MAYBE_VAR}$/ do |link_text|
+  page.all('a', :text => link_text)[0].click
+end
+
 When /I click the (Next|Previous) Page link$/ do |next_or_previous|
   # can't use above as we have services with the word 'next' in the name :(
   klass = ''


### PR DESCRIPTION
Add new step to handle ambiguous matches when multiple services have the exact same name