### PR TITLE
Update DOS search results steps to show award status details

### DIFF
--- a/features/step_definitions/opportunities_steps.rb
+++ b/features/step_definitions/opportunities_steps.rb
@@ -63,6 +63,21 @@ Then (/^I see all the opportunities on the page are of the '(.*)' status$/) do |
     '//*[@class="search-result"]//*[@class="search-result-metadata"][2]//*[@class="search-result-metadata-item"][1]'
   )
   published_or_closed.each do |x|
+    if closed_outcome?(status)
+      expect(x.text).to satisfy { |text| closed_outcome_status?(text) }
+    else
+      expect(x.text).to include("Published")
+    end
+  end
+end
+
+# TO REMOVE
+Then (/^I see all the opportunities on the page are of the '(.*)' less detailed status$/) do |status|
+  published_or_closed = all(
+    :xpath,
+    '//*[@class="search-result"]//*[@class="search-result-metadata"][2]//*[@class="search-result-metadata-item"][1]'
+  )
+  published_or_closed.each do |x|
     if ['Closed', 'Unsuccessful', 'Cancelled'].include? status
       x.text.should == status
     else

--- a/features/step_definitions/opportunities_steps.rb
+++ b/features/step_definitions/opportunities_steps.rb
@@ -2,7 +2,7 @@ When(/^I click a random result in the list of opportunity results returned$/) do
   search_results = all(:xpath, "//*[@class='search-result']")
   selected_result = search_results[rand(search_results.length)]
 
-  @result = @result || Hash.new
+  @result ||= Hash.new
 
   a_elem = selected_result.first(:xpath, ".//h2[@class='search-result-title']/a")
   @result['title'] = a_elem.text
@@ -17,7 +17,7 @@ When(/^I note the result_count$/) do
 end
 
 Then (/^I see an opportunity in the search results$/) do
-  page.should have_selector(:css, ".search-result")
+  expect(page).to have_selector(:css, ".search-result")
 end
 
 Then (/^I see that the stated number of results (does not exceed|equals|is no fewer than) that (\w+)$/) do |comparison_string, variable_name|
