### PR TITLE
Change supplier name to a findable substring

### DIFF
--- a/features/admin/update_supplier_name.feature
+++ b/features/admin/update_supplier_name.feature
@@ -9,12 +9,12 @@ Scenario Outline: Correct users can edit a supplier name
   And I enter 'DM Functional Test Supplier' in the 'Find a supplier by name' field
   And I click the 'find_supplier_by_name_search' button
   And I click a summary table 'Change name' link for 'DM Functional Test Supplier'
-  When I enter 'functional-test-new-name' in the 'New name' field
+  When I enter 'DM Functional Test Supplier Changed Name' in the 'New name' field
   And I click the 'Save' button
   Then I see an entry in the 'Suppliers' table with:
-    | Name                     | Change name | Users | Services |
-    | functional-test-new-name | Change name | Users | Services |
-  When I click a summary table 'Change name' link for 'functional-test-new-name'
+    | Name                                     | Change name | Users | Services |
+    | DM Functional Test Supplier Changed Name | Change name | Users | Services |
+  When I click a summary table 'Change name' link for 'DM Functional Test Supplier Changed Name'
   And I enter 'DM Functional Test Supplier' in the 'New name' field
   And I click the 'Save' button
   Then I see an entry in the 'Suppliers' table with:


### PR DESCRIPTION
Tech debt ticket: https://trello.com/c/FL8SGWyX/436-flaky-functional-tests-on-user-name

Some of the admin functional tests rely on the presence of a supplier with a name containing the string "DM Functional Test Supplier". The 'Update supplier name' scenario changed the supplier name to `functional-test-new-name` which meant flakiness if scenarios were run in parallel. 

The tech debt ticket mentions adding a hash to the name but I don't think that's necessary here.