### PR TITLE
Award flow: Use submit button name instead of value

### DIFF
--- a/features/buyer/award_flow_requirements.feature
+++ b/features/buyer/award_flow_requirements.feature
@@ -28,7 +28,7 @@ Scenario: Award flow - Award a requirement to a winning supplier
   And I enter '1' in the 'input-awardedContractStartDate-month' field
   And I enter '2020' in the 'input-awardedContractStartDate-year' field
   And I enter '20000.00' in the 'input-awardedContractValue' field
-  And I click the 'Submit' button
+  And I click the 'submit' button
   Then I see a success banner message containing 'updated'
 
   When I go to that brief overview page


### PR DESCRIPTION
Trello: https://trello.com/c/AFg4WfRP/334-let-buyers-know-that-suppliers-will-be-alerted-when-they-update-the-award-status

The wording on the button has changed as part of https://github.com/alphagov/digitalmarketplace-briefs-frontend/pull/79 - using the element name should allow this to pass on preview and staging (it works locally for both master and the new branch).