### PR TITLE
Update supplier app button content

### DIFF
--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -302,7 +302,7 @@ end
 
 When /I update the value of '(.*)' to '(.*)' using the summary table '(.*)' link(?: and the '(.*)' button)?/ do |field_to_edit, new_value, link_name, button_name|
   summary_page = current_url
-  button_name ||= "Continue"
+  button_name ||= "Save and continue"
 
   step "I click the summary table '#{link_name}' link for '#{field_to_edit}'"
   step "I enter '#{new_value}' in the '#{field_to_edit}' field and click its associated '#{button_name}' button"

--- a/features/supplier/supplier_account.feature
+++ b/features/supplier/supplier_account.feature
@@ -16,7 +16,7 @@ Scenario: Supplier user can edit supplier information
   And I enter 'new-email@example.com' in the 'Contact email address' field
   And I enter '12345678' in the 'Contact phone number' field
   And I enter 'All fresh' in the 'Supplier summary' field
-  And I click 'Save and continue'
+  And I click 'Save and return'
   Then I see the 'What buyers will see' summary table filled with:
     | field                     | value                           |
     | Contact name              | New name                        |

--- a/features/supplier/supplier_creation.feature
+++ b/features/supplier/supplier_creation.feature
@@ -4,7 +4,6 @@ Feature: Create new supplier account
 Background:
   Given There is at least one framework that can be applied to
 
-@skip-staging
 Scenario: User steps through supplier account creation process
   Given I am on the homepage
   When I click 'Become a supplier'
@@ -55,69 +54,7 @@ Scenario: User steps through supplier account creation process
     | Contact phone number   | 9876543210                  |
 
   When I click the summary table 'Edit' link for 'Email address'
-  And I enter 'changed.test.email@test.com' in the 'Your email address' field and click its associated 'Continue' button
-  Then I see the 'Your login details' summary table filled with:
-    | field                  | value                        |
-    | Email address          | changed.test.email@test.com  |
-
-  # We can't ever click the "Create account" button to check the final page because this will create a supplier entry
-  # with DUNS number 000000001 and the test will never pass again.
-
-@skip-preview
-Scenario: User steps through supplier account creation process
-  Given I am on the homepage
-  When I click 'Become a supplier'
-  Then I am on the 'Become a supplier' page
-
-  When I click 'Create a supplier account'
-  Then I am on the 'Create a supplier account' page
-
-  When I click 'Start'
-  Then I am on the 'DUNS number' page
-
-  When I enter '000000001' in the 'duns_number' field
-  And I click 'Save and continue'
-  Then I am on the 'Company name' page
-
-  When I enter 'This is a test company name' in the 'company_name' field
-  And I click 'Save and continue'
-  Then I am on the 'Company contact details' page
-
-  When I enter 'Company contact name' in the 'contact_name' field
-  Then I enter 'test.company.email@test.com' in the 'email_address' field
-  Then I enter '0123456789' in the 'phone_number' field
-  And I click 'Save and continue'
-  Then I am on the 'Create login' page
-
-  When I enter 'test.supplier.email@test.com' in the 'email_address' field
-  And I click 'Save and continue'
-  Then I am on the 'Check your information' page
-  And I see the 'Your company details' summary table filled with:
-    | field                  | value                       |
-    | DUNS number            | 000000001                   |
-    | Company name           | This is a test company name |
-    | Contact name           | Company contact name        |
-    | Contact email          | test.company.email@test.com |
-    | Contact phone number   | 0123456789                  |
-  And I see the 'Your login details' summary table filled with:
-    | field                  | value                        |
-    | Email address          | test.supplier.email@test.com |
-
-  When I update the value of 'DUNS number' to '000000002' using the summary table 'Edit' link and the 'Save and continue' button
-  And I update the value of 'Company name' to 'Changed test company name' using the summary table 'Edit' link
-  And I update the value of 'Contact name' to 'Changed contact name' using the summary table 'Edit' link
-  And I update the value of 'Contact email' to 'test.changed.email@test.com' using the summary table 'Edit' link
-  And I update the value of 'Contact phone number' to '9876543210' using the summary table 'Edit' link
-  Then I see the 'Your company details' summary table filled with:
-    | field                  | value                       |
-    | DUNS number            | 000000002                   |
-    | Company name           | Changed test company name   |
-    | Contact name           | Changed contact name        |
-    | Contact email          | test.changed.email@test.com |
-    | Contact phone number   | 9876543210                  |
-
-  When I click the summary table 'Edit' link for 'Email address'
-  And I enter 'changed.test.email@test.com' in the 'Your email address' field and click its associated 'Continue' button
+  And I enter 'changed.test.email@test.com' in the 'Your email address' field and click its associated 'Save and continue' button
   Then I see the 'Your login details' summary table filled with:
     | field                  | value                        |
     | Email address          | changed.test.email@test.com  |

