### PR TITLE
Extend supplier_account flow for new details editing flow

### DIFF
--- a/features/supplier/supplier_account.feature
+++ b/features/supplier/supplier_account.feature
@@ -7,9 +7,10 @@ Background:
   And I am on the /suppliers page
 
 @skip-staging
-Scenario: Supplier user can edit supplier information
+Scenario: Supplier user can provide and change supplier details before confirming them for framework applications
   When I click 'Supplier details'
   Then I am on the 'Company details' page
+  And I don't see the 'Save and confirm' button
 
   When I click 'Change'
   And I enter 'New name' in the 'Contact name' field
@@ -24,6 +25,166 @@ Scenario: Supplier user can edit supplier information
     | Contact phone number      | 12345678                        |
     | Summary                   | All fresh                       |
 
+  When I click the summary table 'Answer required' link for 'Registered company name'
+  Then I am on the 'Registered company name' page
+  And I enter 'Toys "ᴙ" Us' in the 'Registered company name' field and click its associated 'Save and return' button
+
+  Then I click the summary table 'Answer required' link for 'Registered company address'
+  And I am on the 'What is your registered office address?' page
+  And I enter '101 Toys Street' in the 'Building and street' field
+  And I enter 'Toytown' in the 'Town or city' field
+  And I enter 'T0 YSZ' in the 'Postcode' field
+  And I enter 'United Kingdom' in the 'location-autocomplete' field and click its associated 'Save and return' button
+
+  Then I click the summary table 'Answer required' link for 'Registration number'
+  And I am on the 'Are you registered with Companies House?' page
+  And I choose 'Yes' radio button
+  And I enter '18092231' in the 'companies_house_number' field and click its associated 'Save and return' button
+
+  Then I click the summary table 'Answer required' link for 'Trading status'
+  And I am on the 'What’s your trading status?' page
+  And I choose 'limited company (LTD)' radio button
+  And I click 'Save and return'
+
+  Then I click the summary table 'Answer required' link for 'Company size'
+  And I am on the 'What size is your organisation?' page
+  And I choose 'Large' radio button
+  And I click 'Save and return'
+
+  Then I click the summary table 'Answer required' link for 'VAT number'
+  And I am on the 'Are you registered for VAT?' page
+  And I choose 'Yes' radio button
+  And I enter '410802502' in the 'vat_number' field and click its associated 'Save and return' button
+
+  # Not checking DUNS number here, as the value is random
+  Then I see the 'Registration information' summary table filled with:
+    | field                     |  value                                        |
+    | Registered company name   | Toys "ᴙ" Us                                   |
+    | Registered company address| 101 Toys Street Toytown T0 YSZ United Kingdom |
+    | Registration number       | 18092231                                      |
+    | Trading status            | Limited company (LTD)                         |
+    | Company size              | Large                                         |
+    | VAT number                | 410802502                                     |
+
+  # Can pull the dunsNumber from the supplier and use it with this step
+  And I see 'that supplier.dunsNumber' text on the page
+
+  # This button should only appear once all details are filled in.
+  And I see the 'Save and confirm' button
+
+  When I click the summary table 'Change' link for 'Registered company name'
+  Then I am on the 'Registered company name' page
+  And I enter 'Toys "ᴙ" Not Us' in the 'Registered company name' field and click its associated 'Save and return' button
+
+  Then I click the summary table 'Change' link for 'Registered company address'
+  And I am on the 'What is your registered office address?' page
+  And I enter '101 Liquidation Street' in the 'Building and street' field
+  And I enter 'Shutdown' in the 'Town or city' field
+  And I enter 'N0 TOY' in the 'Postcode' field
+  And I enter 'France' in the 'location-autocomplete' field and click its associated 'Save and return' button
+
+  Then I click the summary table 'Change' link for 'Registration number'
+  And I am on the 'Are you registered with Companies House?' page
+  And I choose 'Yes' radio button
+  And I enter '18092232' in the 'companies_house_number' field and click its associated 'Save and return' button
+
+  Then I click the summary table 'Change' link for 'Trading status'
+  And I am on the 'What’s your trading status?' page
+  And I choose 'other' radio button
+  And I click 'Save and return'
+
+  Then I click the summary table 'Change' link for 'Company size'
+  And I am on the 'What size is your organisation?' page
+  And I choose 'Micro' radio button
+  And I click 'Save and return'
+
+  Then I click the summary table 'Change' link for 'VAT number'
+  And I am on the 'Are you registered for VAT?' page
+  And I choose 'No' radio button
+  And I click 'Save and return'
+
+  # Duns number is never editable
+  Then I click the summary table 'Change' link for 'DUNS number'
+  And I am on the 'Change your DUNS number' page
+  And I see 'Contact cloud_digital@crowncommercial.gov.uk to make changes to your:' text on the pages
+  And I don't see the 'Save and continue' button
+  And I click the 'Return to company details' link
+
+  # Not checking DUNS number here, as the value is random
+  Then I see the 'Registration information' summary table filled with:
+    | field                     |  value                                                |
+    | Registered company name   | Toys "ᴙ" Not Us                                       |
+    | Registered company address| 101 Liquidation Street Shutdown N0 TOY France         |
+    | Registration number       | 18092232                                              |
+    | Trading status            | Other                                                 |
+    | Company size              | Micro                                                 |
+    | VAT number                | Not VAT registered                                    |
+
+  # Can pull the dunsNumber from the supplier and use it with this step
+  And I see 'that supplier.dunsNumber' text on the page
+
+  # Confirming company details should redirect you back to the company details page if not currently applying to a
+  # framework
+  When I click the 'Save and confirm' button
+  Then I am on the 'Company details' page
+  And I don't see the 'Save and confirm' button
+
+  # Certain fields can't be changed after supplier details have been confirmed
+  When I click the summary table 'Change' link for 'Registered company name'
+  Then I am on the 'Change your registered company name' page
+  And I see 'Contact cloud_digital@crowncommercial.gov.uk to make changes to your:' text on the pages
+  And I don't see the 'Save and continue' button
+  Then I click the 'Return to company details' link
+
+  Then I click the summary table 'Change' link for 'Registration number'
+  Then I am on the 'Change your registration number' page
+  And I see 'Contact cloud_digital@crowncommercial.gov.uk to make changes to your:' text on the pages
+  And I don't see the 'Save and continue' button
+  Then I click the 'Return to company details' link
+
+  Then I click the summary table 'Change' link for 'VAT number'
+  Then I am on the 'Change your VAT number' page
+  And I see 'Contact cloud_digital@crowncommercial.gov.uk to make changes to your:' text on the pages
+  And I don't see the 'Save and continue' button
+  Then I click the 'Return to company details' link
+
+  Then I click the summary table 'Change' link for 'DUNS number'
+  Then I am on the 'Change your DUNS number' page
+  And I see 'Contact cloud_digital@crowncommercial.gov.uk to make changes to your:' text on the pages
+  And I don't see the 'Save and continue' button
+  Then I click the 'Return to company details' link
+
+  # Other fields can still be changed after supplier details have been confirmed
+  Then I click the summary table 'Change' link for 'Registered company address'
+  And I am on the 'What is your registered office address?' page
+  And I enter '188-196 Regent Street' in the 'Building and street' field
+  And I enter 'London' in the 'Town or city' field
+  And I enter 'W1B 5BT' in the 'Postcode' field
+  And I enter 'United Kingdom' in the 'location-autocomplete' field and click its associated 'Save and return' button
+
+  Then I click the summary table 'Change' link for 'Trading status'
+  And I am on the 'What’s your trading status?' page
+  And I choose 'public limited company (PLC)' radio button
+  And I click 'Save and return'
+
+  Then I click the summary table 'Change' link for 'Company size'
+  And I am on the 'What size is your organisation?' page
+  And I choose 'Large' radio button
+  And I click 'Save and return'
+  Then I am on the 'Company details' page
+
+  # Not checking DUNS number here, as the value is random
+  Then I see the 'Registration information' summary table filled with:
+    | field                     |  value                                                |
+    | Registered company name   | Toys "ᴙ" Not Us                                       |
+    | Registered company address| 188-196 Regent Street London W1B 5BT United Kingdom   |
+    | Registration number       | 18092232                                              |
+    | Trading status            | Public limited company (PLC)                          |
+    | Company size              | Large                                                 |
+    | VAT number                | Not VAT registered                                    |
+
+  # Can pull the dunsNumber from the supplier and use it with this step
+  And I see 'that supplier.dunsNumber' text on the page
 
 @notify @skip-staging
 Scenario: Supplier user can add and remove contributors

