### PR TITLE
Service documents require a valid file extension

### DIFF
--- a/features/support/fixtures.rb
+++ b/features/support/fixtures.rb
@@ -258,7 +258,7 @@ module Fixtures
       priceMax: "700",
       priceMin: "200",
       priceUnit: "Person",
-      pricingDocumentURL: "https://assets.digitalmarketplace.service.gov.uk/g-cloud-9/documents/",
+      pricingDocumentURL: "https://assets.digitalmarketplace.service.gov.uk/g-cloud-9/documents/test.pdf",
       QAAndTesting: false,
       resellingType: "not_reseller",
       securityTesting: false,
@@ -267,17 +267,17 @@ module Fixtures
           "Benefit 2"
       ],
       serviceConstraints: "None",
-      serviceDefinitionDocumentURL: "https://assets.digitalmarketplace.service.gov.uk/g-cloud-9/documents/",
+      serviceDefinitionDocumentURL: "https://assets.digitalmarketplace.service.gov.uk/g-cloud-9/documents/test.pdf",
       serviceDescription: "Deliver digital transformation by the bucketload!",
       serviceFeatures: [
           "Feature 1"
       ],
       serviceName: "Test cloud support service",
       setupAndMigrationService: false,
-      sfiaRateDocumentURL: "https://assets.digitalmarketplace.service.gov.uk/g-cloud-9/documents/",
+      sfiaRateDocumentURL: "https://assets.digitalmarketplace.service.gov.uk/g-cloud-9/documents/test.pdf",
       staffSecurityClearanceChecks: "staff_screening_not_bs7858_2012",
       supportLevels: "None",
-      termsAndConditionsDocumentURL: "https://assets.digitalmarketplace.service.gov.uk/g-cloud-9/documents/",
+      termsAndConditionsDocumentURL: "https://assets.digitalmarketplace.service.gov.uk/g-cloud-9/documents/test.pdf",
       training: false,
       webChatSupport: "no",
     }


### PR DESCRIPTION
Some G Cloud services on preview/staging were giving 500 errors. This was because of bad test data in the document URLs (the document files need a valid file extension, e.g. `.pdf` so that the appropriate icon can be displayed on the service page). 

This PR fixes the `fooDocumentURL` fields on the service fixture.

Resetting the preview data to a recent DB dump should fix the existing data.