### PR TITLE
Method parentheses and hash syntax

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -48,9 +48,6 @@ UnusedBlockArgument:
 VariableName:
   Enabled: false
 
-HashSyntax:
-  Enabled: false
-
 WordArray:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,9 +27,6 @@ TrailingBlankLines:
 AndOr:
   Enabled: false
 
-DefWithParentheses:
-  Enabled: false
-
 MethodCalledOnDoEndBlock:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -72,9 +72,6 @@ UselessAssignment:
 Void:
   Enabled: false
 
-BracesAroundHashParameters:
-  Enabled: false
-
 SpaceInsideHashLiteralBraces:
   Enabled: false
 

--- a/features/step_definitions/brief_response_steps.rb
+++ b/features/step_definitions/brief_response_steps.rb
@@ -12,7 +12,7 @@ Given /^I am logged in as the buyer of a (closed|live) brief$/ do |status|
   @buyer_user = matched_brief['users'][0]
   @lot_slug = matched_brief['lotSlug']
   @framework_slug = matched_brief['frameworkSlug']
-  @buyer_user.update({'password' => ENV["DM_PRODUCTION_BUYER_USER_PASSWORD"]})
+  @buyer_user.update('password' => ENV["DM_PRODUCTION_BUYER_USER_PASSWORD"])
   steps %Q{
     Given that buyer is logged in
   }
@@ -24,7 +24,7 @@ Given /^I am logged in as the buyer of a closed brief with responses$/ do
   @lot_slug = @brief['lotSlug']
   @framework_slug = @brief['frameworkSlug']
   @buyer_user = @brief['users'][0]
-  @buyer_user.update({'password' => ENV["DM_PRODUCTION_BUYER_USER_PASSWORD"]})
+  @buyer_user.update('password' => ENV["DM_PRODUCTION_BUYER_USER_PASSWORD"])
   steps %Q{
     Given that buyer is logged in
   }

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -166,24 +166,24 @@ When /I choose #{MAYBE_VAR} radio button(?: for the '(.*)' question)?$/ do |radi
 end
 
 When /I check a random '(.*)' checkbox$/ do |checkbox_name|
-  checkbox = all_fields(checkbox_name, {type: 'checkbox'}).sample
+  checkbox = all_fields(checkbox_name, type: 'checkbox').sample
   check_checkbox(checkbox)
 end
 
 When /I choose a random '(.*)' radio button$/ do |name|
 
-  radio = all_fields(name, {type: 'radio'}).sample
+  radio = all_fields(name, type: 'radio').sample
   choose_radio(radio)
 end
 
 When /I check all '(.*)' checkboxes$/ do |checkbox_name|
-  all_fields(checkbox_name, {type: 'checkbox'}).each do |checkbox|
+  all_fields(checkbox_name, type: 'checkbox').each do |checkbox|
     check_checkbox(checkbox)
   end
 end
 
 Then /I don't see a '(.*)' checkbox$/ do |checkbox_name|
-  expect(all_fields(checkbox_name, {type: 'checkbox'}).length).to eq(0)
+  expect(all_fields(checkbox_name, type: 'checkbox').length).to eq(0)
 end
 
 Then /I don't see any '(.*)' checkboxes$/ do |checkbox_fieldname|
