### PR TITLE
Temporary check for old DOS search outcome statuses

### DIFF
--- a/features/step_definitions/opportunities_steps.rb
+++ b/features/step_definitions/opportunities_steps.rb
@@ -63,7 +63,7 @@ Then (/^I see all the opportunities on the page are of the '(.*)' less detailed 
   )
   published_or_closed.each do |x|
     if ['Closed', 'Unsuccessful', 'Cancelled'].include? status
-      x.text.should == status
+      expect(x.text).to satisfy { |text| old_closed_outcome_status?(text) }
     else
       x.text.include?("Published").should be true
     end

--- a/features/support/helpers.rb
+++ b/features/support/helpers.rb
@@ -27,6 +27,14 @@ CLOSED_OUTCOMES = {
   Unsuccessful: 'Closed: no suitable suppliers'
 }.freeze
 
+#TO REMOVE
+OLD_CLOSED_OUTCOMES = %w(
+  Awarded
+  Cancelled
+  Closed
+  Unsuccessful
+).freeze
+
 def full_lot(lot)
   LOTS[lot.to_sym]
 end
@@ -41,6 +49,11 @@ end
 
 def closed_outcome_status?(text)
   CLOSED_OUTCOMES.value?(text)
+end
+
+#TO REMOVE
+def old_closed_outcome_status?(text)
+  OLD_CLOSED_OUTCOMES.include?(text)
 end
 
 def normalize_whitespace(text)


### PR DESCRIPTION
This will enable the DOS opportunities tests to pass until https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/732
has been rolled out to prod.

https://trello.com/c/y59qiKOl/335-show-award-status-in-dos-search-results