### PR TITLE
Namespace supplier name

### DIFF
--- a/features/admin/deactivate_supplier_user.feature
+++ b/features/admin/deactivate_supplier_user.feature
@@ -3,28 +3,28 @@ Feature: Deactivate a supplier's contributor
 
 Background:
   Given I have a supplier with:
-    | name          | DM Functional Test Supplier |
+    | name          | DM Functional Test Supplier - Deactivate a suppliers contributor feature |
   And that supplier has a user with:
-    | name          | DM Functional Test Supplier User #1 |
-    | email_address | user-one@example.com                |
+    | name          | Deactivate a suppliers contributor feature User #1 |
+    | email_address | user-one@example.com                               |
   And that supplier has a user with:
-    | name          | DM Functional Test Supplier User #2 |
-    | email_address | user-two@example.com                |
+    | name          | Deactivate a suppliers contributor feature User #2 |
+    | email_address | user-two@example.com                               |
 
 Scenario Outline: Correct users can deactivate and reactivate a supplier's contributor
   Given I am logged in as the production <role> user
   And I click the 'Edit supplier accounts or view services' link
-  And I enter 'DM Functional Test Supplier' in the 'Find a supplier by name' field
+  And I enter 'DM Functional Test Supplier - Deactivate a suppliers contributor feature' in the 'Find a supplier by name' field
   And I click the 'find_supplier_by_name_search' button
-  And I click a summary table 'Users' link for 'DM Functional Test Supplier'
-  When I click the summary table 'Deactivate' button for 'DM Functional Test Supplier User #1'
+  And I click a summary table 'Users' link for 'DM Functional Test Supplier - Deactivate a suppliers contributor feature'
+  When I click the summary table 'Deactivate' button for 'Deactivate a suppliers contributor feature User #1'
   Then I see an entry in the 'Users' table with:
-    | Name                                | Email address        | Last login  | Pwd changed | Locked |
-    | DM Functional Test Supplier User #1 | user-one@example.com | <ANY>       | <ANY>       | No     |
-  When I click the summary table 'Activate' button for 'DM Functional Test Supplier User #1'
+    | Name                                               | Email address        | Last login  | Pwd changed | Locked |
+    | Deactivate a suppliers contributor feature User #1 | user-one@example.com | <ANY>       | <ANY>       | No     |
+  When I click the summary table 'Activate' button for 'Deactivate a suppliers contributor feature User #1'
   Then I see an entry in the 'Users' table with:
-    | Name                                | Email address        | Last login  | Pwd changed | Locked |
-    | DM Functional Test Supplier User #1 | user-one@example.com | <ANY>       | <ANY>       | No     |
+    | Name                                               | Email address        | Last login  | Pwd changed | Locked |
+    | Deactivate a suppliers contributor feature User #1 | user-one@example.com | <ANY>       | <ANY>       | No     |
 
   Examples:
     | role  |
@@ -33,16 +33,16 @@ Scenario Outline: Correct users can deactivate and reactivate a supplier's contr
 Scenario Outline: Correct users can view but not deactivate suppliers users
   Given I am logged in as the production <role> user
   And I click the '<link-name>' link
-  And I enter 'DM Functional Test Supplier' in the 'Find a supplier by name' field
+  And I enter 'DM Functional Test Supplier - Deactivate a suppliers contributor feature' in the 'Find a supplier by name' field
   And I click the 'find_supplier_by_name_search' button
-  When I click a summary table 'Users' link for 'DM Functional Test Supplier'
+  When I click a summary table 'Users' link for 'DM Functional Test Supplier - Deactivate a suppliers contributor feature'
   Then I don't see the 'Deactivate' button
   And I see an entry in the 'Users' table with:
-    | Name                                | Email address        | Last login  | Pwd changed | Locked | Status |
-    | DM Functional Test Supplier User #1 | user-one@example.com | <ANY>       | <ANY>       | No     | Active |
+    | Name                                               | Email address        | Last login  | Pwd changed | Locked | Status |
+    | Deactivate a suppliers contributor feature User #1 | user-one@example.com | <ANY>       | <ANY>       | No     | Active |
   And I see an entry in the 'Users' table with:
-    | Name                                | Email address        | Last login  | Pwd changed | Locked | Status |
-    | DM Functional Test Supplier User #2 | user-two@example.com | <ANY>       | <ANY>       | No     | Active |
+    | Name                                               | Email address        | Last login  | Pwd changed | Locked | Status |
+    | Deactivate a suppliers contributor feature User #2 | user-two@example.com | <ANY>       | <ANY>       | No     | Active |
 
   Examples:
     | role                    | link-name                   |
@@ -51,7 +51,7 @@ Scenario Outline: Correct users can view but not deactivate suppliers users
 
 Scenario Outline: Correct users cannot view suppliers users
   Given I am logged in as the production <role> user
-  When I am on the /admin/suppliers?supplier_name_prefix=DM+Functional+Test+Supplier page
+  When I am on the /admin/suppliers?supplier_name_prefix=DM+Functional+Test+Supplier+-+Deactivate+a+supplier's+contributor+feature page
   Then I don't see the 'Users' link
 
   Examples:

