### PR TITLE
Logical operator precedence

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,16 +12,10 @@ EmptyLineBetweenDefs:
 TrailingBlankLines:
   Enabled: false
 
-AndOr:
-  Enabled: false
-
 MethodCalledOnDoEndBlock:
   Enabled: false
 
 MultilineBlockChain:
-  Enabled: false
-
-MultilineIfThen:
   Enabled: false
 
 ParenthesesAroundCondition:

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -5,7 +5,7 @@ Then (/^I see that supplier in the list of suppliers$/) do
       # now refine with a much more precise test
       row_element.all(:css, "a").any? { |a_element|
         a_element[:href] =~ Regexp.new('^(.*\D)?' + "#{@supplier['id']}" + '(\D.*)?$')
-      } and row_element.all(:css, ".summary-item-field-first > span").any? { |span_element|
+      } && row_element.all(:css, ".summary-item-field-first > span").any? { |span_element|
         span_element.text == normalize_whitespace(@supplier['name'])
       }
     }.length

--- a/features/step_definitions/catalogue_steps.rb
+++ b/features/step_definitions/catalogue_steps.rb
@@ -15,7 +15,7 @@ When(/^I click a random result in the list of service results returned$/) do
 end
 
 Then (/^I (don't )?see a search result$/) do |negate|
-  if negate then
+  if negate
     expect(page).not_to have_selector(:css, "div.search-result")
   else
     expect(page).to have_selector(:css, "div.search-result")
@@ -30,14 +30,14 @@ Then (/^I see that service in the search results$/) do
       sr_element.all(:css, "h2 a").any? { |a_element|
         (
           a_element[:href] =~ Regexp.new('^(.*\D)?' + "#{@service['id']}" + '(\D.*)?$')
-        ) and (
+        ) && (
           a_element.text == normalize_whitespace(@service['serviceName'])
         )
-      } and sr_element.all(:css, "p.search-result-supplier").any? { |p_element|
+      } && sr_element.all(:css, "p.search-result-supplier").any? { |p_element|
         p_element.text == normalize_whitespace(@service['supplierName'])
-      } and sr_element.all(:css, "li.search-result-metadata-item,li.search-result-metadata-item-inline").any? { |li_element|
+      } && sr_element.all(:css, "li.search-result-metadata-item,li.search-result-metadata-item-inline").any? { |li_element|
         li_element.text == normalize_whitespace(@service['lotName'])
-      } and sr_element.all(:css, "li.search-result-metadata-item,li.search-result-metadata-item-inline").any? { |li_element|
+      } && sr_element.all(:css, "li.search-result-metadata-item,li.search-result-metadata-item-inline").any? { |li_element|
         li_element.text == normalize_whitespace(@service['frameworkName'])
       }
     }.length

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -46,7 +46,7 @@ Given /^I have a random g-cloud service from the API$/ do
   page_one = call_api(:get, "/services", params: params)
   expect(page_one.code).to eq(200)
   last_page_url = JSON.parse(page_one.body)['links']['last']
-  params[:page] = if last_page_url then
+  params[:page] = if last_page_url
                     1 + rand(CGI.parse(URI.parse(last_page_url).query)['page'][0].to_i)
                   else
                     1
@@ -78,7 +78,7 @@ Given /^I have a random (?:([a-z-]+) )?supplier from the API$/ do |metaframework
   end
   page_one = call_api(:get, "/suppliers", params: params)
   last_page_url = JSON.parse(page_one.body)['links']['last']
-  params[:page] = if last_page_url then
+  params[:page] = if last_page_url
                     1 + rand(CGI.parse(URI.parse(last_page_url).query)['page'][0].to_i)
                   else
                     1
@@ -99,7 +99,7 @@ Given /^I have a random dos brief from the API$/ do
   params = { status: "live,closed", framework: "digital-outcomes-and-specialists-2" }
   page_one = call_api(:get, "/briefs", params: params)
   last_page_url = JSON.parse(page_one.body)['links']['last']
-  params[:page] = if last_page_url then
+  params[:page] = if last_page_url
                     1 + rand(CGI.parse(URI.parse(last_page_url).query)['page'][0].to_i)
                   else
                     1
@@ -257,7 +257,7 @@ Then(/^I see the page's h1 ends in #{MAYBE_VAR}$/) do |term|
 end
 
 Then /I see #{MAYBE_VAR} as the value of the '(.*)' field$/ do |value, field|
-  if page.has_field?(field, type: 'radio', visible: :all) or page.has_field?(field, type: 'checkbox', visible: :all)
+  if page.has_field?(field, type: 'radio', visible: :all) || page.has_field?(field, type: 'checkbox', visible: :all)
     expect(first_field(field, checked: true).value).to eq(value)
   else
     expect(first_field(field).value).to eq(value)
@@ -350,7 +350,7 @@ Then /^I see an entry in the '(.*)' table with:$/ do |table_heading, table|
     # Get the row as an array of strings to compare with our expected row
     row_text_values = row.all('td').map { |td| td.text }
     # Ensure that the expected strings are in the correct place and that we skip anything with '<ANY>'
-    if expected_row.each_with_index.map { |expected_value, expected_index| expected_value == '<ANY>' or row_text_values[expected_index] == expected_value }.all?
+    if expected_row.each_with_index.map { |expected_value, expected_index| (expected_value == '<ANY>') || (row_text_values[expected_index] == expected_value) }.all?
       match = true
       break
     end

--- a/features/step_definitions/supplieraz_steps.rb
+++ b/features/step_definitions/supplieraz_steps.rb
@@ -1,6 +1,6 @@
 When(/^I click the first letter of that supplier\.name$/) do
   # This step is hardcoded as we need to add a small exception for cases where the first character is non-alphabetic
-  if ('a'..'z').include? @supplier['name'][0].downcase then
+  if ('a'..'z').include? @supplier['name'][0].downcase
     step "I click '#{@supplier['name'][0].upcase}' link"
   end
 end
@@ -13,7 +13,7 @@ When(/^I click that specific supplier$/) do
     # now refine with a much more precise test
     (
       a_element[:href] =~ Regexp.new('^(.*\D)?' + "#{@supplier['id']}" + '(\D.*)?$')
-    ) and (
+    ) && (
       a_element.text == normalize_whitespace(@supplier['name'])
     )
   }
@@ -26,7 +26,7 @@ Then(/^I do not see any suppliers that don't begin with that letter$/) do
   supplier_links.each { |element|
     expect(element.text[0].upcase).to eq(@letter)
   }
-  if supplier_links.length == 0 then
+  if supplier_links.length == 0
     puts "(but no suppliers were found)"
   end
 end

--- a/features/support/api_helpers.rb
+++ b/features/support/api_helpers.rb
@@ -298,7 +298,7 @@ def create_live_service(framework_slug, lot_slug, supplier_id, role = nil)
   service_data['services']['supplierId'] = supplier_id
   service_data['services']['frameworkSlug'] = framework_slug
 
-  if lot_slug == 'digital-specialists' and role
+  if (lot_slug == 'digital-specialists') && role
     # Override the specialist role from the fixture by removing the old developer keys and adding keys
     # for the new role using the original developer values
     service_data['services']["#{role}Locations".to_sym] = service_data['services'].delete(:developerLocations)
@@ -373,7 +373,7 @@ def get_or_create_user(custom_user_data)
     @user = JSON.parse(response.body)["users"]
     return @user
   end
-  if custom_user_data["email_address"] != nil or custom_user_data["supplier_id"] != nil
+  if (custom_user_data["email_address"] != nil) || (custom_user_data["supplier_id"] != nil)
     response = call_api(
       :get,
       "/users",

--- a/features/support/form_helpers.rb
+++ b/features/support/form_helpers.rb
@@ -8,7 +8,7 @@ module FormHelper
       :checkbox
     elsif el[:type] == 'radio'
       :radio
-    elsif el[:type] == 'text' and el.matches_css? 'div.input-list input'
+    elsif (el[:type] == 'text') && el.matches_css?('div.input-list input')
       # TODO condition is expensive.... can we cache?
       :list
     else
@@ -57,7 +57,7 @@ module FormHelper
     results = all_fields(
       locator, options
     ).select { |el|
-      el.visible? or get_parent_label(el).visible?
+      el.visible? || get_parent_label(el).visible?
     }.map { |v|
       v[:name]
     }
@@ -70,7 +70,7 @@ module FormHelper
     # takes either a single string or array of strings
 
     locator, options = nil, locator if locator.is_a? Hash
-    raise "Must pass a hash containing 'with'" if not options.is_a?(Hash) or not options.has_key?(:with)
+    raise "Must pass a hash containing 'with'" if (not options.is_a?(Hash)) || (not options.has_key?(:with))
     with = [options.delete(:with)].flatten
     result = all_fields(locator, options)
 
@@ -97,7 +97,7 @@ module FormHelper
     # takes either a single string or array of strings
 
     locator, options = nil, locator if locator.is_a? Hash
-    raise "Must pass a hash containing 'with'" if not options.is_a?(Hash) or not options.has_key?(:with)
+    raise "Must pass a hash containing 'with'" if (not options.is_a?(Hash)) || (not options.has_key?(:with))
     with = [options.delete(:with)].flatten
     result = all(:field, locator, options)
 
@@ -120,7 +120,7 @@ module FormHelper
     # Like fill_in but will work with checkboxes, radios, and input lists too.
 
     locator, options = nil, locator if locator.is_a? Hash
-    raise "Must pass a hash containing 'with'" if not options.is_a?(Hash) or not options.has_key?(:with)
+    raise "Must pass a hash containing 'with'" if (not options.is_a?(Hash)) || (not options.has_key?(:with))
     with = options.delete(:with)
 
     result = all_fields(locator, options)
@@ -204,7 +204,7 @@ module FormHelper
     maybe_within do
       find_fields.each do |name|
 
-        values[name] = (with[name] or random_for name)
+        values[name] = (with[name] || random_for(name))
 
         fill_field name, with: values[name]
       end


### PR DESCRIPTION
Ruby's `and` and `or` are not the same as Python's.

```
a = true and false
a => true

a = true && false
a => false
```

This is because of operator [precedence](https://ruby-doc.org/core-2.3.1/doc/syntax/precedence_rdoc.html).

You might see `and` and `or` used like so:

`do_something_awesome or raise RuntimeError "All the awesome is gone"`

Though quite often the above is written as:

`raise RuntimeError "All the awesome is gone" unless do_something_awesome`

`then` is also usually not used in conditional statements.