### PR TITLE
Use Notify test email address

### DIFF
--- a/features/admin/invite_admin_user.feature
+++ b/features/admin/invite_admin_user.feature
@@ -5,10 +5,10 @@ Scenario Outline: Admin Manager user can log in and invite admin users
   Given I am logged in as the production <role> user
   And I click the 'View and edit admin accounts' link
   And I click the 'Invite user' link
-  When I enter 'functional-test@user.marketplace.team' in the 'Email address' field
+  When I enter 'simulate-delivered@notifications.service.gov.uk' in the 'Email address' field
   And I choose the 'Manage services' radio button
   And I click the 'Invite user' button
-  Then I see a success banner message containing 'An invitation has been sent to functional-test@user.marketplace.team.'
+  Then I see a success banner message containing 'An invitation has been sent to simulate-delivered@notifications.service.gov.uk.'
 
   Examples:
     | role          |


### PR DESCRIPTION
In our Notify dashboard most failed deliveries listed are for functional-test@user.marketplace.team.

It's better to use the email address they have specifically for this exact purpose (see https://www.notifications.service.gov.uk/integration-testing), rather than pollute our stats and make it hard for us to find genuine failed emails.