### PR TITLE
Add customisable content for the continue/save button

### DIFF
--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -296,11 +296,12 @@ When /I click the summary table '(.*)' (link|button) for '(.*)'$/ do |link_name,
   edit_link.click
 end
 
-When /I update the value of '(.*)' to '(.*)' using the summary table '(.*)' link/ do |field_to_edit, new_value, link_name|
+When /I update the value of '(.*)' to '(.*)' using the summary table '(.*)' link(?: and the '(.*)' button)?/ do |field_to_edit, new_value, link_name, button_name|
   summary_page = current_url
+  button_name ||= "Continue"
 
   step "I click the summary table '#{link_name}' link for '#{field_to_edit}'"
-  step "I enter '#{new_value}' in the '#{field_to_edit}' field and click its associated 'Continue' button"
+  step "I enter '#{new_value}' in the '#{field_to_edit}' field and click its associated '#{button_name}' button"
 
   page.visit(summary_page)
 end

--- a/features/supplier/supplier_creation.feature
+++ b/features/supplier/supplier_creation.feature
@@ -43,7 +43,7 @@ Scenario: User steps through supplier account creation process
     | field                  | value                        |
     | Email address          | test.supplier.email@test.com |
 
-  When I update the value of 'DUNS number' to '000000002' using the summary table 'Edit' link
+  When I update the value of 'DUNS number' to '000000002' using the summary table 'Edit' link and the 'Save and continue' button
   And I update the value of 'Company name' to 'Changed test company name' using the summary table 'Edit' link
   And I update the value of 'Contact name' to 'Changed contact name' using the summary table 'Edit' link
   And I update the value of 'Contact email' to 'test.changed.email@test.com' using the summary table 'Edit' link


### PR DESCRIPTION
## Summary
We've updated the content for the button on the DUNS number page, but our currently functional tests only expect to see 'Continue'. Have added the ability to customise this button text per step.