### PR TITLE
Remove aliased 'I have a buyer' and 'I have a supplier' user steps to make way for new supplier step

### DIFF
--- a/features/buyer/requirements.feature
+++ b/features/buyer/requirements.feature
@@ -139,7 +139,7 @@ Scenario: Create user research participants
 
 Scenario Outline: Copy requirements
   Given I have a live digital-outcomes-and-specialists framework
-  And I have a buyer
+  And I have a buyer user
   And that buyer is logged in
   And I have a <status> digital-specialists brief
   And I click the 'View your account' link
@@ -159,7 +159,7 @@ Scenario Outline: Copy requirements
 
 Scenario Outline: View requirement in a dashboard
   Given I have a live digital-outcomes-and-specialists framework
-  And I have a buyer
+  And I have a buyer user
   And that buyer is logged in
   And I have a <status> digital-specialists brief
   When I click 'View your account'

--- a/features/public/public.feature
+++ b/features/public/public.feature
@@ -3,7 +3,7 @@ Feature: Published requirements can be viewed by the public
 
 Scenario: Public views the publish requirements. Details presented matches what was publisehd.
   Given I have a live digital-outcomes-and-specialists framework
-  And I have a buyer
+  And I have a buyer user
   And that buyer is logged in
   And I have a live digital-specialists brief
   And I click the 'Log out' button

--- a/features/step_definitions/brief_response_steps.rb
+++ b/features/step_definitions/brief_response_steps.rb
@@ -1,5 +1,5 @@
 Given /^I have a (draft|live|withdrawn) (.*) brief$/ do |status, lot_slug|
-  brief = create_brief(@framework['slug'], lot_slug, @buyer["id"])
+  brief = create_brief(@framework['slug'], lot_slug, @buyer_user["id"])
   puts "created brief with id #{brief['id']}"
   brief = publish_brief(brief['id']) unless status == "draft"
   withdraw_brief(brief['id']) if status == "withdrawn"
@@ -9,10 +9,10 @@ end
 Given /^I am logged in as the buyer of a (closed|live) brief$/ do |status|
   matched_brief = get_briefs('digital-outcomes-and-specialists-2', status).sample
   @brief = matched_brief
-  @buyer = matched_brief['users'][0]
+  @buyer_user = matched_brief['users'][0]
   @lot_slug = matched_brief['lotSlug']
   @framework_slug = matched_brief['frameworkSlug']
-  @buyer.update({'password' => ENV["DM_PRODUCTION_BUYER_USER_PASSWORD"]})
+  @buyer_user.update({'password' => ENV["DM_PRODUCTION_BUYER_USER_PASSWORD"]})
   steps %Q{
     Given that buyer is logged in
   }
@@ -23,8 +23,8 @@ Given /^I am logged in as the buyer of a closed brief with responses$/ do
   @brief = get_brief(submitted_brief_response['brief']['id'])
   @lot_slug = @brief['lotSlug']
   @framework_slug = @brief['frameworkSlug']
-  @buyer = @brief['users'][0]
-  @buyer.update({'password' => ENV["DM_PRODUCTION_BUYER_USER_PASSWORD"]})
+  @buyer_user = @brief['users'][0]
+  @buyer_user.update({'password' => ENV["DM_PRODUCTION_BUYER_USER_PASSWORD"]})
   steps %Q{
     Given that buyer is logged in
   }

--- a/features/supplier/supplier_account.feature
+++ b/features/supplier/supplier_account.feature
@@ -2,7 +2,7 @@
 Feature: Supplier can view and edit their supplier account information
 
 Background:
-  Given I have a supplier
+  Given I have a supplier user
   And that supplier is logged in
   And I am on the /suppliers page
 

--- a/features/supplier/supplier_applies_for_an_opportunity.feature
+++ b/features/supplier/supplier_applies_for_an_opportunity.feature
@@ -3,9 +3,9 @@ Feature: Supplier applies for an opportunity
 
 Background:
   Given I have a live digital-outcomes-and-specialists framework