@@ -257,8 +257,8 @@ Then(/^I see the page's h1 ends in #{MAYBE_VAR}$/) do |term|
 end
 
 Then /I see #{MAYBE_VAR} as the value of the '(.*)' field$/ do |value, field|
-  if page.has_field?(field, {type: 'radio', visible: :all}) or page.has_field?(field, {type: 'checkbox', visible: :all})
-    expect(first_field(field, {checked: true}).value).to eq(value)
+  if page.has_field?(field, type: 'radio', visible: :all) or page.has_field?(field, type: 'checkbox', visible: :all)
+    expect(first_field(field, checked: true).value).to eq(value)
   else
     expect(first_field(field).value).to eq(value)
   end
@@ -368,10 +368,10 @@ end
 Then /^I see the '(.*)' radio button is checked(?: for the '(.*)' question)?$/ do |radio_button_name, question|
   if question
     within(:xpath, "//span[normalize-space(text())=\"#{question}\"]/../..") do
-      expect(first_field(radio_button_name, {type: 'radio'})).to be_checked
+      expect(first_field(radio_button_name, type: 'radio')).to be_checked
     end
   else
-    expect(first_field(radio_button_name, {type: 'radio'})).to be_checked
+    expect(first_field(radio_button_name, type: 'radio')).to be_checked
   end
 end
 

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -187,7 +187,7 @@ Then /I don't see a '(.*)' checkbox$/ do |checkbox_name|
 end
 
 Then /I don't see any '(.*)' checkboxes$/ do |checkbox_fieldname|
-  expect(page).to have_selector(:xpath, "//input[@type='checkbox'][@name='#{checkbox_fieldname}']", :count => 0)
+  expect(page).to have_selector(:xpath, "//input[@type='checkbox'][@name='#{checkbox_fieldname}']", count: 0)
 end
 
 When /^I enter a random value in the '(.*)' field( and click its associated '(.*)' button)?$/ do |field_name, maybe_click_statement, click_button_name|

--- a/features/step_definitions/emails.rb
+++ b/features/step_definitions/emails.rb
@@ -8,10 +8,10 @@ module DMNotify
   def self.get_email(message_type, email_address)
     email_hash = Base64.urlsafe_encode64(Digest::SHA256.digest(email_address))
     client = Notifications::Client.new(dm_notify_api_key)
-    client.get_notifications({
+    client.get_notifications(
       'template_type' => 'email',
       'reference' => "#{message_type}-#{email_hash}"
-    })
+    )
   end
 end
 

--- a/features/step_definitions/login_steps.rb
+++ b/features/step_definitions/login_steps.rb
@@ -32,7 +32,7 @@ end
 
 Given /^I have a supplier user$/ do
   @supplier = create_supplier
-  @supplier_user = create_user('supplier', {"supplierId"=>@supplier['id']})
+  @supplier_user = create_user('supplier', "supplierId" => @supplier['id'])
 end
 
 Given /^I have (?:a|an) ([a-z\-]+) user with:$/ do |role, table|

--- a/features/step_definitions/opportunities_steps.rb
+++ b/features/step_definitions/opportunities_steps.rb
@@ -57,7 +57,7 @@ end
 
 Then (/^I see no results$/) do
   expect(page.first(:css, ".search-summary-count").text.to_i).to eq(0)
-  expect(page).to have_selector(:css, '.search-result', :count => 0)
+  expect(page).to have_selector(:css, '.search-result', count: 0)
 end
 
 Then /^I see the details of the brief match what was published$/ do

--- a/features/step_definitions/requirements_steps.rb
+++ b/features/step_definitions/requirements_steps.rb
@@ -25,7 +25,7 @@ Then(/^'(.*)' should (not |)be ticked$/) do |label, negative|
 
   count = case negative.empty? when true then 1 else 0 end
 
-  expect(page).to have_selector(:xpath, expr, :count => count)
+  expect(page).to have_selector(:xpath, expr, count: count)
 end
 
 When "I answer the following questions:" do |table|
@@ -34,7 +34,7 @@ When "I answer the following questions:" do |table|
     expr = "//li[a[text()='#{question}']]/span[@class='tick']"
 
     # should be no tick mark beside the question name on the overview page
-    expect(page).to have_selector(:xpath, expr, :count => 0)
+    expect(page).to have_selector(:xpath, expr, count: 0)
 
     # click the question name on the overview page (eg, "Location")
     click_on question
@@ -43,7 +43,7 @@ When "I answer the following questions:" do |table|
 
     click_on 'Save and continue'
 
-    expect(page).to have_selector(:xpath, expr, :count => 1)
+    expect(page).to have_selector(:xpath, expr, count: 1)
   }
 end
 
@@ -68,7 +68,7 @@ When "I answer all summary questions with:" do |table|
       click_on first('a').text
     end
 
-    answer = fill_form :with => with
+    answer = fill_form with: with
 
     @fields.merge! answer
 