--- a/features/supplier/supplier_creation.feature
+++ b/features/supplier/supplier_creation.feature
@@ -4,6 +4,7 @@ Feature: Create new supplier account
 Background:
   Given There is at least one framework that can be applied to
 
+@skip-staging # Temporary duplicate scenario to be removed after new button content is release to staging.
 Scenario: User steps through supplier account creation process
   Given I am on the homepage
   When I click 'Become a supplier'
@@ -55,6 +56,65 @@ Scenario: User steps through supplier account creation process
 
   When I click the summary table 'Edit' link for 'Email address'
   And I enter 'changed.test.email@test.com' in the 'Your email address' field and click its associated 'Save and continue' button
+  Then I see the 'Your login details' summary table filled with:
+    | field                  | value                        |
+    | Email address          | changed.test.email@test.com  |
+
+  # We can't ever click the "Create account" button to check the final page because this will create a supplier entry
+  # with DUNS number 000000001 and the test will never pass again.
+
+@skip-preview # Temporary duplicate scenario to be removed after new button content is release to staging.
+Scenario: User steps through supplier account creation process
+  Given I am on the homepage
+  When I click 'Become a supplier'
+  Then I am on the 'Become a supplier' page
+
+  When I click 'Create a supplier account'
+  Then I am on the 'Create a supplier account' page
+
+  When I click 'Start'
+  Then I am on the 'DUNS number' page
+
+  When I enter '000000001' in the 'duns_number' field
+  And I click 'Save and continue'
+  Then I am on the 'What buyers will see' page
+
+  When I enter 'This is a test company name' in the 'company_name' field
+  And I enter 'Company contact name' in the 'contact_name' field
+  And I enter 'test.company.email@test.com' in the 'email_address' field
+  And I enter '0123456789' in the 'phone_number' field
+  And I click 'Continue'
+  Then I am on the 'Create login' page
+
+  When I enter 'test.supplier.email@test.com' in the 'email_address' field
+  And I click 'Continue'
+  Then I am on the 'Check your information' page
+  And I see the 'Your company details' summary table filled with:
+    | field                  | value                       |
+    | DUNS number            | 000000001                   |
+    | Company name           | This is a test company name |
+    | Contact name           | Company contact name        |
+    | Contact email          | test.company.email@test.com |
+    | Contact phone number   | 0123456789                  |
+  And I see the 'Your login details' summary table filled with:
+    | field                  | value                        |
+    | Email address          | test.supplier.email@test.com |
+
+  When I update the value of 'DUNS number' to '000000002' using the summary table 'Edit' link
+  And I update the value of 'Company name' to 'Changed test company name' using the summary table 'Edit' link
+  And I update the value of 'Contact name' to 'Changed contact name' using the summary table 'Edit' link
+  And I update the value of 'Contact email' to 'test.changed.email@test.com' using the summary table 'Edit' link
+  And I update the value of 'Contact phone number' to '9876543210' using the summary table 'Edit' link
+  Then I see the 'Your company details' summary table filled with:
+    | field                  | value                       |
+    | DUNS number            | 000000002                   |
+    | Company name           | Changed test company name   |
+    | Contact name           | Changed contact name        |
+    | Contact email          | test.changed.email@test.com |
+    | Contact phone number   | 9876543210                  |
+
+  When I click the summary table 'Edit' link for 'Email address'
+  And I enter 'changed.test.email@test.com' in the 'Your email address' field and click its associated 'Continue' button
   Then I see the 'Your login details' summary table filled with:
     | field                  | value                        |
     | Email address          | changed.test.email@test.com  |

--- a/features/supplier/supplier_creation.feature
+++ b/features/supplier/supplier_creation.feature
@@ -24,11 +24,11 @@ Scenario: User steps through supplier account creation process
   And I enter 'Company contact name' in the 'contact_name' field
   And I enter 'test.company.email@test.com' in the 'email_address' field
   And I enter '0123456789' in the 'phone_number' field
