### PR TITLE
default.nix: phantomjs -> phantomjs2

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -21,7 +21,7 @@ in (with args; {
         pkgs.bundler
         pkgs.bundix
         pkgs.libxml2
-        pkgs.phantomjs
+        pkgs.phantomjs2
       ];
 
       # if we don't have this, we get unicode troubles in a --pure nix-shell


### PR DESCRIPTION
recent changes in cloudfrount's tls setup would appear to have broken
operation with phantomjs 1.9.8