--- a/features/step_definitions/supplier_steps.rb
+++ b/features/step_definitions/supplier_steps.rb
@@ -22,7 +22,7 @@ end
 
 Given /^that(?: (micro|small|medium|large))? supplier has applied to be on that framework$/ do |organisation_size|
   organisation_size ||= ['micro', 'small', 'medium', 'large'].sample
-  submit_supplier_declaration(@framework['slug'], @supplier["id"], {'status': 'complete', 'organisationSize': organisation_size, 'nameOfOrganisation': 'foobarbaz', 'primaryContactEmail': 'foo@bar.com'})
+  submit_supplier_declaration(@framework['slug'], @supplier["id"], 'status': 'complete', 'organisationSize': organisation_size, 'nameOfOrganisation': 'foobarbaz', 'primaryContactEmail': 'foo@bar.com')
 end
 
 Given 'we accept that suppliers application to the framework' do

--- a/features/support/api_helpers.rb
+++ b/features/support/api_helpers.rb
@@ -9,11 +9,11 @@ def call_api(method, path, options={})
   auth_token = options.delete(:auth_token) || dm_api_access_token
   url = "#{domain}#{path}"
   payload = options.delete(:payload)
-  options.merge!({
+  options.merge!(
     content_type: :json,
     accept: :json,
     authorization: "Bearer #{auth_token}"
-  })
+  )
   if payload.nil?
     RestClient.send(method, url, options) {|response, request, result| response}
   else

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -40,31 +40,31 @@ def domain_for_app(app)
   end
 end
 
-def dm_api_domain()
+def dm_api_domain
   ENV['DM_API_DOMAIN'] || 'http://localhost:5000'
 end
 
-def dm_api_access_token()
+def dm_api_access_token
   ENV['DM_API_ACCESS_TOKEN'] || 'myToken'
 end
 
-def dm_search_api_domain()
+def dm_search_api_domain
   ENV['DM_SEARCH_API_DOMAIN'] || 'http://localhost:5001'
 end
 
-def dm_search_api_access_token()
+def dm_search_api_access_token
   ENV['DM_SEARCH_API_ACCESS_TOKEN'] || 'myToken'
 end
 
-def dm_frontend_domain()
+def dm_frontend_domain
   ENV['DM_FRONTEND_DOMAIN']
 end
 
-def dm_pagination_limit()
+def dm_pagination_limit
   (ENV['DM_PAGINATION_LIMIT'] || 100).to_i
 end
 
-def dm_notify_api_key()
+def dm_notify_api_key
   ENV['DM_NOTIFY_API_KEY']
 end
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -16,14 +16,14 @@ if (ENV['BROWSER'] == 'true')
   Capybara.register_driver :selenium do |app|
     http_client = Selenium::WebDriver::Remote::Http::Default.new
     http_client.timeout = 180
-    Capybara::Selenium::Driver.new(app, :browser => :firefox, :http_client => http_client)
+    Capybara::Selenium::Driver.new(app, browser: :firefox, http_client: http_client)
   end
 else
   Capybara.default_driver = :poltergeist
 
   Capybara.register_driver :poltergeist do |app|
     Capybara::Poltergeist::Driver.new(
-      app, :timeout => 180, :phantomjs_logger => File.open(File::NULL, "w"), :phantomjs_options => [])
+      app, timeout: 180, phantomjs_logger: File.open(File::NULL, "w"), phantomjs_options: [])
   end
 end
 

--- a/features/support/form_helpers.rb
+++ b/features/support/form_helpers.rb
@@ -110,7 +110,7 @@ module FormHelper
     result = all(:field, locator, options)
 
     with.zip(result).each do |value, element|
-      fill_in element[:id], :with => value
+      fill_in element[:id], with: value
     end
 
     result
@@ -136,11 +136,11 @@ module FormHelper
 
       result.select { |v| v.value == with }
     when :checkbox
-      check_only locator, options.merge({ :with => with })
+      check_only locator, options.merge({ with: with })
     when :list
-      input_list locator, options.merge({ :with => with })
+      input_list locator, options.merge({ with: with })
     else