--- a/features/supplier/supplier_creation.feature
+++ b/features/supplier/supplier_creation.feature
@@ -4,7 +4,7 @@ Feature: Create new supplier account
 Background:
   Given There is at least one framework that can be applied to
 
-@skip-staging # Temporary duplicate scenario to be removed after new button content is release to staging.
+@skip-staging
 Scenario: User steps through supplier account creation process
   Given I am on the homepage
   When I click 'Become a supplier'
@@ -63,7 +63,7 @@ Scenario: User steps through supplier account creation process
   # We can't ever click the "Create account" button to check the final page because this will create a supplier entry
   # with DUNS number 000000001 and the test will never pass again.
 
-@skip-preview # Temporary duplicate scenario to be removed after new button content is release to staging.
+@skip-preview
 Scenario: User steps through supplier account creation process
   Given I am on the homepage
   When I click 'Become a supplier'

--- a/features/supplier/view_and_edit_g_cloud_services.feature
+++ b/features/supplier/view_and_edit_g_cloud_services.feature
@@ -17,7 +17,7 @@ Background:
   When I click 'Test cloud support service'
   Then I am on the 'Test cloud support service' page
 
-@skip-staging # Temporary duplicate scenario to be removed after new button content is release to staging.
+@skip-staging
 Scenario: Supplier user can edit the name of a service
   When I click the top-level summary table 'Edit' link for the section 'Service name'
   Then I am on the 'Service name' page
