### PR TITLE
Remove skip staging flag for live reload feature

### DIFF
--- a/features/smoke-tests/public/live_reload.feature
+++ b/features/smoke-tests/public/live_reload.feature
@@ -1,7 +1,6 @@
 @live-reload
 Feature: Live reload search
 
-@skip-staging
 Scenario: Live reload search hitting enter should not cause a full page reload
   Given I am on the homepage
   And I click 'View Digital Outcomes and Specialists opportunities'
@@ -12,7 +11,6 @@ Scenario: Live reload search hitting enter should not cause a full page reload
   Then I see that the page has not been reloaded
   And I see the 'Clear filters' link with href '/digital-outcomes-and-specialists/opportunities?q=Tea%5Cn'
 
-@skip-staging
 Scenario: Live reload search button should not cause a full page reload
   Given I am on the homepage
   And I click 'View Digital Outcomes and Specialists opportunities'
@@ -23,26 +21,3 @@ Scenario: Live reload search button should not cause a full page reload
   When I click the 'Search' button
   Then I see that the page has not been reloaded
   And I see the 'Clear filters' link with href '/digital-outcomes-and-specialists/opportunities?q=Tea'
-
-@skip-preview
-Scenario: Live reload search hitting enter should not cause a full page reload
-  Given I am on the homepage
-  And I click 'View Digital Outcomes and Specialists opportunities'
-  And I am on the 'Digital Outcomes and Specialists opportunities' page
-  Then I see the 'Clear filters' link with href 'digital-outcomes-and-specialists/opportunities'
-  And I set the page reload flag
-  When I enter 'Tea\n' in the 'search' field
-  Then I see that the page has not been reloaded
-  And I see the 'Clear filters' link with href '/digital-outcomes-and-specialists/opportunities?q=Tea%5Cn&doc_type=briefs'
-
-@skip-preview
-Scenario: Live reload search button should not cause a full page reload
-  Given I am on the homepage
-  And I click 'View Digital Outcomes and Specialists opportunities'
-  And I am on the 'Digital Outcomes and Specialists opportunities' page
-  Then I see the 'Clear filters' link with href 'digital-outcomes-and-specialists/opportunities'
-  And I set the page reload flag
-  And I enter 'Tea' in the 'search' field
-  When I click the 'Search' button
-  Then I see that the page has not been reloaded
-  And I see the 'Clear filters' link with href '/digital-outcomes-and-specialists/opportunities?q=Tea&doc_type=briefs'


### PR DESCRIPTION
After buyer frontend end is on preview this can be merged in

https://trello.com/c/8RzdZPsZ/393-buyer-frontend-search-page-doctype-parameter-is-broken-and-should-be-removed