-      result = fill_in locator, options.merge({ :with => with })
+      result = fill_in locator, options.merge({ with: with })
 
       [result]
     end

--- a/features/support/form_helpers.rb
+++ b/features/support/form_helpers.rb
@@ -132,15 +132,15 @@ module FormHelper
 
     case field_type result.first
     when :radio
-      choose_radio(locator, options.merge({ option: with }))
+      choose_radio(locator, options.merge(option: with))
 
       result.select { |v| v.value == with }
     when :checkbox
-      check_only locator, options.merge({ with: with })
+      check_only locator, options.merge(with: with)
     when :list
-      input_list locator, options.merge({ with: with })
+      input_list locator, options.merge(with: with)
     else
-      result = fill_in locator, options.merge({ with: with })
+      result = fill_in locator, options.merge(with: with)
 
       [result]
     end

--- a/features/support/helpers.rb
+++ b/features/support/helpers.rb
@@ -50,7 +50,7 @@ end
 ## finding and selecting invisible fields
 
 def all_fields(locator, options={})
-  all(:field, locator, options.merge({:visible => :all}))
+  all(:field, locator, options.merge({visible: :all}))
 end
 
 def first_field(locator, options={})
@@ -63,7 +63,7 @@ def return_element(type, locator_or_element, options={})
   else
     # when passing in the value of the element we want to choose/check, we pass it in as {:option => "value"}
     # but when we're finding it, we need to pass it in as {:with => "value"}
-    find_options = options[:option] ? {:with => options[:option]} : {}
+    find_options = options[:option] ? {with: options[:option]} : {}
     element = first_field(locator_or_element, find_options.merge({type: type}))
   end
 

--- a/features/support/helpers.rb
+++ b/features/support/helpers.rb
@@ -50,7 +50,7 @@ end
 ## finding and selecting invisible fields
 
 def all_fields(locator, options={})
-  all(:field, locator, options.merge({visible: :all}))
+  all(:field, locator, options.merge(visible: :all))
 end
 
 def first_field(locator, options={})
@@ -64,7 +64,7 @@ def return_element(type, locator_or_element, options={})
     # when passing in the value of the element we want to choose/check, we pass it in as {:option => "value"}
     # but when we're finding it, we need to pass it in as {:with => "value"}
     find_options = options[:option] ? {with: options[:option]} : {}
-    element = first_field(locator_or_element, find_options.merge({type: type}))
+    element = first_field(locator_or_element, find_options.merge(type: type))
   end
 
   # If the label for this radio/checkbox is not visible, it is effectively hidden from the user
@@ -78,21 +78,21 @@ end
 def choose_radio(locator_or_radio, options={})
   radio = return_element('radio', locator_or_radio, options)
 
-  choose(radio[:id], options.merge({allow_label_click: true}))
+  choose(radio[:id], options.merge(allow_label_click: true))
   puts "Radio button value: #{radio.value}"
 end
 
 def check_checkbox(locator_or_checkbox, options={})
   checkbox = return_element('checkbox', locator_or_checkbox, options)
 
-  check(checkbox[:id], options.merge({allow_label_click: true}))
+  check(checkbox[:id], options.merge(allow_label_click: true))
   puts "Checkbox value: #{checkbox.value}"
 end
 
 def uncheck_checkbox(locator_or_checkbox, options={})
   checkbox = return_element('checkbox', locator_or_checkbox, options)
 
-  uncheck(checkbox[:id], options.merge({allow_label_click: true}))
+  uncheck(checkbox[:id], options.merge(allow_label_click: true))
   puts "Unselected: #{checkbox.value}"
 end
 


### PR DESCRIPTION
Continuing with the gradual enabling of govuk linting, this PR covers the following:

### Method definitions without any arguments do not require parentheses

~~def foo()~~ → def foo

### Ruby 1.9 onwards has a different hash syntax for symbol keys

~~:foo => 'bar'~~ → foo: 'bar'

### If a hash is the last argument in a method's signature then the curly braces are not required

~~def a_method( { foo: 'bar' } )~~ → def a_method(foo: 'bar')