### PR TITLE
catalogue smoke tests: too many search results fix

### DIFF
--- a/features/smoke-tests/buyer/catalogue.feature
+++ b/features/smoke-tests/buyer/catalogue.feature
@@ -33,8 +33,8 @@ Scenario: User is able to search by service id and have result returned.
   And I wait for the page to reload
   Then I see that service.id in the search summary text
   And I see that service.id as the value of the 'q' field
-  And I see that service in the search results
-  When I click a link with text that service.serviceName
+  When I continue clicking 'Next' until I see that service in the search results
+  And I click a link with text that service.serviceName in that search_result
   Then I am on that service.serviceName page
 
 Scenario: User is able to search by service name and have result returned.
@@ -44,8 +44,8 @@ Scenario: User is able to search by service name and have result returned.
   And I wait for the page to reload
   Then I see that quoted service.serviceName in the search summary text
   And I see that quoted service.serviceName as the value of the 'q' field
-  And I see that service in the search results
-  When I click a link with text that service.serviceName
+  When I continue clicking 'Next' until I see that service in the search results
+  And I click a link with text that service.serviceName in that search_result
   Then I am on that service.serviceName page
 
 Scenario: User is able to navigate to service detail page via selecting the service from the search results
@@ -62,8 +62,8 @@ Scenario: User is able to search by keywords field on the search results page to
   And I wait for the page to reload
   Then I see that service.id in the search summary text
   And I see that service.id as the value of the 'q' field
-  And I see that service in the search results
-  When I click a link with text that service.serviceName
+  When I continue clicking 'Next' until I see that service in the search results
+  And I click a link with text that service.serviceName in that search_result
   Then I am on that service.serviceName page
 
 Scenario: User is able to click on a random category

