### PR TITLE
use bilaterally normalize-space()'ed text when looking for links

### DIFF
--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -133,7 +133,7 @@ When /I click a (button|link) with class name #{MAYBE_VAR}$/ do |elem_type, butt
 end
 
 When /I click a link with text #{MAYBE_VAR}$/ do |link_text|
-  page.all('a', :text => link_text)[0].click
+  page.find(:xpath, "//a[normalize-space(string())=normalize-space(#{escape_xpath(link_text)})]").click
 end
 
 When /I click the (Next|Previous) Page link$/ do |next_or_previous|

--- a/features/support/helpers.rb
+++ b/features/support/helpers.rb
@@ -109,3 +109,15 @@ RSpec::Matchers.define :include_url do |expected|
     actual_list.map {|actual| urls_are_equal(actual, expected)}.include?(true)
   end
 end
+
+# from https://github.com/ilyakatz/capybara/blob/c0844c8cf43801fa1d88e502b71b8e75ed6da017/lib/capybara/xpath.rb#L8
+def escape_xpath(string)
+  if string.include?("'")
+    string = string.split("'", -1).map do |substr|
+      "'#{substr}'"
+    end.join(%q{,"'",})
+    "concat(#{string})"
+  else
+    "'#{string}'"
+  end
+end


### PR DESCRIPTION
This fixes e.g. the catalogue smoke test when a service with a `serviceName`
containing a double-space is chosen. also include an `escape_xpath`
implementation cribbed from the interwebs which we should make more use of.

The fact that this normalization is needed has an interesting implication: capybara is operating on the post-html-normalized body text?