### PR TITLE
catalogue smoke tests: add test of no-results search term

### DIFF
--- a/features/smoke-tests/buyer/catalogue.feature
+++ b/features/smoke-tests/buyer/catalogue.feature
@@ -102,3 +102,10 @@ Scenario: User is able to paginate through search results and all of the navigat
   When I click the Previous Page link
   Then I am taken to page 1 of results
   And I see the same number of category links as noted
+
+Scenario: User gets no results for an unfindable term
+  Given I am on the /g-cloud/search page
+  And I enter 'metempsychosis' in the 'q' field
+  And I wait for the page to reload
+  Then I don't see a search result
+  And I see 'metempsychosis' in the search summary text

--- a/features/step_definitions/catalogue_steps.rb
+++ b/features/step_definitions/catalogue_steps.rb
@@ -14,8 +14,12 @@ When(/^I click a random result in the list of service results returned$/) do
   a_elem.click
 end
 
-Then (/^I see a search result$/) do
-  page.should have_selector(:css, "div.search-result")
+Then (/^I (don't )?see a search result$/) do |negate|
+  if negate then
+    page.should_not have_selector(:css, "div.search-result")
+  else
+    page.should have_selector(:css, "div.search-result")
+  end
 end
 
 Then (/^I see that service in the search results$/) do


### PR DESCRIPTION
An app got pushed out which broke no-results pages of g9 search and the first we heard of it was production 500s appearing. This should make sure we catch that kind of thing earlier.