-  And I click 'Continue'
+  And I click 'Save and continue'
   Then I am on the 'Create login' page
 
   When I enter 'test.supplier.email@test.com' in the 'email_address' field
-  And I click 'Continue'
+  And I click 'Save and continue'
   Then I am on the 'Check your information' page
   And I see the 'Your company details' summary table filled with:
     | field                  | value                       |
@@ -41,7 +41,7 @@ Scenario: User steps through supplier account creation process
     | field                  | value                        |
     | Email address          | test.supplier.email@test.com |
 
-  When I update the value of 'DUNS number' to '000000002' using the summary table 'Edit' link and the 'Save and continue' button
+  When I update the value of 'DUNS number' to '000000002' using the summary table 'Edit' link
   And I update the value of 'Company name' to 'Changed test company name' using the summary table 'Edit' link
   And I update the value of 'Contact name' to 'Changed contact name' using the summary table 'Edit' link
   And I update the value of 'Contact email' to 'test.changed.email@test.com' using the summary table 'Edit' link
@@ -80,17 +80,17 @@ Scenario: User steps through supplier account creation process
   Then I am on the 'Company name' page
 
   When I enter 'This is a test company name' in the 'company_name' field
-  And I click 'Continue'
+  And I click 'Save and continue'
   Then I am on the 'Company contact details' page
 
   When I enter 'Company contact name' in the 'contact_name' field
   Then I enter 'test.company.email@test.com' in the 'email_address' field
   Then I enter '0123456789' in the 'phone_number' field
-  And I click 'Continue'
+  And I click 'Save and continue'
   Then I am on the 'Create login' page
 
   When I enter 'test.supplier.email@test.com' in the 'email_address' field
-  And I click 'Continue'
+  And I click 'Save and continue'
   Then I am on the 'Check your information' page
   And I see the 'Your company details' summary table filled with:
     | field                  | value                       |

--- a/features/supplier/view_and_edit_g_cloud_services.feature
+++ b/features/supplier/view_and_edit_g_cloud_services.feature
@@ -21,7 +21,7 @@ Scenario: Supplier user can edit the name of a service
   When I click the top-level summary table 'Edit' link for the section 'Service name'
   Then I am on the 'Service name' page
   And I enter 'Changed cloud support service' in the 'serviceName' field
-  And I click 'Save and return to service'
+  And I click 'Save and return'
   Then I am on the 'Changed cloud support service' page
   And I see a success banner message containing 'You’ve edited your service. The changes are now live on the Digital Marketplace.'
 
@@ -32,7 +32,7 @@ Scenario: Supplier user can edit the description of a service
   When I click the top-level summary table 'Edit' link for the section 'About your service'
   Then I am on the 'About your service' page
   And I enter 'This is an updated description' in the 'serviceDescription' field
-  And I click 'Save and return to service'
+  And I click 'Save and return'
   Then I am on the 'Test cloud support service' page
   And I see a success banner message containing 'You’ve edited your service. The changes are now live on the Digital Marketplace.'
   And I see the 'About your service' summary table filled with:
@@ -47,7 +47,7 @@ Scenario: Supplier user can edit the features and benefits of a service
   Then I am on the 'Service features and benefits' page
   And I enter 'New Feature 2' in the 'input-serviceFeatures-2' field
   And I enter 'Updated Benefit 2' in the 'input-serviceBenefits-2' field
-  And I click 'Save and return to service'
+  And I click 'Save and return'
   Then I am on the 'Test cloud support service' page
   And I see a success banner message containing 'You’ve edited your service. The changes are now live on the Digital Marketplace.'
   And I see the 'Service features and benefits' summary table filled with:
@@ -58,7 +58,7 @@ Scenario: Supplier user can replace the service definition document
   When I click the top-level summary table 'Edit' link for the section 'Documents'
   Then I am on the 'Documents' page
   And I choose file 'test.pdf' for the field 'serviceDefinitionDocumentURL'
-  And I click 'Save and return to service'
+  And I click 'Save and return'
   Then I am on the 'Test cloud support service' page
   And I see a success banner message containing 'You’ve edited your service. The changes are now live on the Digital Marketplace.'
 
