### PR TITLE
Remove duplicate scenarios for supplier flow

### DIFF
--- a/features/supplier/supplier_account.feature
+++ b/features/supplier/supplier_account.feature
@@ -6,7 +6,6 @@ Background:
   And that supplier is logged in
   And I am on the /suppliers page
 
-@skip-staging
 Scenario: Supplier user can provide and change supplier details before confirming them for framework applications
   When I click 'Supplier details'
   Then I am on the 'Company details' page

--- a/features/supplier/supplier_creation.feature
+++ b/features/supplier/supplier_creation.feature
@@ -4,7 +4,6 @@ Feature: Create new supplier account
 Background:
   Given There is at least one framework that can be applied to
 
-@skip-staging
 Scenario: User steps through supplier account creation process
   Given I am on the homepage
   When I click 'Become a supplier'
@@ -56,65 +55,6 @@ Scenario: User steps through supplier account creation process
 
   When I click the summary table 'Edit' link for 'Email address'
   And I enter 'changed.test.email@test.com' in the 'Your email address' field and click its associated 'Save and continue' button
-  Then I see the 'Your login details' summary table filled with:
-    | field                  | value                        |
-    | Email address          | changed.test.email@test.com  |
-
-  # We can't ever click the "Create account" button to check the final page because this will create a supplier entry
-  # with DUNS number 000000001 and the test will never pass again.
-
-@skip-preview
-Scenario: User steps through supplier account creation process
-  Given I am on the homepage
-  When I click 'Become a supplier'
-  Then I am on the 'Become a supplier' page
-
-  When I click 'Create a supplier account'
-  Then I am on the 'Create a supplier account' page
-
-  When I click 'Start'
-  Then I am on the 'DUNS number' page
-
-  When I enter '000000001' in the 'duns_number' field
-  And I click 'Save and continue'
-  Then I am on the 'What buyers will see' page
-
-  When I enter 'This is a test company name' in the 'company_name' field
-  And I enter 'Company contact name' in the 'contact_name' field
-  And I enter 'test.company.email@test.com' in the 'email_address' field
-  And I enter '0123456789' in the 'phone_number' field
-  And I click 'Continue'
-  Then I am on the 'Create login' page
-
-  When I enter 'test.supplier.email@test.com' in the 'email_address' field
-  And I click 'Continue'
-  Then I am on the 'Check your information' page
-  And I see the 'Your company details' summary table filled with:
-    | field                  | value                       |
-    | DUNS number            | 000000001                   |
-    | Company name           | This is a test company name |
-    | Contact name           | Company contact name        |
-    | Contact email          | test.company.email@test.com |
-    | Contact phone number   | 0123456789                  |
-  And I see the 'Your login details' summary table filled with:
-    | field                  | value                        |
-    | Email address          | test.supplier.email@test.com |
-
-  When I update the value of 'DUNS number' to '000000002' using the summary table 'Edit' link
-  And I update the value of 'Company name' to 'Changed test company name' using the summary table 'Edit' link
-  And I update the value of 'Contact name' to 'Changed contact name' using the summary table 'Edit' link
-  And I update the value of 'Contact email' to 'test.changed.email@test.com' using the summary table 'Edit' link
-  And I update the value of 'Contact phone number' to '9876543210' using the summary table 'Edit' link
-  Then I see the 'Your company details' summary table filled with:
-    | field                  | value                       |
-    | DUNS number            | 000000002                   |
-    | Company name           | Changed test company name   |
-    | Contact name           | Changed contact name        |
-    | Contact email          | test.changed.email@test.com |
-    | Contact phone number   | 9876543210                  |
-
-  When I click the summary table 'Edit' link for 'Email address'
-  And I enter 'changed.test.email@test.com' in the 'Your email address' field and click its associated 'Continue' button
   Then I see the 'Your login details' summary table filled with:
     | field                  | value                        |
     | Email address          | changed.test.email@test.com  |

--- a/features/supplier/view_and_edit_g_cloud_services.feature
+++ b/features/supplier/view_and_edit_g_cloud_services.feature
@@ -17,7 +17,6 @@ Background:
   When I click 'Test cloud support service'
   Then I am on the 'Test cloud support service' page
 
-@skip-staging
 Scenario: Supplier user can edit the name of a service
   When I click the top-level summary table 'Edit' link for the section 'Service name'
   Then I am on the 'Service name' page
@@ -26,16 +25,6 @@ Scenario: Supplier user can edit the name of a service
   Then I am on the 'Changed cloud support service' page
   And I see a success banner message containing 'You’ve edited your service. The changes are now live on the Digital Marketplace.'
 
-@skip-preview
-Scenario: Supplier user can edit the name of a service
-  When I click the top-level summary table 'Edit' link for the section 'Service name'
-  Then I am on the 'Service name' page
-  And I enter 'Changed cloud support service' in the 'serviceName' field
-  And I click 'Save and return to service'
-  Then I am on the 'Changed cloud support service' page
-  And I see a success banner message containing 'You’ve edited your service. The changes are now live on the Digital Marketplace.'
-
-@skip-staging
 Scenario: Supplier user can edit the description of a service
   Given I see the 'About your service' summary table filled with:
     | field                        | value                                             |
@@ -50,26 +39,10 @@ Scenario: Supplier user can edit the description of a service
     | field                        | value                          |
     | Service description          | This is an updated description |
 
