### PR TITLE
Set default notify key

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,10 @@ run-parallel: setup
 build-report:
 	report_builder -s 'reports' -o 'reports/index' -f html -t features,errors -T '<img src="https://media.giphy.com/media/sIIhZliB2McAo/giphy.gif">Functional Test Results'
 
-setup: install clean
+env:
+  DM_NOTIFY_API_KEY := $(if ${DM_NOTIFY_API_KEY}, ${DM_NOTIFY_API_KEY}, $(shell ${DM_CREDENTIALS_REPO}/sops-wrapper -d ${DM_CREDENTIALS_REPO}/vars/preview.yaml | grep notify_api_key | sed 's/^.* //'))
+
+setup: install clean env
 	@echo "Environment:" ${DM_ENVIRONMENT}
 	mkdir -p reports/
 
@@ -32,11 +35,10 @@ clean:
 lint:
 	bundle exec govuk-lint-ruby features --diff
 
-docker-up:
+docker-up: env
 	$(eval export AWS_ACCESS_KEY_ID=$(shell aws configure get aws_access_key_id))
 	$(eval export AWS_SECRET_ACCESS_KEY=$(shell aws configure get aws_secret_access_key))
 	$(eval export DM_MANDRILL_API_KEY=$(shell ${DM_CREDENTIALS_REPO}/sops-wrapper -d ${DM_CREDENTIALS_REPO}/vars/preview.yaml | grep mandrill_key | sed 's/^.* //'))
-	$(eval export DM_NOTIFY_API_KEY=$(shell ${DM_CREDENTIALS_REPO}/sops-wrapper -d ${DM_CREDENTIALS_REPO}/vars/preview.yaml | grep notify_api_key | sed 's/^.* //'))
 	$(if ${AWS_ACCESS_KEY_ID},,$(error AWS_ACCESS_KEY_ID not set.))
 	$(if ${AWS_SECRET_ACCESS_KEY},,$(error AWS_SECRET_ACCESS_KEY not set.))
 	$(if ${DM_MANDRILL_API_KEY},,$(error DM_MANDRILL_API_KEY not set.))

--- a/features/admin/invite_admin_user.feature
+++ b/features/admin/invite_admin_user.feature
@@ -1,6 +1,7 @@
 @invite-admin-user
 Feature: Admin manager can manage users
 
+@notify
 Scenario Outline: Admin Manager user can log in and invite admin users
   Given I am logged in as the production <role> user
   And I click the 'View and edit admin accounts' link

--- a/features/admin/invite_supplier_contributor.feature
+++ b/features/admin/invite_supplier_contributor.feature
@@ -1,6 +1,7 @@
 @invite-supplier-contributor
 Feature: Invite a contributor to a supplier account
 
+@notify
 Scenario Outline: Correct users can invite a contributors to a supplier account
   Given I am logged in as the production <role> user
   And I have a supplier with:


### PR DESCRIPTION
 ## Summary
If DM_NOTIFY_API_KEY has not been defined, automatically decrypt
credentials (from DM_CREDENTIALS_REPO) and inject it. This should make
it easier to run tests locally - though you will still need to have
started your apps with this environment variable in place. Also adds the
`@notify` tag to two scenarios which were missing it.

This is kinda a strawman as it does mean that credentials will get decrypted every time (requiring 2fa input) even if you specify only a subset of the tests. Will this be faff/annoying?