@@ -26,7 +26,7 @@ Scenario: Supplier user can edit the name of a service
   Then I am on the 'Changed cloud support service' page
   And I see a success banner message containing 'You’ve edited your service. The changes are now live on the Digital Marketplace.'
 
-@skip-preview # Temporary duplicate scenario to be removed after new button content is release to staging.
+@skip-preview
 Scenario: Supplier user can edit the name of a service
   When I click the top-level summary table 'Edit' link for the section 'Service name'
   Then I am on the 'Service name' page
@@ -35,7 +35,7 @@ Scenario: Supplier user can edit the name of a service
   Then I am on the 'Changed cloud support service' page
   And I see a success banner message containing 'You’ve edited your service. The changes are now live on the Digital Marketplace.'
 
-@skip-staging # Temporary duplicate scenario to be removed after new button content is release to staging.
+@skip-staging
 Scenario: Supplier user can edit the description of a service
   Given I see the 'About your service' summary table filled with:
     | field                        | value                                             |
@@ -50,7 +50,7 @@ Scenario: Supplier user can edit the description of a service
     | field                        | value                          |
     | Service description          | This is an updated description |
 
-@skip-preview # Temporary duplicate scenario to be removed after new button content is release to staging.
+@skip-preview
 Scenario: Supplier user can edit the description of a service
   Given I see the 'About your service' summary table filled with:
     | field                        | value                                             |
@@ -65,7 +65,7 @@ Scenario: Supplier user can edit the description of a service
     | field                        | value                          |
     | Service description          | This is an updated description |
 
-@skip-staging # Temporary duplicate scenario to be removed after new button content is release to staging.
+@skip-staging
 Scenario: Supplier user can edit the features and benefits of a service
   Given I see the 'Service features and benefits' summary table filled with:
     | field                         | value                                                                                  |
@@ -81,7 +81,7 @@ Scenario: Supplier user can edit the features and benefits of a service
     | field                         | value                                                                                  |
     | Service features and benefits | Service features Feature 1 New Feature 2 Service benefits Benefit 1 Updated Benefit 2  |
 