--- a/features/admin/invite_supplier_contributor.feature
+++ b/features/admin/invite_supplier_contributor.feature
@@ -4,10 +4,10 @@ Feature: Invite a contributor to a supplier account
 Scenario Outline: Correct users can invite a contributors to a supplier account
   Given I am logged in as the production <role> user
   And I have a supplier with:
-    | name          | DM Functional Test Supplier 1 |
+    | name          | DM Functional Test Supplier - Invite a contributor feature |
   And I click the 'Edit supplier accounts or view services' link
-  And I enter 'DM Functional Test Supplier 1' in the 'supplier_name_prefix' field and click its associated 'Search' button
-  And I click a summary table 'Users' link for 'DM Functional Test Supplier 1'
+  And I enter 'DM Functional Test Supplier - Invite a contributor feature' in the 'supplier_name_prefix' field and click its associated 'Search' button
+  And I click a summary table 'Users' link for 'DM Functional Test Supplier - Invite a contributor feature'
   When I enter 'simulate-delivered@notifications.service.gov.uk' in the 'Email address' field
   And I click the 'Send invitation' button
   Then I see a success banner message containing 'User invited'
@@ -18,7 +18,7 @@ Scenario Outline: Correct users can invite a contributors to a supplier account
 
 Scenario Outline: Prohibited user roles cannot manage supplier users
   Given I am logged in as the production <role> user
-  When I am on the /admin/suppliers?supplier_name_prefix=DM+Functional+Test+Supplier+1 page
+  When I am on the /admin/suppliers?supplier_name_prefix=DM+Functional+Test+Supplier+-+Invite+a+contributor+feature page
   Then I don't see the 'Users' link
 
   Examples:
@@ -28,8 +28,8 @@ Scenario Outline: Prohibited user roles cannot manage supplier users
 
 Scenario Outline: Prohibited user roles cannot invite users to a supplier
   Given I am logged in as the production <role> user
-  When I am on the /admin/suppliers?supplier_name_prefix=DM+Functional+Test+Supplier+1 page
-  And I click the summary table 'Users' link for 'DM Functional Test Supplier 1'
+  When I am on the /admin/suppliers?supplier_name_prefix=DM+Functional+Test+Supplier+-+Invite+a+contributor+feature page
+  And I click the summary table 'Users' link for 'DM Functional Test Supplier - Invite a contributor feature'
   Then I don't see the 'Send invitation' button
 
   Examples:

--- a/features/admin/update_supplier_name.feature
+++ b/features/admin/update_supplier_name.feature
@@ -4,22 +4,22 @@ Feature: Update supplier name
 Scenario Outline: Correct users can edit a supplier name
   Given I am logged in as the production <role> user
   And I have a supplier with:
-    | name          | DM Functional Test Supplier |
+    | name          | DM Functional Test Supplier - Update supplier name feature |
   And I click the '<link-name>' link
-  And I enter 'DM Functional Test Supplier' in the 'Find a supplier by name' field
+  And I enter 'DM Functional Test Supplier - Update supplier name feature' in the 'Find a supplier by name' field
   And I click the 'find_supplier_by_name_search' button
-  And I click a summary table 'Change name' link for 'DM Functional Test Supplier'
-  When I enter 'DM Functional Test Supplier Changed Name' in the 'New name' field
+  And I click a summary table 'Change name' link for 'DM Functional Test Supplier - Update supplier name feature'
+  When I enter 'DM Functional Test Supplier - Update supplier name feature - Changed Name' in the 'New name' field
   And I click the 'Save' button
   Then I see an entry in the 'Suppliers' table with:
-    | Name                                     | Change name | Users | Services |
-    | DM Functional Test Supplier Changed Name | Change name | Users | Services |
-  When I click a summary table 'Change name' link for 'DM Functional Test Supplier Changed Name'
-  And I enter 'DM Functional Test Supplier' in the 'New name' field
+    | Name                                                                      | Change name | Users | Services |
+    | DM Functional Test Supplier - Update supplier name feature - Changed Name | Change name | Users | Services |
+  When I click a summary table 'Change name' link for 'DM Functional Test Supplier - Update supplier name feature - Changed Name'
+  And I enter 'DM Functional Test Supplier - Update supplier name feature' in the 'New name' field
   And I click the 'Save' button
   Then I see an entry in the 'Suppliers' table with:
-    | Name                        | Change name | Users | Services |
-    | DM Functional Test Supplier | Change name | Users | Services |
+    | Name                                                       | Change name | Users | Services |
+    | DM Functional Test Supplier - Update supplier name feature | Change name | Users | Services |
 
   Examples:
     | role                    | link-name                               |
@@ -28,7 +28,7 @@ Scenario Outline: Correct users can edit a supplier name
 
 Scenario Outline: Correct users cannot update the supplier name
   Given I am logged in as the production <role> user
-  When I am on the /admin/suppliers?supplier_name_prefix=DM+Functional+Test+Supplier page
+  When I am on the /admin/suppliers?supplier_name_prefix=DM+Functional+Test+Supplier+-+Update+supplier+name+feature page
   Then I don't see the 'Change name' link
 
   Examples:


### PR DESCRIPTION
We were having issues with supplier names clashing when running tests in
parallel. One of the methods we use for creating suppliers does a
`get_or_create` and uses a supplier name as a prefix for the `get`. By
having very similar names we could get into a situation that a required
supplier would never be created, if a similar supplier was created
first.