-  And I have a buyer
+  And I have a buyer user
   And I have a live digital-specialists brief
-  And I have a supplier
+  And I have a supplier user
   And that supplier is logged in
 
 Scenario: Supplier is not eligible as they are not on the framework

--- a/features/supplier/view_and_edit_dos_services.feature
+++ b/features/supplier/view_and_edit_dos_services.feature
@@ -3,7 +3,7 @@ Feature: Supplier being able to view their DOS services
 
 Background:
   Given I have a live digital-outcomes-and-specialists framework
-  And I have a supplier
+  And I have a supplier user
   And that supplier is logged in
   And that supplier has applied to be on that framework
   And we accept that suppliers application to the framework

--- a/features/supplier/view_and_edit_g_cloud_services.feature
+++ b/features/supplier/view_and_edit_g_cloud_services.feature
@@ -3,7 +3,7 @@ Feature: G-Cloud supplier can view and edit their G-Cloud services
 
 Background:
   Given I have a live g-cloud framework with the cloud-support lot
-  And I have a supplier
+  And I have a supplier user
   And that supplier is logged in
   And that supplier has applied to be on that framework
   And we accept that suppliers application to the framework

--- a/features/supplier/withdraw_opportunity.feature
+++ b/features/supplier/withdraw_opportunity.feature
@@ -3,7 +3,7 @@ Feature: Withdraw opportunity supplier journey
 
 Scenario: See detail page for a withdrawn brief
   Given I have a live digital-outcomes-and-specialists framework
-  And I have a buyer
+  And I have a buyer user
   And I have a withdrawn digital-specialists brief
   When I go to that brief page
   Then I am on that brief.title page

--- a/features/support/api_helpers.rb
+++ b/features/support/api_helpers.rb
@@ -311,3 +311,25 @@ def create_live_service(framework_slug, lot_slug, supplier_id, role=nil)
   response.code.should be(201), response.body
   JSON.parse(response.body)['services']
 end
+
+def create_user(user_role, supplier_id=nil)
+  randomString = SecureRandom.hex
+  password = ENV["DM_PRODUCTION_#{user_role.upcase.gsub('-', '_')}_USER_PASSWORD"]
+
+  user_data = {
+    "emailAddress" => randomString + '@example.gov.uk',
+    "name" => "#{user_role.capitalize} Name #{randomString}",
+    "password" => password,
+    "role" => user_role,
+    "phoneNumber" => (SecureRandom.random_number(10000000) + 10000000000).to_s,
+  }
+
+  user_data['supplierId'] = supplier_id.to_i if user_role == 'supplier'
+
+  response = call_api(:post, "/users", payload: {users: user_data, updated_by: 'functional_tests'})
+  response.code.should be(201), response.body
+  @user = JSON.parse(response.body)["users"]
+  @user['password'] = password
+  puts "Email address: #{@user['emailAddress']}"
+  @user
+end

--- a/features/user/lock_account.feature
+++ b/features/user/lock_account.feature
@@ -2,7 +2,7 @@
 Feature: Users are locked if they enter the wrong password too many times
 
 Scenario: User has 5 failed login attempts and is locked out of their account
-  Given I have a supplier
+  Given I have a supplier user
   When The wrong password is entered 5 times for that user
   Then That user can not log in using their correct password
   # TODO: And the user is shown as 'locked' on the admin users page


### PR DESCRIPTION
We need a new `I have a supplier(? with name)` step to create an actual supplier object.
Like:
```
Given I have a supplier
 And that supplier has a user with name 'Test user 1'
 And that supplier has a user with name 'Test user 2'
 And that supplier has a user with name 'Test user 3'
```
These aliased names make the tests harder to understand because they don't describe what we're doing properly. A supplier needs to exist before a user object because a supplier can have multiple users.

The aliases also meant more digging through the code for what was actually going on. 