### PR TITLE
Update DOS search results output

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,3 +16,7 @@ gem "rest-client"
 gem "rspec"
 gem "selenium-webdriver"
 gem "test-unit"
+
+group :test, :development do
+  gem "pry"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,6 +16,7 @@ GEM
     childprocess (0.5.9)
       ffi (~> 1.0, >= 1.0.11)
     cliver (0.3.2)
+    coderay (1.1.2)
     cucumber (2.4.0)
       builder (>= 2.1.2)
       cucumber-core (~> 1.5.0)
@@ -38,6 +39,7 @@ GEM
     jwt (1.5.6)
     launchy (2.4.3)
       addressable (~> 2.3)
+    method_source (0.9.0)
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
@@ -58,6 +60,9 @@ GEM
       cliver (~> 0.3.1)
       websocket-driver (>= 0.2.0)
     power_assert (0.3.1)
+    pry (0.11.3)
+      coderay (~> 1.1.0)
+      method_source (~> 0.9.0)
     rack (2.0.1)
     rack-test (0.6.3)
       rack (>= 1.0)
@@ -113,6 +118,7 @@ DEPENDENCIES
   parallel_tests
   phantomjs
   poltergeist
+  pry
   rake
   report_builder
   rest-client

--- a/features/step_definitions/opportunities_steps.rb
+++ b/features/step_definitions/opportunities_steps.rb
@@ -63,8 +63,8 @@ Then (/^I see all the opportunities on the page are of the '(.*)' status$/) do |
     '//*[@class="search-result"]//*[@class="search-result-metadata"][2]//*[@class="search-result-metadata-item"][1]'
   )
   published_or_closed.each do |x|
-    if ['Closed', 'Unsuccessful', 'Cancelled'].include? status
-      x.text.should == status
+    if ['Awarded', 'Closed', 'Unsuccessful', 'Cancelled'].include? status
+      x.text.should == outcome(status)
     else
       x.text.include?("Published").should be true
     end

--- a/features/support/helpers.rb
+++ b/features/support/helpers.rb
@@ -13,8 +13,19 @@ LOTS = {
   SCS: 'Specialist Cloud Services'
 }
 
+OUTCOMES = {
+  'Awarded' => 'awarded',
+  'Cancelled' => 'cancelled',
+  'Closed' => 'awaiting outcome',
+  'Unsuccessful' => 'no suitable suppliers'
+}
+
 def full_lot(lot)
   LOTS[lot.to_sym]
+end
+
+def outcome(status)
+  "Closed: #{OUTCOMES[status]}"
 end
 
 def normalize_whitespace(text)


### PR DESCRIPTION
We now output more detail in the DOS search results with regard to the
status of an award.

See alphagov/digitalmarketplace-buyer-frontend#723

Also added `pry` gem for debugging.

https://trello.com/c/y59qiKOl/335-show-award-status-in-dos-search-results