-@skip-preview # Temporary duplicate scenario to be removed after new button content is release to staging.
+@skip-preview
 Scenario: Supplier user can edit the features and benefits of a service
   Given I see the 'Service features and benefits' summary table filled with:
     | field                         | value                                                                                  |
@@ -97,7 +97,7 @@ Scenario: Supplier user can edit the features and benefits of a service
     | field                         | value                                                                                  |
     | Service features and benefits | Service features Feature 1 New Feature 2 Service benefits Benefit 1 Updated Benefit 2  |
 
-@skip-staging # Temporary duplicate scenario to be removed after new button content is release to staging.
+@skip-staging
 Scenario: Supplier user can replace the service definition document
   When I click the top-level summary table 'Edit' link for the section 'Documents'
   Then I am on the 'Documents' page
@@ -106,7 +106,7 @@ Scenario: Supplier user can replace the service definition document
   Then I am on the 'Test cloud support service' page
   And I see a success banner message containing 'You’ve edited your service. The changes are now live on the Digital Marketplace.'
 
-@skip-preview # Temporary duplicate scenario to be removed after new button content is release to staging.
+@skip-preview
 Scenario: Supplier user can replace the service definition document
   When I click the top-level summary table 'Edit' link for the section 'Documents'
   Then I am on the 'Documents' page
@@ -115,7 +115,7 @@ Scenario: Supplier user can replace the service definition document
   Then I am on the 'Test cloud support service' page
   And I see a success banner message containing 'You’ve edited your service. The changes are now live on the Digital Marketplace.'
 
-@skip-staging # Temporary duplicate scenario to be removed after new button content is release to staging.
+@skip-staging
 Scenario: Supplier user can not replace the service definition document with a non-pdf file
   When I click the top-level summary table 'Edit' link for the section 'Documents'
   Then I am on the 'Documents' page
@@ -124,7 +124,7 @@ Scenario: Supplier user can not replace the service definition document with a n
   Then I am on the 'Documents' page
   And I see a validation message containing 'Your document is not in an open format. Please save as an Open Document Format (ODF) or PDF/A (eg .pdf, .odt).'
 
-@skip-preview # Temporary duplicate scenario to be removed after new button content is release to staging.
+@skip-preview
 Scenario: Supplier user can not replace the service definition document with a non-pdf file
   When I click the top-level summary table 'Edit' link for the section 'Documents'
   Then I am on the 'Documents' page
@@ -133,7 +133,7 @@ Scenario: Supplier user can not replace the service definition document with a n
   Then I am on the 'Documents' page
   And I see a validation message containing 'Your document is not in an open format. Please save as an Open Document Format (ODF) or PDF/A (eg .pdf, .odt).'
 
-@skip-staging # Temporary duplicate scenario to be removed after new button content is release to staging.
+@skip-staging
 Scenario: Supplier user can not replace the service definition document with a file over 5MB
   When I click the top-level summary table 'Edit' link for the section 'Documents'
   Then I am on the 'Documents' page
@@ -142,7 +142,7 @@ Scenario: Supplier user can not replace the service definition document with a f
   Then I am on the 'Documents' page
   And I see a validation message containing 'Your document exceeds the 5MB limit. Please reduce file size.'
 
-@skip-preview # Temporary duplicate scenario to be removed after new button content is release to staging.
+@skip-preview
 Scenario: Supplier user can not replace the service definition document with a file over 5MB
   When I click the top-level summary table 'Edit' link for the section 'Documents'
   Then I am on the 'Documents' page


### PR DESCRIPTION
This branch is rebased on this PR: https://github.com/alphagov/digitalmarketplace-functional-tests/pull/483, it's only the last commit which should be reviewed here.

For this trello ticket: https://trello.com/c/QBDqUfVk

We need functional tests to cover the new supplier editing details flow.

This covers hitting the 'Save and confirm' button and checking that certain details are no longer editable. Will need PR's for allowing editing until cofirmation, and for the button, to be merged before these can go in.