@@ -25,44 +25,28 @@ Then (/^I see that the stated number of results (does not exceed|equals|is no fe
   @new_result_count = page.first(:css, ".search-summary-count").text.to_i
   puts "Number of results: #{@new_result_count}"
   if comparison_string == "does not exceed"
-    @new_result_count.should <= var_val
+    expect(@new_result_count).to be <= var_val
   elsif comparison_string == "equals"
-    @new_result_count.should == var_val
+    expect(@new_result_count).to eq(var_val)
   elsif comparison_string == "is no fewer than"
-    @new_result_count.should >= var_val
+    expect(@new_result_count).to be >= var_val
   end
 end
 
 Then (/^I see all the opportunities on the page are on the '(.*)' lot$/) do |lot|
-  lots_found = all(
-    :xpath,
-    '//*[@class="search-result"]//*[@class="search-result-metadata"][1]//*[@class="search-result-metadata-item"][1]'
-  )
-  lots_found.each { |x| x.text.should == lot }
+  search_result_metadata_items(:lot).each { |x| expect(x.text).to eq(lot) }
 end
 
 Then (/^I see all the opportunities on the page are in the '(.*)' location/) do |location|
-  locations_found = all(
-    :xpath,
-    '//*[@class="search-result"]//*[@class="search-result-important-metadata"][1]//*[@class="search-result-metadata-item"][2]'
-  )
-  locations_found.each { |x| x.text.should == location }
+  search_result_metadata_items(:location).each { |x| expect(x.text).to eq(location) }
 end
 
 Then (/^I see all the opportunities on the page are for the '(.*)' role/) do |role|
-  locations_found = all(
-    :xpath,
-    '//*[@class="search-result"]//*[@class="search-result-metadata"][1]//*[@class="search-result-metadata-item"][2]'
-  )
-  locations_found.each { |x| x.text.should == role }
+  search_result_metadata_items(:role).each { |x| expect(x.text).to eq(role) }
 end
 
 Then (/^I see all the opportunities on the page are of the '(.*)' status$/) do |status|
-  published_or_closed = all(
-    :xpath,
-    '//*[@class="search-result"]//*[@class="search-result-metadata"][2]//*[@class="search-result-metadata-item"][1]'
-  )
-  published_or_closed.each do |x|
+  search_result_metadata_items(:status).each do |x|
     if closed_outcome?(status)
       expect(x.text).to satisfy { |text| closed_outcome_status?(text) }
     else
@@ -87,8 +71,8 @@ Then (/^I see all the opportunities on the page are of the '(.*)' less detailed 
 end
 
 Then (/^I see no results$/) do
-  page.first(:css, ".search-summary-count").text.to_i.should == 0
-  page.should have_selector(:css, '.search-result', :count => 0)
+  expect(page.first(:css, ".search-summary-count").text.to_i).to eq(0)
+  expect(page).to have_selector(:css, '.search-result', :count => 0)
 end
 
 Then /^I see the details of the brief match what was published$/ do

--- a/features/supplier/opportunities.feature
+++ b/features/supplier/opportunities.feature
@@ -1,6 +1,22 @@
 @opportunities
 Feature: Supplier viewing and filtering DOS opportunities - extension of smoke tests
 
+# TO REMOVE
+@skip-preview
+Scenario Outline: User can filter by individual status
+  Given I am on the /digital-outcomes-and-specialists/opportunities page
+  When I note the result_count
+  And I check '<status>' checkbox
+  And I wait for the page to reload
+  Then I see that the stated number of results does not exceed that result_count
+  And I see all the opportunities on the page are of the '<status>' less detailed status
+
+  Examples:
+    | status       |
+    | Open         |
+    | Closed       |
+
+@skip-staging
 Scenario Outline: User can filter by individual status
   Given I am on the /digital-outcomes-and-specialists/opportunities page
   When I note the result_count
@@ -83,6 +99,69 @@ Scenario Outline: User gets no results for impossible combinations of location a
     | Digital outcomes           | International (outside the UK) |
     | User research participants | Off-site                       |
 
+# TO REMOVE
+@skip-preview
+Scenario Outline: User can filter by status, lot, location and keyword together
+  Given I am on the /digital-outcomes-and-specialists/opportunities page
+  When I note the result_count
+  And I click '<lot>'
+  Then I see that the stated number of results does not exceed that result_count
+  And I note the result_count
+  When I check '<status>' checkbox
+  And I wait for the page to reload
+  Then I see that the stated number of results does not exceed that result_count
+  And I note the result_count
+  And I see all the opportunities on the page are on the '<lot>' lot
+  And I see all the opportunities on the page are of the '<status>' less detailed status
+  When I check '<location>' checkbox
+  And I wait for the page to reload
+  Then I see that the stated number of results does not exceed that result_count
+  And I note the result_count
+  And I see all the opportunities on the page are on the '<lot>' lot
+  And I see all the opportunities on the page are of the '<status>' less detailed status
+  And I see all the opportunities on the page are in the '<location>' location
+  When I enter '<phrase>' in the 'q' field
+  And I wait for the page to reload
+  Then I see '<phrase>' in the search summary text
+  And I see that the stated number of results does not exceed that result_count
+  And I note the result_count
+  And I see all the opportunities on the page are on the '<lot>' lot
+  And I see all the opportunities on the page are of the '<status>' less detailed status
+  And I see all the opportunities on the page are in the '<location>' location
+  # now we remove filters in a different order to test different combinations
+  When I uncheck '<status>' checkbox
+  And I wait for the page to reload
+  Then I see '<phrase>' in the search summary text
+  And I see that the stated number of results is no fewer than that result_count
+  And I note the result_count
+  And I see all the opportunities on the page are on the '<lot>' lot
+  And I see all the opportunities on the page are in the '<location>' location
+  When I click 'All categories'
+  Then I see '<phrase>' in the search summary text
+  And I see that the stated number of results is no fewer than that result_count
+  And I note the result_count
+  And I see all the opportunities on the page are in the '<location>' location
+  When I uncheck '<location>' checkbox
+  And I wait for the page to reload
+  Then I see '<phrase>' in the search summary text
+  And I see that the stated number of results is no fewer than that result_count
+
+  Examples:
+    | lot                        | status       | location                       | phrase              |
+    | Digital specialists        | Open         | Scotland                       | governments         |
+    | Digital outcomes           | Open         | International (outside the UK) | digital             |
+    | User research participants | Open         | Off-site                       | services            |
+    | Digital specialists        | Closed       | South West England             | enterprise software |
+    | Digital outcomes           | Closed       | International (outside the UK) | delivery            |
+    | User research participants | Closed       | Off-site                       | "agile methodology" |
+    | Digital specialists        | Open         | London                         | improve             |
+    | Digital outcomes           | Closed       | International (outside the UK) | performance         |
+    | User research participants | Open         | Off-site                       | analyze             |
+    | Digital specialists        | Closed       | Wales                          | management          |
+    | Digital outcomes           | Open         | Yorkshire and the Humber       | national            |
+    | User research participants | Closed       | Northern Ireland               | metempsychosis      |
+
+@skip-staging
 Scenario Outline: User can filter by status, lot, location and keyword together
   Given I am on the /digital-outcomes-and-specialists/opportunities page
   When I note the result_count

--- a/features/support/helpers.rb
+++ b/features/support/helpers.rb
@@ -11,7 +11,14 @@ LOTS = {
   PaaS: 'Platform as a Service',
   IaaS: 'Infrastructure as a Service',
   SCS: 'Specialist Cloud Services'
-}
+}.freeze
+
+META_DATA_XPATHS = {
+  location: '//*[@class="search-result"]//*[@class="search-result-important-metadata"][1]//*[@class="search-result-metadata-item"][2]',
+  lot: '//*[@class="search-result"]//*[@class="search-result-metadata"][1]//*[@class="search-result-metadata-item"][1]',
+  role: '//*[@class="search-result"]//*[@class="search-result-metadata"][1]//*[@class="search-result-metadata-item"][2]',
+  status: '//*[@class="search-result"]//*[@class="search-result-metadata"][2]//*[@class="search-result-metadata-item"][1]'
+}.freeze
 
 CLOSED_OUTCOMES = {
   Awarded: 'Closed: awarded',
@@ -22,6 +29,10 @@ CLOSED_OUTCOMES = {
 
 def full_lot(lot)
   LOTS[lot.to_sym]
+end
+
+def search_result_metadata_items(type)
+  all(:xpath, META_DATA_XPATHS[type])
 end
 
 def closed_outcome?(status)

--- a/features/support/helpers.rb
+++ b/features/support/helpers.rb
@@ -13,8 +13,23 @@ LOTS = {
   SCS: 'Specialist Cloud Services'
 }
 
+CLOSED_OUTCOMES = {
+  Awarded: 'Closed: awarded',
+  Cancelled: 'Closed: cancelled',
+  Closed: 'Closed: awaiting outcome',
+  Unsuccessful: 'Closed: no suitable suppliers'
+}.freeze
+
 def full_lot(lot)
   LOTS[lot.to_sym]
+end
+
+def closed_outcome?(status)
+  CLOSED_OUTCOMES.key?(status.to_sym)
+end
+
+def closed_outcome_status?(text)
+  CLOSED_OUTCOMES.value?(text)
 end
 
 def normalize_whitespace(text)


### PR DESCRIPTION
We now output more detail in the DOS search results with regard to the status of an award.

This PR re-reverts alphagov/digitalmarketplace-functional-tests#477

Also refactor the opportunity steps a little bit.

Related to: https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/732

https://trello.com/c/y59qiKOl/335-show-award-status-in-dos-search-results

