### PR TITLE
Logged in users can change their password

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Technology wise it is a Ruby project using:
 - [Capybara](https://github.com/jnicklas/capybara)
 - [Bundler](http://bundler.io/)
 
-## Bootstraping the project on Mac
+## Bootstrapping the project on Mac
 
 This installation assumes you're using [Homebrew](http://brew.sh/) and Ruby
 installed by Homebrew. We expect you to have [rbenv](https://github.com/rbenv/rbenv)
@@ -79,6 +79,28 @@ applications are running the functional tests can be run with
 `make run`
 
 (or you can substitute `local` with the name of whatever `config/*.sh` environment file you're using.
+
+#### Using Notify in functional tests
+
+If your scenario includes sending a Notify email, you can temporarily set a sandbox `DM_NOTIFY_API_KEY` in the app
+config for that scenario.
+
+For example, in the `config.py` for the scenario's frontend app:
+
+```
+class Development(Config):
+    ...
+
+    # DM_NOTIFY_API_KEY = "not_a_real_key-00000000-fake-uuid-0000-000000000000"
+    DM_NOTIFY_API_KEY = "my-sandbox-api-key-that-I-set-up-in-the-Notify-dashboard"
+
+```
+
+This should match the setting in your `local.sh` config file.
+
+This will allow the functional tests to assert that an email has arrived in the Notify sandbox.
+
+Remember not to commit the change to `config.py`!
 
 ## Linting
 

--- a/features/user/change_password.feature
+++ b/features/user/change_password.feature
@@ -1,0 +1,17 @@
+@password_change
+Feature: Password change
+
+Background:
+  Given I have a supplier user
+  And that supplier is logged in
+  And I am on the /suppliers page
+
+Scenario: Supplier user can change their password
+  When I click 'Change your password'
+  Then I am on the 'Change your password' page
+  When I enter that user.password in the 'Old password' field
+  And I enter that user.password in the 'New password' field
+  And I enter that user.password in the 'Confirm new password' field
+  And I click 'Save changes' button
+  Then I see a success banner message containing 'You have successfully changed your password.'
+  And I am on the /suppliers page

--- a/features/user/change_password.feature
+++ b/features/user/change_password.feature
@@ -1,4 +1,4 @@
-@password_change @skip-staging
+@password_change @notify @skip-staging
 Feature: Password change
 Background:
 
@@ -13,6 +13,9 @@ Scenario Outline: Logged in user can change their password
   And I click 'Save changes' button
   Then I see a success banner message containing 'You have successfully changed your password.'
   And I am on the <dashboard_url> page
+  And I receive a 'change-password-alert' email for that user.emailAddress
+  And I click the link in that email
+  Then I am on the 'Reset password' page
 
   Examples:
     | role     |  dashboard_url |
@@ -31,6 +34,9 @@ Scenario Outline: Logged in admin user can change their password
   And I click 'Save changes' button
   Then I see a success banner message containing 'You have successfully changed your password.'
   And I am on the /admin page
+  And I receive a 'change-password-alert' email for that user.emailAddress
+  And I click the link in that email
+  Then I am on the 'Reset password' page
 
   Examples:
     | role                    |

--- a/features/user/change_password.feature
+++ b/features/user/change_password.feature
@@ -1,4 +1,4 @@
-@password_change @notify @skip-staging
+@password-change @notify @skip-staging
 Feature: Password change
 Background:
 
@@ -45,3 +45,16 @@ Scenario Outline: Logged in admin user can change their password
     | admin-ccs-category      |
     | admin-ccs-sourcing      |
     | admin-manager           |
+
+
+Scenario: User sees validation if they input incorrect old password
+  Given I am logged in as a supplier user
+  And I am on the /suppliers page
+  When I click 'Change your password'
+  Then I am on the 'Change your password' page
+  When I enter 'WrongPassword' in the 'Old password' field
+  And I enter that user.password in the 'New password' field
+  And I enter that user.password in the 'Confirm new password' field
+  And I click 'Save changes' button
+  Then I am on the 'Change your password' page
+  And I see a validation message containing 'Make sure you’ve entered the right password.'

--- a/features/user/change_password.feature
+++ b/features/user/change_password.feature
@@ -18,3 +18,24 @@ Scenario Outline: Logged in user can change their password
     | role     |  dashboard_url |
     | buyer    |  /buyers       |
     | supplier |  /suppliers    |
+
+
+Scenario Outline: Logged in admin user can change their password
+  Given I am logged in as a production <role> user
+  And I am on the /admin page
+  When I click 'Change your password'
+  Then I am on the 'Change your password' page
+  When I enter that user.password in the 'Old password' field
+  And I enter that user.password in the 'New password' field
+  And I enter that user.password in the 'Confirm new password' field
+  And I click 'Save changes' button
+  Then I see a success banner message containing 'You have successfully changed your password.'
+  And I am on the /admin page
+
+  Examples:
+    | role                    |
+    | admin                   |
+    | admin-framework-manager |
+    | admin-ccs-category      |
+    | admin-ccs-sourcing      |
+    | admin-manager           |

--- a/features/user/change_password.feature
+++ b/features/user/change_password.feature
@@ -1,4 +1,4 @@
-@password_change
+@password_change @skip-staging
 Feature: Password change
 Background:
 

--- a/features/user/change_password.feature
+++ b/features/user/change_password.feature
@@ -1,12 +1,10 @@
 @password_change
 Feature: Password change
-
 Background:
-  Given I have a supplier user
-  And that supplier is logged in
-  And I am on the /suppliers page
 
-Scenario: Supplier user can change their password
+Scenario Outline: Logged in user can change their password
+  Given I am logged in as a <role> user
+  And I am on the <dashboard_url> page
   When I click 'Change your password'
   Then I am on the 'Change your password' page
   When I enter that user.password in the 'Old password' field
@@ -14,4 +12,9 @@ Scenario: Supplier user can change their password
   And I enter that user.password in the 'Confirm new password' field
   And I click 'Save changes' button
   Then I see a success banner message containing 'You have successfully changed your password.'
-  And I am on the /suppliers page
+  And I am on the <dashboard_url> page
+
+  Examples:
+    | role     |  dashboard_url |
+    | buyer    |  /buyers       |
+    | supplier |  /suppliers    |


### PR DESCRIPTION
Buyer, Supplier and Admin users should see a password change link on their dashboard.

Clicking the link goes to a Change Password form where the user must enter their old password, a new password and confirm the new password.

After the password has been successfully changed, the user is redirected back to their dashboard.