### PR TITLE
Do not install development and test gems in prod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ setup: install clean
 	mkdir -p reports/
 
 install:
-	bundle install --path .bundle
+	bundle install --path .bundle --without development test
 
 config/local.sh:
 	cp config/example.sh config/local.sh


### PR DESCRIPTION
We do not want to install any of the gems in the development and test groups to production.