### PR TITLE
Remove skip-staging flag from password change flow

### DIFF
--- a/features/user/change_password.feature
+++ b/features/user/change_password.feature
@@ -1,4 +1,4 @@
-@password-change @notify @skip-staging
+@password-change @notify
 Feature: Password change
 Background:
 


### PR DESCRIPTION
To be merged after password change flow (user, supplier, briefs and admin frontends) passes QA on preview and is out on staging.