@@ -66,7 +66,7 @@ Scenario: Supplier user can not replace the service definition document with a n
   When I click the top-level summary table 'Edit' link for the section 'Documents'
   Then I am on the 'Documents' page
   And I choose file 'word.docx' for the field 'serviceDefinitionDocumentURL'
-  And I click 'Save and return to service'
+  And I click 'Save and return'
   Then I am on the 'Documents' page
   And I see a validation message containing 'Your document is not in an open format. Please save as an Open Document Format (ODF) or PDF/A (eg .pdf, .odt).'
 
@@ -74,7 +74,7 @@ Scenario: Supplier user can not replace the service definition document with a f
   When I click the top-level summary table 'Edit' link for the section 'Documents'
   Then I am on the 'Documents' page
   And I choose file '6mb.pdf' for the field 'serviceDefinitionDocumentURL'
-  And I click 'Save and return to service'
+  And I click 'Save and return'
   Then I am on the 'Documents' page
   And I see a validation message containing 'Your document exceeds the 5MB limit. Please reduce file size.'
 

--- a/features/supplier/view_and_edit_g_cloud_services.feature
+++ b/features/supplier/view_and_edit_g_cloud_services.feature
@@ -17,6 +17,7 @@ Background:
   When I click 'Test cloud support service'
   Then I am on the 'Test cloud support service' page
 
+@skip-staging # Temporary duplicate scenario to be removed after new button content is release to staging.
 Scenario: Supplier user can edit the name of a service
   When I click the top-level summary table 'Edit' link for the section 'Service name'
   Then I am on the 'Service name' page
@@ -25,6 +26,16 @@ Scenario: Supplier user can edit the name of a service
   Then I am on the 'Changed cloud support service' page
   And I see a success banner message containing 'You’ve edited your service. The changes are now live on the Digital Marketplace.'
 
+@skip-preview # Temporary duplicate scenario to be removed after new button content is release to staging.
+Scenario: Supplier user can edit the name of a service
+  When I click the top-level summary table 'Edit' link for the section 'Service name'
+  Then I am on the 'Service name' page
+  And I enter 'Changed cloud support service' in the 'serviceName' field
+  And I click 'Save and return to service'
+  Then I am on the 'Changed cloud support service' page
+  And I see a success banner message containing 'You’ve edited your service. The changes are now live on the Digital Marketplace.'
+
+@skip-staging # Temporary duplicate scenario to be removed after new button content is release to staging.
 Scenario: Supplier user can edit the description of a service
   Given I see the 'About your service' summary table filled with:
     | field                        | value                                             |
@@ -39,6 +50,22 @@ Scenario: Supplier user can edit the description of a service
     | field                        | value                          |
     | Service description          | This is an updated description |
 
+@skip-preview # Temporary duplicate scenario to be removed after new button content is release to staging.
+Scenario: Supplier user can edit the description of a service
+  Given I see the 'About your service' summary table filled with:
+    | field                        | value                                             |
+    | Service description          | Deliver digital transformation by the bucketload! |
+  When I click the top-level summary table 'Edit' link for the section 'About your service'
+  Then I am on the 'About your service' page
+  And I enter 'This is an updated description' in the 'serviceDescription' field
+  And I click 'Save and return to service'
+  Then I am on the 'Test cloud support service' page
+  And I see a success banner message containing 'You’ve edited your service. The changes are now live on the Digital Marketplace.'
+  And I see the 'About your service' summary table filled with:
+    | field                        | value                          |
+    | Service description          | This is an updated description |
+
+@skip-staging # Temporary duplicate scenario to be removed after new button content is release to staging.
 Scenario: Supplier user can edit the features and benefits of a service
   Given I see the 'Service features and benefits' summary table filled with:
     | field                         | value                                                                                  |
@@ -54,6 +81,23 @@ Scenario: Supplier user can edit the features and benefits of a service
     | field                         | value                                                                                  |
     | Service features and benefits | Service features Feature 1 New Feature 2 Service benefits Benefit 1 Updated Benefit 2  |
 
