### PR TITLE
Use unicode quotes rather than apostrophes

### DIFF
--- a/features/buyer/award_flow_requirements.feature
+++ b/features/buyer/award_flow_requirements.feature
@@ -40,7 +40,7 @@ Scenario: Award flow - Award a requirement to a winning supplier
   And I see a temporary-message banner message containing 'Value: £20,000'
   And I see a temporary-message banner message containing 'Company size'
 
-
+@skip-preview
 Scenario: Award Flow - Cancel requirements
 
   Given I choose 'No' radio button
@@ -57,12 +57,46 @@ Scenario: Award Flow - Cancel requirements
   And I see a temporary-message banner message containing 'The buyer cancelled this opportunity, for example because they no longer '
   And I see a temporary-message banner message containing 'have the budget. They may publish an updated version later.'
 
+@skip-staging
+Scenario: Award Flow - Cancel requirements
 
+  Given I choose 'No' radio button
+  And I click the 'Save and continue' button
+  Then I am on the 'Why didn’t you award a contract for %s?' page with brief 'title'
+
+  When I choose 'Your requirements have been cancelled' radio button
+  And I click the 'Update requirements' button
+  Then I am on the '%s' page with brief 'title'
+  And I see a success banner message containing 'updated'
+
+  When I go to that brief page
+  Then I see a temporary-message banner message containing 'This opportunity was cancelled'
+  And I see a temporary-message banner message containing 'The buyer cancelled this opportunity, for example because they no longer '
+  And I see a temporary-message banner message containing 'have the budget. They may publish an updated version later.'
+
+@skip-preview
 Scenario: Award flow - Mark requirements as unsuccessful
 
   Given I choose 'No' radio button
   And I click the 'Save and continue' button
   Then I am on the 'Why didn't you award a contract for %s?' page with brief 'title'
+
+  When I choose 'There were no suitable suppliers' radio button
+  And I click the 'Update requirements' button
+  Then I am on the '%s' page with brief 'title'
+  And I see a success banner message containing 'updated'
+
+  When I go to that brief page
+  Then I see a temporary-message banner message containing 'No suitable suppliers applied'
+  And I see a temporary-message banner message containing 'The buyer didn't award this contract because no suppliers met their '
+  And I see a temporary-message banner message containing 'requirements. They may publish an updated version later.'
+
+@skip-staging
+Scenario: Award flow - Mark requirements as unsuccessful
+
+  Given I choose 'No' radio button
+  And I click the 'Save and continue' button
+  Then I am on the 'Why didn’t you award a contract for %s?' page with brief 'title'
 
   When I choose 'There were no suitable suppliers' radio button
   And I click the 'Update requirements' button


### PR DESCRIPTION
 ## Summary
We generally prefer unicode right quotes (u+2019) over apostrophes. I've
updated this apostrophe in the briefs-frontend but we have functional
tests asserting this content, so this needs updating as well.

https://github.com/alphagov/digitalmarketplace-briefs-frontend/pull/109