--- a/features/step_definitions/catalogue_steps.rb
+++ b/features/step_definitions/catalogue_steps.rb
@@ -23,14 +23,18 @@ Then (/^I (don't )?see a search result$/) do |negate|
 end
 
 Then (/^I continue clicking #{MAYBE_VAR} until I see that service in the search results$/) do |next_link_label|
+  i = 1
   until search_results = CatalogueHelpers.get_service_search_results(page, @service)
     # ^^^ note assignment, not comparison here ^^^
+    i += 1
     page.click_link(next_link_label)
     # if there wasn't another matching "next" link we should have errored out above
   end
 
   expect(search_results.length).to eq(1)
   @search_result = search_results[0]
+
+  puts "Found service on page #{i}"
 end
 
 Then(/^I see #{MAYBE_VAR} in the search summary text$/) do |value|

--- a/features/step_definitions/catalogue_steps.rb
+++ b/features/step_definitions/catalogue_steps.rb
@@ -22,26 +22,15 @@ Then (/^I (don't )?see a search result$/) do |negate|
   end
 end
 
-Then (/^I see that service in the search results$/) do
-  # we do a broad match using xpath first
-  expect(
-    page.all(:xpath, "//*[@class='search-result'][.//h2//a[contains(@href, '#{@service['id']}')]]").find_all { |sr_element|
-      # now refine with a much more precise test
-      sr_element.all(:css, "h2 a").any? { |a_element|
-        (
-          a_element[:href] =~ Regexp.new('^(.*\D)?' + "#{@service['id']}" + '(\D.*)?$')
-        ) && (
-          a_element.text == normalize_whitespace(@service['serviceName'])
-        )
-      } && sr_element.all(:css, "p.search-result-supplier").any? { |p_element|
-        p_element.text == normalize_whitespace(@service['supplierName'])
-      } && sr_element.all(:css, "li.search-result-metadata-item,li.search-result-metadata-item-inline").any? { |li_element|
-        li_element.text == normalize_whitespace(@service['lotName'])
-      } && sr_element.all(:css, "li.search-result-metadata-item,li.search-result-metadata-item-inline").any? { |li_element|
-        li_element.text == normalize_whitespace(@service['frameworkName'])
-      }
-    }.length
-  ).to eq(1)
+Then (/^I continue clicking #{MAYBE_VAR} until I see that service in the search results$/) do |next_link_label|
+  until search_results = CatalogueHelpers.get_service_search_results(page, @service)
+    # ^^^ note assignment, not comparison here ^^^
+    page.click_link(next_link_label)
+    # if there wasn't another matching "next" link we should have errored out above
+  end
+
+  expect(search_results.length).to eq(1)
+  @search_result = search_results[0]
 end
 
 Then(/^I see #{MAYBE_VAR} in the search summary text$/) do |value|

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -45,7 +45,7 @@ Given /^I have a random g-cloud service from the API$/ do
   params = { status: "published", framework: latest_g_cloud_slug }
   page_one = call_api(:get, "/services", params: params)
   expect(page_one.code).to eq(200)
-  last_page_url = JSON.parse(page_one.body)['links']['last']
+  last_page_url = JSON.parse(page_one.body).dig('links', 'last')
   params[:page] = if last_page_url
                     1 + rand(CGI.parse(URI.parse(last_page_url).query)['page'][0].to_i)
                   else

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -128,8 +128,11 @@ When /I click #{MAYBE_VAR} ?(button|link)?$/ do |button_link_name, elem_type|
   end
 end
 
-When /I click a link with text #{MAYBE_VAR}$/ do |link_text|
-  found_links = page.all(:xpath, "//a[normalize-space(string())=normalize-space(#{escape_xpath(link_text)})]")
+When /I click a link with text #{MAYBE_VAR}(?: in #{MAYBE_VAR})?$/ do |link_text, element|
+  expect(element).not_to be_a(String), "It's not yet decided what a plain String should mean in this context"
+
+  region = element || page
+  found_links = region.all(:xpath, "//a[normalize-space(string())=normalize-space(#{escape_xpath(link_text)})]")
   if found_links.length > 1
     puts "Warning: #{found_links.length} '#{link_text}' links found"
   end

--- a/features/step_definitions/supplieraz_steps.rb
+++ b/features/step_definitions/supplieraz_steps.rb
@@ -31,7 +31,8 @@ Then(/^I do not see any suppliers that don't begin with that letter$/) do
   end
 end
 
-Then (/^I see that supplier in one of the pages that follow from clicking '(.*)'$/) do |next_link_label|
+Then (/^I see that supplier in one of the pages that follow from clicking #{MAYBE_VAR}$/) do |next_link_label|
+  # vvv note assignment, not comparison here vvv
   until search_result = page.first(:xpath, "//*[@class='search-result'][.//h2//a[contains(@href, '#{@supplier['id']}')]]")
     page.click_link(next_link_label)
     # if there wasn't another matching "next" link we should have errored out above

--- a/features/step_definitions/supplieraz_steps.rb
+++ b/features/step_definitions/supplieraz_steps.rb
@@ -32,8 +32,8 @@ Then(/^I do not see any suppliers that don't begin with that letter$/) do
 end
 
 Then (/^I see that supplier in one of the pages that follow from clicking #{MAYBE_VAR}$/) do |next_link_label|
-  # vvv note assignment, not comparison here vvv
   until search_result = page.first(:xpath, "//*[@class='search-result'][.//h2//a[contains(@href, '#{@supplier['id']}')]]")
+    # ^^^ note assignment, not comparison here ^^^
     page.click_link(next_link_label)
     # if there wasn't another matching "next" link we should have errored out above
   end

--- a/features/step_definitions/supplieraz_steps.rb
+++ b/features/step_definitions/supplieraz_steps.rb
@@ -32,8 +32,10 @@ Then(/^I do not see any suppliers that don't begin with that letter$/) do
 end
 
 Then (/^I see that supplier in one of the pages that follow from clicking #{MAYBE_VAR}$/) do |next_link_label|
+  i = 1
   until search_result = page.first(:xpath, "//*[@class='search-result'][.//h2//a[contains(@href, '#{@supplier['id']}')]]")
     # ^^^ note assignment, not comparison here ^^^
+    i += 1
     page.click_link(next_link_label)
     # if there wasn't another matching "next" link we should have errored out above
   end
@@ -41,6 +43,8 @@ Then (/^I see that supplier in one of the pages that follow from clicking #{MAYB
   expect(
     search_result.first(:xpath, ".//h2[@class='search-result-title']/a").text
   ).to eq(normalize_whitespace(@supplier['name']))
+
+  puts "Found supplier on page #{i}"
 end
 
 Given(/I navigate to the list of '(.*)' page$/) do |value|

--- a/features/support/catalogue_helpers.rb
+++ b/features/support/catalogue_helpers.rb
@@ -7,4 +7,23 @@ module CatalogueHelpers
     page.all(:css, ".lot-filters ul ul :link")
   end
 
+  def self.get_service_search_results(page, service)
+    page.all(:xpath, "//*[@class='search-result'][.//h2//a[contains(@href, '#{service['id']}')]]").find_all { |sr_element|
+      # now refine with a much more precise test
+      sr_element.all(:css, "h2 a").any? { |a_element|
+        (
+          a_element[:href] =~ Regexp.new('^(.*\D)?' + "#{service['id']}" + '(\D.*)?$')
+        ) && (
+          a_element.text == normalize_whitespace(service['serviceName'])
+        )
+      } && sr_element.all(:css, "p.search-result-supplier").any? { |p_element|
+        p_element.text == normalize_whitespace(service['supplierName'])
+      } && sr_element.all(:css, "li.search-result-metadata-item,li.search-result-metadata-item-inline").any? { |li_element|
+        li_element.text == normalize_whitespace(service['lotName'])
+      } && sr_element.all(:css, "li.search-result-metadata-item,li.search-result-metadata-item-inline").any? { |li_element|
+        li_element.text == normalize_whitespace(service['frameworkName'])
+      }
+    }
+  end
+
 end


### PR DESCRIPTION
Trello https://trello.com/c/ytrH8YmI/247-make-gcloud-service-search-flakey-functional-test-more-permissive

A few small improvements made here, but chiefly what I did was to make the test page through the results until the desired service is found (or we run out of "next" buttons). This way we're testing the paging functionality too.