### PR TITLE
Update step to bring inline with newer definition

### DIFF
--- a/features/buyer/buyer_dashboard.feature
+++ b/features/buyer/buyer_dashboard.feature
@@ -9,7 +9,7 @@ Scenario: Users should see new Dashboard
 
 Scenario: Users should see link when there are searches available to view
   Given I am logged in as a buyer user
-  And I have created and saved a search
+  And I have created and saved a search called 'my cloud project'
   And I am on the /buyers page
   Then I see the 'View your saved searches' link
 


### PR DESCRIPTION
This step definition was updated but not all the steps were updated. This step was undefined but still passing. See:
https://github.com/alphagov/digitalmarketplace-functional-tests/pull/455