### PR TITLE
Literal array syntax

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -75,9 +75,6 @@ RedundantBlockCall:
 UnneededInterpolation:
   Enabled: false
 
-BarePercentLiterals:
-  Enabled: false
-
 EmptyLinesAroundExceptionHandlingKeywords:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -33,9 +33,6 @@ UnusedBlockArgument:
 VariableName:
   Enabled: false
 
-WordArray:
-  Enabled: false
-
 AmbiguousRegexpLiteral:
   Enabled: false
 
@@ -94,9 +91,6 @@ ExtraSpacing:
   Enabled: false
 
 DateTime:
-  Enabled: false
-
-SymbolArray:
   Enabled: false
 
 SymbolProc:

--- a/features/step_definitions/brief_response_steps.rb
+++ b/features/step_definitions/brief_response_steps.rb
@@ -13,9 +13,7 @@ Given /^I am logged in as the buyer of a (closed|live) brief$/ do |status|
   @lot_slug = matched_brief['lotSlug']
   @framework_slug = matched_brief['frameworkSlug']
   @buyer_user.update('password' => ENV["DM_PRODUCTION_BUYER_USER_PASSWORD"])
-  steps %Q{
-    Given that buyer is logged in
-  }
+  steps "Given that buyer is logged in"
 end
 
 Given /^I am logged in as the buyer of a closed brief with responses$/ do
@@ -25,9 +23,7 @@ Given /^I am logged in as the buyer of a closed brief with responses$/ do
   @framework_slug = @brief['frameworkSlug']
   @buyer_user = @brief['users'][0]
   @buyer_user.update('password' => ENV["DM_PRODUCTION_BUYER_USER_PASSWORD"])
-  steps %Q{
-    Given that buyer is logged in
-  }
+  steps "Given that buyer is logged in"
 end
 
 Given /^I go to that brief page$/ do
@@ -72,16 +68,16 @@ end
 Given /^I publish an answer to a question$/ do
   @random_question_text = SecureRandom.hex
   @random_answer_text = SecureRandom.hex
