### PR TITLE
catalogue/opportunity search tests: also check presence and connectivity of aria-live regions

### DIFF
--- a/features/smoke-tests/buyer/catalogue.feature
+++ b/features/smoke-tests/buyer/catalogue.feature
@@ -84,11 +84,14 @@ Scenario: User is able to click on several random filters
   And I have a random g-cloud lot from the API
   And I click that lot.name
   Then I am on the 'Search results' page
-  And I note the number of search results
-  Then I select several random filters
+  When I note the number of search results
+  Then a filter checkbox's associated aria-live region contains that result_count
+  When I select several random filters
   And I wait for the page to reload
   Then I am on the 'Search results' page
   And I see fewer search results than noted
+  When I note the number of search results
+  Then a filter checkbox's associated aria-live region contains that result_count
 
 Scenario: User is able to paginate through search results and all of the navigation is preserved
   Given I am on the /g-cloud page

--- a/features/step_definitions/catalogue_steps.rb
+++ b/features/step_definitions/catalogue_steps.rb
@@ -47,18 +47,20 @@ Then(/^I see #{MAYBE_VAR} in the search summary text$/) do |value|
 end
 
 Then (/^I note the number of search results$/) do
-  @service_count = CatalogueHelpers.get_service_count(page)
+  @result_count = CatalogueHelpers.get_service_count(page)
+  puts "Noted result_count: #{@result_count}"
 end
 
 Then /^I click a random category link$/ do
   links = CatalogueHelpers.get_category_links(page)
   link_el = links.sample
   @category_name = link_el.text.sub(/ \([0-9]*\)/, "")  # remove service count
+  puts "Clicking '#{link_el.text}'"
   link_el.click
 end
 
 Then(/^I see fewer search results than noted$/) do
-  expect(CatalogueHelpers.get_service_count(page)).to be < @service_count
+  expect(CatalogueHelpers.get_service_count(page)).to be < @result_count
 end
 
 Then(/^I select several random filters$/) do
@@ -67,6 +69,7 @@ end
 
 Then(/^I note the number of category links$/) do
   @category_link_count = CatalogueHelpers.get_category_links(page).length
+  puts "Noted category_link_count: #{@category_link_count}"
 end
 
 Then(/^I am taken to page (\d+) of results$/) do |page_number|

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -396,3 +396,9 @@ end
 Then(/^I should get a download file of type '(.*)'$/) do |file_type|
   expect(page.response_headers['Content-Disposition']).to match( "attachment;filename=\\S*\\." + file_type )
 end
+
+Then(/^a filter checkbox's associated aria-live region contains #{MAYBE_VAR}$/) do |value|
+  page.find_by_id(
+    page.all(:xpath, "//div[contains(@class, 'govuk-option-select')]//input[@type='checkbox']").sample["aria-controls"]
+  ).text.should include(value.to_s)
+end

--- a/features/supplier/opportunities.feature
+++ b/features/supplier/opportunities.feature
@@ -41,11 +41,14 @@ Scenario: Specialist roles are selectable for Digital specialists
   And I don't see any 'specialistRole' checkboxes
   When I click 'Digital specialists'
   And I note the result_count
-  And I check 'Designer' checkbox
+  Then a filter checkbox's associated aria-live region contains that result_count
+  When I check 'Designer' checkbox
   And I wait for the page to reload
   Then I see that the stated number of results does not exceed that result_count
   And I see all the opportunities on the page are on the 'Digital specialists' lot
   And I see all the opportunities on the page are for the 'Designer' role
+  When I note the result_count
+  Then a filter checkbox's associated aria-live region contains that result_count
 
 Scenario Outline: Specialist roles are not selectable for non-Digital specialists lots
   Given I am on the /digital-outcomes-and-specialists/opportunities page


### PR DESCRIPTION
Also take the chance to unify some functionality between service & brief search, add some useful verbosity to the execution.

See https://trello.com/c/qUViIfu9/172-dynamic-content-on-the-search-pages-which-updates-without-a-page-reload-is-marked-up-using-wai-aria-live-regions and https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/705