-@skip-preview
-Scenario: Supplier user can edit the description of a service
-  Given I see the 'About your service' summary table filled with:
-    | field                        | value                                             |
-    | Service description          | Deliver digital transformation by the bucketload! |
-  When I click the top-level summary table 'Edit' link for the section 'About your service'
-  Then I am on the 'About your service' page
-  And I enter 'This is an updated description' in the 'serviceDescription' field
-  And I click 'Save and return to service'
-  Then I am on the 'Test cloud support service' page
-  And I see a success banner message containing 'You’ve edited your service. The changes are now live on the Digital Marketplace.'
-  And I see the 'About your service' summary table filled with:
-    | field                        | value                          |
-    | Service description          | This is an updated description |
-
-@skip-staging
 Scenario: Supplier user can edit the features and benefits of a service
   Given I see the 'Service features and benefits' summary table filled with:
-    | field                         | value                                                                                  |
-    | Service features and benefits | Service features Feature 1 Service benefits Benefit 1 Benefit 2  |
+    | field                         | value                                                           |
+    | Service features and benefits | Service features Feature 1 Service benefits Benefit 1 Benefit 2 |
   When I click the top-level summary table 'Edit' link for the section 'Service features and benefits'
   Then I am on the 'Service features and benefits' page
   And I enter 'New Feature 2' in the 'input-serviceFeatures-2' field
@@ -81,23 +54,6 @@ Scenario: Supplier user can edit the features and benefits of a service
     | field                         | value                                                                                  |
     | Service features and benefits | Service features Feature 1 New Feature 2 Service benefits Benefit 1 Updated Benefit 2  |
 
-@skip-preview
-Scenario: Supplier user can edit the features and benefits of a service
-  Given I see the 'Service features and benefits' summary table filled with:
-    | field                         | value                                                                                  |
-    | Service features and benefits | Service features Feature 1 Service benefits Benefit 1 Benefit 2  |
-  When I click the top-level summary table 'Edit' link for the section 'Service features and benefits'
-  Then I am on the 'Service features and benefits' page
-  And I enter 'New Feature 2' in the 'input-serviceFeatures-2' field
-  And I enter 'Updated Benefit 2' in the 'input-serviceBenefits-2' field
-  And I click 'Save and return to service'
-  Then I am on the 'Test cloud support service' page
-  And I see a success banner message containing 'You’ve edited your service. The changes are now live on the Digital Marketplace.'
-  And I see the 'Service features and benefits' summary table filled with:
-    | field                         | value                                                                                  |
-    | Service features and benefits | Service features Feature 1 New Feature 2 Service benefits Benefit 1 Updated Benefit 2  |
-
-@skip-staging
 Scenario: Supplier user can replace the service definition document
   When I click the top-level summary table 'Edit' link for the section 'Documents'
   Then I am on the 'Documents' page
@@ -106,16 +62,6 @@ Scenario: Supplier user can replace the service definition document
   Then I am on the 'Test cloud support service' page
   And I see a success banner message containing 'You’ve edited your service. The changes are now live on the Digital Marketplace.'
 
-@skip-preview
-Scenario: Supplier user can replace the service definition document
-  When I click the top-level summary table 'Edit' link for the section 'Documents'
-  Then I am on the 'Documents' page
-  And I choose file 'test.pdf' for the field 'serviceDefinitionDocumentURL'
-  And I click 'Save and return to service'
-  Then I am on the 'Test cloud support service' page
-  And I see a success banner message containing 'You’ve edited your service. The changes are now live on the Digital Marketplace.'
-
-@skip-staging
 Scenario: Supplier user can not replace the service definition document with a non-pdf file
   When I click the top-level summary table 'Edit' link for the section 'Documents'
   Then I am on the 'Documents' page
@@ -124,30 +70,11 @@ Scenario: Supplier user can not replace the service definition document with a n
   Then I am on the 'Documents' page
   And I see a validation message containing 'Your document is not in an open format. Please save as an Open Document Format (ODF) or PDF/A (eg .pdf, .odt).'
 
-@skip-preview
-Scenario: Supplier user can not replace the service definition document with a non-pdf file
-  When I click the top-level summary table 'Edit' link for the section 'Documents'
-  Then I am on the 'Documents' page
-  And I choose file 'word.docx' for the field 'serviceDefinitionDocumentURL'
-  And I click 'Save and return to service'
-  Then I am on the 'Documents' page
-  And I see a validation message containing 'Your document is not in an open format. Please save as an Open Document Format (ODF) or PDF/A (eg .pdf, .odt).'
-
-@skip-staging
 Scenario: Supplier user can not replace the service definition document with a file over 5MB
   When I click the top-level summary table 'Edit' link for the section 'Documents'
   Then I am on the 'Documents' page
   And I choose file '6mb.pdf' for the field 'serviceDefinitionDocumentURL'
   And I click 'Save and return'
-  Then I am on the 'Documents' page
-  And I see a validation message containing 'Your document exceeds the 5MB limit. Please reduce file size.'
-
-@skip-preview
-Scenario: Supplier user can not replace the service definition document with a file over 5MB
-  When I click the top-level summary table 'Edit' link for the section 'Documents'
-  Then I am on the 'Documents' page
-  And I choose file '6mb.pdf' for the field 'serviceDefinitionDocumentURL'
-  And I click 'Save and return to service'
   Then I am on the 'Documents' page
   And I see a validation message containing 'Your document exceeds the 5MB limit. Please reduce file size.'
 


### PR DESCRIPTION
There were a number of duplicated scenarios to allow the test to work on
preview and staging at the same time. The changes have been released to
staging now so we can remove the duplicates.