### PR TITLE
Allow ambiguous links

### DIFF
--- a/features/admin/deactivate_supplier_user.feature
+++ b/features/admin/deactivate_supplier_user.feature
@@ -16,7 +16,7 @@ Scenario Outline: Correct users can deactivate and reactivate a supplier's contr
   And I click the 'Edit supplier accounts or view services' link
   And I enter 'DM Functional Test Supplier' in the 'Find a supplier by name' field
   And I click the 'find_supplier_by_name_search' button
-  And I click the summary table 'Users' link for 'DM Functional Test Supplier'
+  And I click a summary table 'Users' link for 'DM Functional Test Supplier'
   When I click the summary table 'Deactivate' button for 'DM Functional Test Supplier User #1'
   Then I see an entry in the 'Users' table with:
     | Name                                | Email address        | Last login  | Pwd changed | Locked |
@@ -35,7 +35,7 @@ Scenario Outline: Correct users can view but not deactivate suppliers users
   And I click the '<link-name>' link
   And I enter 'DM Functional Test Supplier' in the 'Find a supplier by name' field
   And I click the 'find_supplier_by_name_search' button
-  When I click the summary table 'Users' link for 'DM Functional Test Supplier'
+  When I click a summary table 'Users' link for 'DM Functional Test Supplier'
   Then I don't see the 'Deactivate' button
   And I see an entry in the 'Users' table with:
     | Name                                | Email address        | Last login  | Pwd changed | Locked | Status |

--- a/features/admin/invite_supplier_contributor.feature
+++ b/features/admin/invite_supplier_contributor.feature
@@ -7,7 +7,7 @@ Scenario Outline: Correct users can invite a contributors to a supplier account
     | name          | DM Functional Test Supplier 1 |
   And I click the 'Edit supplier accounts or view services' link
   And I enter 'DM Functional Test Supplier 1' in the 'supplier_name_prefix' field and click its associated 'Search' button
-  And I click the summary table 'Users' link for 'DM Functional Test Supplier 1'
+  And I click a summary table 'Users' link for 'DM Functional Test Supplier 1'
   When I enter 'simulate-delivered@notifications.service.gov.uk' in the 'Email address' field
   And I click the 'Send invitation' button
   Then I see a success banner message containing 'User invited'

--- a/features/admin/update_supplier_name.feature
+++ b/features/admin/update_supplier_name.feature
@@ -8,13 +8,13 @@ Scenario Outline: Correct users can edit a supplier name
   And I click the '<link-name>' link
   And I enter 'DM Functional Test Supplier' in the 'Find a supplier by name' field
   And I click the 'find_supplier_by_name_search' button
-  And I click the summary table 'Change name' link for 'DM Functional Test Supplier'
+  And I click a summary table 'Change name' link for 'DM Functional Test Supplier'
   When I enter 'functional-test-new-name' in the 'New name' field
   And I click the 'Save' button
   Then I see an entry in the 'Suppliers' table with:
     | Name                     | Change name | Users | Services |
     | functional-test-new-name | Change name | Users | Services |
-  When I click the summary table 'Change name' link for 'functional-test-new-name'
+  When I click a summary table 'Change name' link for 'functional-test-new-name'
   And I enter 'DM Functional Test Supplier' in the 'New name' field
   And I click the 'Save' button
   Then I see an entry in the 'Suppliers' table with:

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -307,6 +307,21 @@ When /I click the summary table '(.*)' (link|button) for '(.*)'$/ do |link_name,
   edit_link.click
 end
 
+When /I click a summary table '(.*)' (link|button) for '(.*)'$/ do |link_name, elem_type, field_to_edit|
+  case elem_type
+    when 'link'
+      edit_link = page.all(:xpath, "//tr/*/span[normalize-space(text()) = '#{field_to_edit}']/../..//a[contains(normalize-space(text()), '#{link_name}')]")
+    else
+      edit_link = page.all(:xpath, "//tr/*/span[normalize-space(text()) = '#{field_to_edit}']/../..//input[normalize-space(@value) = '#{link_name}']")
+  end
+
+  if edit_link.length > 1
+    puts "Warning: #{edit_link.length} '#{link_name}' links found"
+  end
+
+  edit_link[0].click
+end
+
 When /I update the value of '(.*)' to '(.*)' using the summary table '(.*)' link(?: and the '(.*)' button)?/ do |field_to_edit, new_value, link_name, button_name|
   summary_page = current_url
   button_name ||= "Save and continue"


### PR DESCRIPTION
 ## Summary
Some of our functional tests have been failing on staging due to
ambiguous link text when trying to test admin users disabling supplier
accounts. This updates the tests to allow ambiguous matches and simply
pick the first item from the list to work on.