### PR TITLE
Clear session cookies before logging in a user

### DIFF
--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -1,3 +1,7 @@
 Before('@smoke-tests') do
   @SMOKE_TESTS = true
 end
+
+Before do
+  Capybara.reset_sessions!
+end


### PR DESCRIPTION
Trello: https://trello.com/c/PZyZdMtG/337-custom-dimension-to-capture-size-of-supplier

This will hopefully avoid Google Analytics linking separate users from different tests (and thus overwriting any custom dimensions they set and producing weird results in the GA dashboard).

I'm not sure if `login_steps.rb` is the best place for this - ideally we'd reset the session after every scenario rather than just before the login step. Where would we put a `teardown` equivalent?