### PR TITLE
Bump parser version to 2.5.0.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,7 +59,7 @@ GEM
     parallel (1.12.0)
     parallel_tests (2.15.0)
       parallel
-    parser (2.5.0.4)
+    parser (2.5.0.5)
       ast (~> 2.4.0)
     phantomjs (2.1.1.0)
     poltergeist (1.11.0)


### PR DESCRIPTION
The 2.5.0.4 version of the parser gem was removed from Rubygems. The author posted his reason why here:

https://github.com/whitequark/parser/issues/478#issuecomment-375930229