+@skip-preview # Temporary duplicate scenario to be removed after new button content is release to staging.
+Scenario: Supplier user can edit the features and benefits of a service
+  Given I see the 'Service features and benefits' summary table filled with:
+    | field                         | value                                                                                  |
+    | Service features and benefits | Service features Feature 1 Service benefits Benefit 1 Benefit 2  |
+  When I click the top-level summary table 'Edit' link for the section 'Service features and benefits'
+  Then I am on the 'Service features and benefits' page
+  And I enter 'New Feature 2' in the 'input-serviceFeatures-2' field
+  And I enter 'Updated Benefit 2' in the 'input-serviceBenefits-2' field
+  And I click 'Save and return to service'
+  Then I am on the 'Test cloud support service' page
+  And I see a success banner message containing 'You’ve edited your service. The changes are now live on the Digital Marketplace.'
+  And I see the 'Service features and benefits' summary table filled with:
+    | field                         | value                                                                                  |
+    | Service features and benefits | Service features Feature 1 New Feature 2 Service benefits Benefit 1 Updated Benefit 2  |
+
+@skip-staging # Temporary duplicate scenario to be removed after new button content is release to staging.
 Scenario: Supplier user can replace the service definition document
   When I click the top-level summary table 'Edit' link for the section 'Documents'
   Then I am on the 'Documents' page
@@ -62,6 +106,16 @@ Scenario: Supplier user can replace the service definition document
   Then I am on the 'Test cloud support service' page
   And I see a success banner message containing 'You’ve edited your service. The changes are now live on the Digital Marketplace.'
 
+@skip-preview # Temporary duplicate scenario to be removed after new button content is release to staging.
+Scenario: Supplier user can replace the service definition document
+  When I click the top-level summary table 'Edit' link for the section 'Documents'
+  Then I am on the 'Documents' page
+  And I choose file 'test.pdf' for the field 'serviceDefinitionDocumentURL'
+  And I click 'Save and return to service'
+  Then I am on the 'Test cloud support service' page
+  And I see a success banner message containing 'You’ve edited your service. The changes are now live on the Digital Marketplace.'
+
+@skip-staging # Temporary duplicate scenario to be removed after new button content is release to staging.
 Scenario: Supplier user can not replace the service definition document with a non-pdf file
   When I click the top-level summary table 'Edit' link for the section 'Documents'
   Then I am on the 'Documents' page
@@ -70,11 +124,30 @@ Scenario: Supplier user can not replace the service definition document with a n
   Then I am on the 'Documents' page
   And I see a validation message containing 'Your document is not in an open format. Please save as an Open Document Format (ODF) or PDF/A (eg .pdf, .odt).'
 
+@skip-preview # Temporary duplicate scenario to be removed after new button content is release to staging.
+Scenario: Supplier user can not replace the service definition document with a non-pdf file
+  When I click the top-level summary table 'Edit' link for the section 'Documents'
+  Then I am on the 'Documents' page
+  And I choose file 'word.docx' for the field 'serviceDefinitionDocumentURL'
+  And I click 'Save and return to service'
+  Then I am on the 'Documents' page
+  And I see a validation message containing 'Your document is not in an open format. Please save as an Open Document Format (ODF) or PDF/A (eg .pdf, .odt).'
+
+@skip-staging # Temporary duplicate scenario to be removed after new button content is release to staging.
 Scenario: Supplier user can not replace the service definition document with a file over 5MB
   When I click the top-level summary table 'Edit' link for the section 'Documents'
   Then I am on the 'Documents' page
   And I choose file '6mb.pdf' for the field 'serviceDefinitionDocumentURL'
   And I click 'Save and return'
+  Then I am on the 'Documents' page
+  And I see a validation message containing 'Your document exceeds the 5MB limit. Please reduce file size.'
+
+@skip-preview # Temporary duplicate scenario to be removed after new button content is release to staging.
+Scenario: Supplier user can not replace the service definition document with a file over 5MB
+  When I click the top-level summary table 'Edit' link for the section 'Documents'
+  Then I am on the 'Documents' page
+  And I choose file '6mb.pdf' for the field 'serviceDefinitionDocumentURL'
+  And I click 'Save and return to service'
   Then I am on the 'Documents' page
   And I see a validation message containing 'Your document exceeds the 5MB limit. Please reduce file size.'
 


### PR DESCRIPTION
This PR is to fix issues that will occur if/when this PR on the supplier app is merged: https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/840

It also removes a now redundant scenario for when the supplier sign up flow was different on preview and staging. The preview changes have now been pushed out to prod so we can remove.