### PR TITLE
Set supplier org size on supplier instead of declaration

### DIFF
--- a/features/step_definitions/supplier_steps.rb
+++ b/features/step_definitions/supplier_steps.rb
@@ -36,7 +36,8 @@ end
 
 Given /^that(?: (micro|small|medium|large))? supplier has applied to be on that framework$/ do |organisation_size|
   organisation_size ||= %w[micro small medium large].sample
-  submit_supplier_declaration(@framework['slug'], @supplier["id"], 'status': 'complete', 'organisationSize': organisation_size, 'nameOfOrganisation': 'foobarbaz', 'primaryContactEmail': 'foo.bar@example.com')
+  update_supplier(@supplier["id"], 'organisationSize': organisation_size)
+  submit_supplier_declaration(@framework['slug'], @supplier["id"], 'status': 'complete', 'nameOfOrganisation': 'foobarbaz', 'primaryContactEmail': 'foo.bar@example.com')
 end
 
 Given 'we accept that suppliers application to the framework' do

--- a/features/support/api_helpers.rb
+++ b/features/support/api_helpers.rb
@@ -268,6 +268,16 @@ def create_supplier(custom_supplier_data = {})
   JSON.parse(response.body)['suppliers']
 end
 
+def update_supplier(supplier_id, data)
+  response = call_api(
+    :post,
+    "/suppliers/#{supplier_id}",
+    payload: { updated_by: "functional tests", suppliers: data }
+  )
+  expect(response.code).to eq(200), _error(response, "Failed to update supplier")
+  JSON.parse(response.body)['suppliers']
+end
+
 def create_live_service(framework_slug, lot_slug, supplier_id, role = nil)
   # Create a 15 digit service ID, miniscule clash risk
   start = 10 ** 14


### PR DESCRIPTION
We now use the org size from the supplier object when serializing
brief-responses. If a supplier doesn't have their org size set (which
they have to to be able to apply to a framework), we see errors in the
frontend.

This update moves setting the org size from the declaration to the supplier.


<img width="1440" alt="screen shot 2018-04-26 at 18 21 44" src="https://user-images.githubusercontent.com/13836290/39321424-e878f1f0-497e-11e8-987c-fcf4fe851178.png">
