### PR TITLE
Remove doc_type from search result params

### DIFF
--- a/features/smoke-tests/public/live_reload.feature
+++ b/features/smoke-tests/public/live_reload.feature
@@ -1,6 +1,30 @@
 @live-reload
 Feature: Live reload search
 
+@skip-staging
+Scenario: Live reload search hitting enter should not cause a full page reload
+  Given I am on the homepage
+  And I click 'View Digital Outcomes and Specialists opportunities'
+  And I am on the 'Digital Outcomes and Specialists opportunities' page
+  Then I see the 'Clear filters' link with href 'digital-outcomes-and-specialists/opportunities'
+  And I set the page reload flag
+  When I enter 'Tea\n' in the 'search' field
+  Then I see that the page has not been reloaded
+  And I see the 'Clear filters' link with href '/digital-outcomes-and-specialists/opportunities?q=Tea%5Cn'
+
+@skip-staging
+Scenario: Live reload search button should not cause a full page reload
+  Given I am on the homepage
+  And I click 'View Digital Outcomes and Specialists opportunities'
+  And I am on the 'Digital Outcomes and Specialists opportunities' page
+  Then I see the 'Clear filters' link with href 'digital-outcomes-and-specialists/opportunities'
+  And I set the page reload flag
+  And I enter 'Tea' in the 'search' field
+  When I click the 'Search' button
+  Then I see that the page has not been reloaded
+  And I see the 'Clear filters' link with href '/digital-outcomes-and-specialists/opportunities?q=Tea'
+
+@skip-preview
 Scenario: Live reload search hitting enter should not cause a full page reload
   Given I am on the homepage
   And I click 'View Digital Outcomes and Specialists opportunities'
@@ -11,6 +35,7 @@ Scenario: Live reload search hitting enter should not cause a full page reload
   Then I see that the page has not been reloaded
   And I see the 'Clear filters' link with href '/digital-outcomes-and-specialists/opportunities?q=Tea%5Cn&doc_type=briefs'
 
+@skip-preview
 Scenario: Live reload search button should not cause a full page reload
   Given I am on the homepage
   And I click 'View Digital Outcomes and Specialists opportunities'


### PR DESCRIPTION
We no longer have a hidden field for `doc_type` for use with analytics. We are able to use the 'Destination Page' dimension against the 'Search Term' dimension filtering by either '/g-cloud/' or '/digital-outcomes-and-specialists/' which provides more reliable data.

Merge after:
- [x] https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/738

https://trello.com/c/8RzdZPsZ/393-buyer-frontend-search-page-doctype-parameter-is-broken-and-should-be-removed