### PR TITLE
Change a step to look for admin email address dynamically, not statically

### DIFF
--- a/features/admin/access_a_service.feature
+++ b/features/admin/access_a_service.feature
@@ -20,7 +20,8 @@ Scenario: Admin with Service Manager role can edit, remove and publish a service
   When I click the 'Remove service' link
   Then I see a destructive banner message containing 'Are you sure you want to remove ‘Plant-based cloud hosting’?'
   When I click 'Remove'
-  Then I see a temporary-message banner message containing 'Removed by production-admin-ccs-category-user@example.gov.uk'
+  Then I see a temporary-message banner message containing 'Removed by '
+  And I see a temporary-message banner message containing 'that user.emailAddress'
   When I click 'Publish service'
   Then I see a destructive banner message containing 'Are you sure you want to publish ‘Plant-based cloud hosting’?'
   When I click 'Publish'


### PR DESCRIPTION
In the feature where we test admin users accessing supplier services
an error was introduced: one of the steps looked for a static
user email address in a message, but this email address changes
depending on the environment. So instead we are now asserting
contents of the message in two steps: one looks for "Removed by "
text while other dynamically looks for the email address.