### PR TITLE
Use `false` instead of `nil`

### DIFF
--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -407,7 +407,7 @@ end
 Then /^I (don't |)see '(.*?)'(?: or '(.*)')? text on the page/ do |negative, expected_text, alternative_expected_text|
   has_text = page.has_content?(expected_text)
 
-  has_alternative_text = nil
+  has_alternative_text = false
   if alternative_expected_text
     has_alternative_text = page.has_content?(alternative_expected_text)
   end


### PR DESCRIPTION
The step should check for `false` instead of `nil` to avoid an
assertion error in the negative case.