-  steps %Q{
-      Then I enter '#{@random_question_text}' in the 'question' field
-      Then I enter '#{@random_answer_text}' in the 'answer' field
-      Then I click the 'Publish question and answer' button
+  steps %{
+    Then I enter '#{@random_question_text}' in the 'question' field
+    Then I enter '#{@random_answer_text}' in the 'answer' field
+    Then I click the 'Publish question and answer' button
   }
 end
 
 Then /^I see the published question and answer$/ do
-  steps %Q{
-      Then I see '#{@random_question_text}' in the 'Questions asked by suppliers' summary table
-      Then I see '#{@random_answer_text}' in the 'Questions asked by suppliers' summary table
+  steps %{
+    Then I see '#{@random_question_text}' in the 'Questions asked by suppliers' summary table
+    Then I see '#{@random_answer_text}' in the 'Questions asked by suppliers' summary table
   }
 end

--- a/features/step_definitions/direct_award_steps.rb
+++ b/features/step_definitions/direct_award_steps.rb
@@ -1,5 +1,5 @@
 When(/^I have created and saved a search called '(.*)'$/) do |search_name|
-  steps %Q{
+  steps %{
     Given I am on the /g-cloud/search?q=email+analysis+provider page
     And I click 'Save search'
     Then I am on the 'Choose where to save your search' page

--- a/features/step_definitions/login_steps.rb
+++ b/features/step_definitions/login_steps.rb
@@ -16,7 +16,7 @@ end
 
 Given /^I am logged in as (?:a|the) (production )?([\w\-]+) user$/ do |production, user_role|
   login_page = '/user/login'
-  steps %Q{
+  steps %{
     Given I have a #{production}#{user_role} user
     And I am on the #{login_page} page
     When I enter that user.emailAddress in the 'Email address' field
@@ -60,7 +60,7 @@ end
 Given /^that (supplier|buyer) is logged in$/ do |user_role|
   user = user_role == 'supplier' ? @supplier_user : @buyer_user
 
-  steps %Q{
+  steps %{
     And I am on the /user/login page
     When I enter '#{user['emailAddress']}' in the 'Email address' field
     And I enter '#{user['password']}' in the 'Password' field
@@ -71,7 +71,7 @@ end
 
 When /^The wrong password is entered (\d+) times for that user$/ do |tries|
   tries.to_i.times do |n|
-    steps %Q{
+    steps %{
       Given I am on the /user/login page
       When I enter '#{@user['emailAddress']}' in the 'Email address' field
       And I enter 'the_wrong_password' in the 'Password' field
@@ -81,7 +81,7 @@ When /^The wrong password is entered (\d+) times for that user$/ do |tries|
 end
 
 Then /^That user can not log in using their correct password$/ do
-  steps %Q{
+  steps %{
     Given I am on the /user/login page
     When I enter '#{@user['emailAddress']}' in the 'Email address' field
     And I enter '#{@user['password']}' in the 'Password' field

--- a/features/step_definitions/opportunities_steps.rb
+++ b/features/step_definitions/opportunities_steps.rb
@@ -61,7 +61,7 @@ Then (/^I see no results$/) do
 end
 
 Then /^I see the details of the brief match what was published$/ do
-  steps %Q{
+  steps %{
     Given I see the 'Overview' summary table filled with:
       | field                        | value                         |
       | Specialist role              | Developer                     |

--- a/features/step_definitions/requirements_steps.rb
+++ b/features/step_definitions/requirements_steps.rb
@@ -95,7 +95,7 @@ When "I answer all summary questions with:" do |table|
 end
 
 When "I answer all summary questions" do
-  steps %Q{
+  steps %{
      When I answer all summary questions with:
        | field | value |
   }

--- a/features/step_definitions/supplier_steps.rb
+++ b/features/step_definitions/supplier_steps.rb
@@ -2,7 +2,7 @@ Given 'There is at least one framework that can be applied to' do
   response = call_api(:get, "/frameworks")
   expect(response.code).to eq(200), _error(response, "Failed getting frameworks")
   frameworks = JSON.parse(response.body)['frameworks']
-  frameworks.delete_if { |framework| not ['coming', 'open'].include?(framework['status']) }
+  frameworks.delete_if { |framework| not %w[coming open].include?(framework['status']) }
   if frameworks.empty?
     puts 'SKIPPING as there are no coming or open frameworks'
     skip_this_scenario
@@ -13,7 +13,7 @@ Given 'There is at most one framework that can be applied to' do
   response = call_api(:get, "/frameworks")
   expect(response.code).to eq(200), _error(response, "Failed getting frameworks")
   frameworks = JSON.parse(response.body)['frameworks']
-  frameworks.delete_if { |framework| not ['coming', 'open'].include?(framework['status']) }
+  frameworks.delete_if { |framework| not %w[coming open].include?(framework['status']) }
   if frameworks.length > 1
     puts 'SKIPPING as there is more than one framework coming or open'
     skip_this_scenario
@@ -21,7 +21,7 @@ Given 'There is at most one framework that can be applied to' do
 end
 
 Given /^that(?: (micro|small|medium|large))? supplier has applied to be on that framework$/ do |organisation_size|
-  organisation_size ||= ['micro', 'small', 'medium', 'large'].sample
+  organisation_size ||= %w[micro small medium large].sample
   submit_supplier_declaration(@framework['slug'], @supplier["id"], 'status': 'complete', 'organisationSize': organisation_size, 'nameOfOrganisation': 'foobarbaz', 'primaryContactEmail': 'foo@bar.com')
 end
 

--- a/features/support/fixtures.rb
+++ b/features/support/fixtures.rb
@@ -7,10 +7,7 @@ module Fixtures
       supplierId: nil,
       frameworkSlug: nil,
       lot: 'digital-specialists',
-      developerLocations: [
-          "London",
-          "Scotland"
-        ],
+      developerLocations: %w[London Scotland],
       developerPriceMax: "200",
       developerPriceMin: "100",
       bespokeSystemInformation: true,
@@ -33,10 +30,7 @@ module Fixtures
         "Agile coaching"
       ],
       helpGovernmentImproveServices: true,
-      locations: [
-        "London",
-        "Scotland"
-      ],
+      locations: %w[London Scotland],
       openStandardsPrinciples: true,
     }
   end
@@ -49,10 +43,7 @@ module Fixtures
       frameworkSlug: nil,
       lot: 'user-research-participants',
       anonymousRecruitment: true,
-      locations: [
-        "London",
-        "Scotland"
-      ],
+      locations: %w[London Scotland],
       manageIncentives: true,
       recruitFromList: true,
       recruitMethods: [

--- a/features/support/form_helpers.rb
+++ b/features/support/form_helpers.rb
@@ -169,7 +169,7 @@ module FormHelper
     values = Hash.new { |h, k| h[k] = {} }
 
     results.each do |result|
-      if [:checkbox, :radio].include? field_type(result)
+      if %i[checkbox radio].include? field_type(result)
 
         label = find("label[for='#{result[:id]}']").text
 

--- a/features/support/helpers.rb
+++ b/features/support/helpers.rb
@@ -108,13 +108,13 @@ def urls_are_equal(url1, url2)
   end
   url1 = URI::parse(url1)
   url2 = URI::parse(url2)
-  [:scheme, :host, :path].each do |key|
+  %i[scheme host path].each do |key|
     if url1.send(key) != url2.send(key)
       return false
     end
   end
   # query and fragment parameters can appear in any order
-  [:query, :fragment].each do |key|
+  %i[query fragment].each do |key|
     if url1.send(key)
       if !url2.send(key)
         return false


### PR DESCRIPTION
The following is a convention enforced by the govuk linter and used around GDS. There is no technical reasoning behind it.

## Use literal array syntax

~~['comma', 'separated', 'strings']~~ → %w[space separated strings]

~~[:comma, :separated, :symbols]~~ → %s[space separated symbols]

~~[1, 2, 3]~~ → %i[1 2 3]


Modifier | Meaning
-- | --
%q[ ] | Non-interpolated String (except for \\ \[ and \])
%Q[ ] | Interpolated String (default)
%r[ ] | Interpolated Regexp (flags can appear after the closing delimiter)
%i[ ] | Non-interpolated Array of symbols, separated by whitespace (after Ruby 2.0)
%I[ ] | Interpolated Array of symbols, separated by whitespace (after Ruby 2.0)
%w[ ] | Non-interpolated Array of words, separated by whitespace
%W[ ] | Interpolated Array of words, separated by whitespace
%x[ ] | Interpolated shell command
%s[ ] | Non-interpolated symbol



## Use bare % literals string interpolation

The default percent literal for string interpolation is `Q` so it is not required explicitly.

~~%Q{string}~~ → %{string}