### PR TITLE
Make test go fast zoom zoom

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "capybara", "2.10.1"
+gem "capybara", "2.18.0"
 gem "capybara-screenshot", "1.0.14"
 gem "cucumber", "2.4.0"
 gem "govuk-lint", "3.7.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,17 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.4.0)
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
     ast (2.4.0)
     builder (3.2.2)
-    capybara (2.10.1)
+    capybara (2.18.0)
       addressable
-      mime-types (>= 1.16)
+      mini_mime (>= 0.1.3)
       nokogiri (>= 1.3.3)
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
-      xpath (~> 2.0)
+      xpath (>= 2.0, < 4.0)
     capybara-screenshot (1.0.14)
       capybara (>= 1.0, < 3)
       launchy
@@ -48,6 +49,7 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
+    mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     multi_json (1.12.1)
     multi_test (0.1.2)
@@ -71,9 +73,10 @@ GEM
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
-    rack (2.0.1)
-    rack-test (0.6.3)
-      rack (>= 1.0)
+    public_suffix (3.0.2)
+    rack (2.0.5)
+    rack-test (1.0.0)
+      rack (>= 1.0, < 3)
     rainbow (2.2.2)
       rake
     rake (11.3.0)
@@ -134,14 +137,14 @@ GEM
     websocket-driver (0.6.4)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
-    xpath (2.0.0)
-      nokogiri (~> 1.3)
+    xpath (3.1.0)
+      nokogiri (~> 1.8)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  capybara (= 2.10.1)
+  capybara (= 2.18.0)
   capybara-screenshot (= 1.0.14)
   cucumber (= 2.4.0)
   govuk-lint (= 3.7.0)

--- a/README.md
+++ b/README.md
@@ -201,3 +201,9 @@ Even if the test being written isn't expected to result in a Notify message (e.g
 used against Mailchimp or just stored in a declaration) it's still best to stick to this vetted list of email domains -
 you never know when someone's going to quietly add a new notification of an event, and it's quite useful to have a
 handle on what email addresses we're throwing about in general in case we get any other complaints from other services.
+
+### Debugging slow-running functional tests
+Capybara is a web testing framework designed to allow assertions against sites that dynamically load/display content. To do this, some of their selector/finder methods will look for elements/content, and retry over a given period if it's not visible immediately. This can cause test steps to pause for a second or two when we're not using the most appropriate selector (like a selector which looks for content _not_ being present if we don't expect it to be there, as opposed to using a selector that looks for content _being_ present, and then asserting the result is false).
+
+IF you run functional tests with the DM_DEBUG_SLOW_TESTS environment variable set, Capybara's synchronisation method will be monkeypatched to raise a SlowFinderError which will help debug where we might not be using the correct Capybara method for our 'happy' case so that we can easily find and change it to something more suitable.
+

--- a/features/buyer/requirements.feature
+++ b/features/buyer/requirements.feature
@@ -137,6 +137,7 @@ Scenario: Create user research participants
    And I don't see the 'Review and publish your requirements' link
 
 
+@copy-requirements
 Scenario Outline: Copy requirements
   Given I have a live digital-outcomes-and-specialists framework
   And I have a buyer user

--- a/features/smoke-tests/public/live_reload.feature
+++ b/features/smoke-tests/public/live_reload.feature
@@ -5,19 +5,19 @@ Scenario: Live reload search hitting enter should not cause a full page reload
   Given I am on the homepage
   And I click 'View Digital Outcomes and Specialists opportunities'
   And I am on the 'Digital Outcomes and Specialists opportunities' page
-  Then I see the 'Clear filters' link with href 'digital-outcomes-and-specialists/opportunities'
+  Then I wait to see the 'Clear filters' link with href 'digital-outcomes-and-specialists/opportunities'
   And I set the page reload flag
   When I enter 'Tea\n' in the 'search' field
   Then I see that the page has not been reloaded
-  And I see the 'Clear filters' link with href '/digital-outcomes-and-specialists/opportunities?q=Tea%5Cn'
+  And I wait to see the 'Clear filters' link with href '/digital-outcomes-and-specialists/opportunities?q=Tea%5Cn'
 
 Scenario: Live reload search button should not cause a full page reload
   Given I am on the homepage
   And I click 'View Digital Outcomes and Specialists opportunities'
   And I am on the 'Digital Outcomes and Specialists opportunities' page
-  Then I see the 'Clear filters' link with href 'digital-outcomes-and-specialists/opportunities'
+  Then I wait to see the 'Clear filters' link with href 'digital-outcomes-and-specialists/opportunities'
   And I set the page reload flag
   And I enter 'Tea' in the 'search' field
   When I click the 'Search' button
   Then I see that the page has not been reloaded
-  And I see the 'Clear filters' link with href '/digital-outcomes-and-specialists/opportunities?q=Tea'
+  And I wait to see the 'Clear filters' link with href '/digital-outcomes-and-specialists/opportunities?q=Tea'

--- a/features/step_definitions/framework_application_steps.rb
+++ b/features/step_definitions/framework_application_steps.rb
@@ -36,7 +36,7 @@ Then(/^I submit a service for each lot$/) do
     link = find_elements_by_xpath("//ul[@class='browse-list']//a")[index]
     link.click
     begin
-      click_on 'Add a service'
+      click_on 'Add a service', wait: false
     rescue Capybara::ElementNotFound => e
       answer_all_dos_lot_questions "Edit"
       answer_all_service_questions "Add"
@@ -44,11 +44,11 @@ Then(/^I submit a service for each lot$/) do
     else
       answer = fill_form
       merge_fields_and_print_answers(answer)
-      click_on 'Save and continue'
+      click_on 'Save and continue', wait: false
       answer_all_dos_lot_questions "Edit"
       answer_all_service_questions "Answer question"
       find_elements_by_xpath("//input[@value='Mark as complete']")[0].click
-      click_on "Back to application"
+      click_on "Back to application", wait: false
     end
 
     # turn on when debugging to make a screenshot when a service for a lot is submitted:

--- a/features/step_definitions/requirements_steps.rb
+++ b/features/step_definitions/requirements_steps.rb
@@ -5,17 +5,17 @@ end
 Given "I have created $type requirement" do |type|
   page.visit("#{dm_frontend_domain}")
 
-  click_on "Find #{type}"
+  click_on "Find #{type}", wait: false
 
   expect(page).to have_selector('h1', text: "Find #{type}")
 
-  click_on 'Create requirement'
+  click_on 'Create requirement', wait: false
 
   answers = fill_form
 
   @fields.merge! answers
 
-  click_on 'Save and continue'
+  click_on 'Save and continue', wait: false
 
   expect(page).to have_selector('h1', text: answers['title'])
 end
@@ -37,11 +37,11 @@ When "I answer the following questions:" do |table|
     expect(page).to have_selector(:xpath, expr, count: 0)
 
     # click the question name on the overview page (eg, "Location")
-    click_on question
+    click_on question, wait: false
 
     @fields.merge! fill_form
 
-    click_on 'Save and continue'
+    click_on 'Save and continue', wait: false
 
     expect(page).to have_selector(:xpath, expr, count: 1)
   }
@@ -65,7 +65,7 @@ When "I answer all summary questions with:" do |table|
 
   all('tr.summary-item-row').to_a.each_with_index do |row, index|
     within all('tr.summary-item-row')[index] do
-      click_on first('a').text
+      click_on first('a').text, wait: false
     end
 
     answer = fill_form with: with
@@ -74,7 +74,7 @@ When "I answer all summary questions with:" do |table|
 
     substitutions = find_substitutions
 
-    click_on 'Save and continue'
+    click_on 'Save and continue', wait: false
 
     within all('tr.summary-item-row')[index] do
       # Find the value in the summary table.

--- a/features/step_definitions/supplier_steps.rb
+++ b/features/step_definitions/supplier_steps.rb
@@ -20,7 +20,7 @@ Given 'There is at most one framework that can be applied to' do
   end
 end
 
-Given 'There is a framework that is open for applications' do
+Given 'there is a framework that is open for applications' do
   response = call_api(:get, "/frameworks")
   expect(response.code).to be(200), _error(response, "Failed getting frameworks")
   frameworks = JSON.parse(response.body)['frameworks']

--- a/features/supplier/supplier_applies_to_a_framework.feature
+++ b/features/supplier/supplier_applies_to_a_framework.feature
@@ -2,11 +2,11 @@
 Feature: Apply to an open framework
 
 Background:
-  Given There is a framework that is open for applications
+  Given there is a framework that is open for applications
   And I have a supplier user
   And that supplier is logged in
 
-Scenario: Supplier submits a framework declaration
+Scenario: Supplier submits a framework application
   Given I am on the /suppliers page
   When I start that framework application
   Then I am on the 'Apply to framework' page for that framework application

--- a/features/supplier/view_and_edit_g_cloud_services.feature
+++ b/features/supplier/view_and_edit_g_cloud_services.feature
@@ -54,6 +54,7 @@ Scenario: Supplier user can edit the features and benefits of a service
     | field                         | value                                                                                  |
     | Service features and benefits | Service features Feature 1 New Feature 2 Service benefits Benefit 1 Updated Benefit 2  |
 
+@file-upload
 Scenario: Supplier user can replace the service definition document
   When I click the top-level summary table 'Edit' link for the section 'Documents'
   Then I am on the 'Documents' page
@@ -62,6 +63,7 @@ Scenario: Supplier user can replace the service definition document
   Then I am on the 'Test cloud support service' page
   And I see a success banner message containing 'You’ve edited your service. The changes are now live on the Digital Marketplace.'
 
+@file-upload
 Scenario: Supplier user can not replace the service definition document with a non-pdf file
   When I click the top-level summary table 'Edit' link for the section 'Documents'
   Then I am on the 'Documents' page
@@ -70,6 +72,7 @@ Scenario: Supplier user can not replace the service definition document with a n
   Then I am on the 'Documents' page
   And I see a validation message containing 'Your document is not in an open format. Please save as an Open Document Format (ODF) or PDF/A (eg .pdf, .odt).'
 
+@file-upload
 Scenario: Supplier user can not replace the service definition document with a file over 5MB
   When I click the top-level summary table 'Edit' link for the section 'Documents'
   Then I am on the 'Documents' page

--- a/features/support/api_helpers.rb
+++ b/features/support/api_helpers.rb
@@ -255,7 +255,7 @@ def create_supplier(custom_supplier_data = {})
     contactInformation: [{
       contactName: random_string,
       email: random_string + "-supplier@example.com",
-      phoneNumber: '%010d' % rand(10 ** 11 -1),
+      phoneNumber: '%010d' % rand(10**11 - 1),
     }]
   }
   supplier_data.update(custom_supplier_data)
@@ -280,8 +280,8 @@ end
 
 def create_live_service(framework_slug, lot_slug, supplier_id, role = nil)
   # Create a 15 digit service ID, miniscule clash risk
-  start = 10 ** 14
-  last = 10 ** 15 - 1
+  start = 10**14
+  last = 10**15 - 1
   random_service_id = rand(start..last).to_s
 
   service_data = {

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,6 +1,7 @@
 require 'erb'
 require 'rspec'
 require 'nokogiri'
+require 'capybara'
 require 'capybara/cucumber'
 require 'capybara/poltergeist'
 require 'capybara-screenshot/cucumber'
@@ -70,3 +71,31 @@ end
 
 Capybara.asset_host = dm_frontend_domain
 Capybara.save_path = "reports/"
+
+if ENV['DM_DEBUG_SLOW_TESTS']
+  # Monkeypatch Capybara's synchronize method to let us catch places where we're using the 'wrong' kind of finder
+  # Capybara has waiting and non-waiting finders. If we use a waiting finder to look for text that isn't present, when we
+  # actually expect the text *not* to be there, our tests will run slower than they should.
+  # Sourced from https://github.com/ngauthier/capybara-slow_finder_errors (MIT licence).
+  module Capybara
+    class SlowFinderError < CapybaraError; end
+
+    module Node
+      class Base
+        def synchronize_with_timeout_error(*args, &block)
+          start_time = Time.now
+          synchronize_without_timeout_error(*args, &block)
+        rescue Capybara::ElementNotFound => e
+          seconds = args.first || Capybara.default_max_wait_time
+          if seconds > 0 && Time.now - start_time > seconds
+            raise SlowFinderError, "Timeout reached while running a *waiting* Capybara finder...perhaps you wanted to return immediately? Use a non-waiting Capybara finder. More info: http://blog.codeship.com/faster-rails-tests?utm_source=gem_exception"
+          end
+
+          raise
+        end
+        alias_method :synchronize_without_timeout_error, :synchronize
+        alias_method :synchronize, :synchronize_with_timeout_error
+      end
+    end
+  end
+end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -69,8 +69,13 @@ def dm_notify_api_key
   ENV['DM_NOTIFY_API_KEY']
 end
 
+def dm_custom_wait_time
+  5
+end
+
 Capybara.asset_host = dm_frontend_domain
 Capybara.save_path = "reports/"
+Capybara.default_max_wait_time = 0.05
 
 if ENV['DM_DEBUG_SLOW_TESTS']
   # Monkeypatch Capybara's synchronize method to let us catch places where we're using the 'wrong' kind of finder

--- a/features/support/form_helpers.rb
+++ b/features/support/form_helpers.rb
@@ -8,8 +8,7 @@ module FormHelper
       :checkbox
     elsif el[:type] == 'radio'
       :radio
-    elsif (el[:type] == 'text') && el.matches_css?('div.input-list input')
-      # TODO condition is expensive.... can we cache?
+    elsif (el[:type] == 'text') && el.matches_css?('div.input-list input', wait: false)
       :list
     elsif el[:type] == 'file'
       :file
@@ -24,7 +23,7 @@ module FormHelper
     (0..rand(3)).map { |i| SecureRandom.base64.gsub(/[+=\/]/, '') }.join
   end
 
-  def random_for(locator, options = {})
+  def random_for(locator, options = { wait: false })
     # Generate a suitable random value based on locator
 
     locator, options = nil, locator if locator.is_a? Hash
@@ -54,7 +53,7 @@ module FormHelper
     label && label.visible?
   end
 
-  def find_fields(locator = nil, options = {})
+  def find_fields(locator = nil, options = { wait: false })
     # Find all field names
     # If the inputs themselves aren't visible (ie, radios and checkboxes), verify that the parent labels are
     results = all_fields(
@@ -68,7 +67,7 @@ module FormHelper
     results.uniq
   end
 
-  def check_only(locator = nil, options = {})
+  def check_only(locator = nil, options = { wait: false })
     # Ensure only the values provided in options[:with] are selected
     # takes either a single string or array of strings
 
@@ -95,7 +94,7 @@ module FormHelper
     result
   end
 
-  def input_list(locator = nil, options = {})
+  def input_list(locator = nil, options = { wait: false })
     # Enter the values provided in options[:with] into an input list
     # takes either a single string or array of strings
 
@@ -106,7 +105,7 @@ module FormHelper
 
     within result[0] do
       within(:xpath, '../..') do
-        (3..with.length).each { click_on find('.list-entry-add').text } if with.length > 2
+        (3..with.length).each { click_on find('.list-entry-add').text, wait: false } if with.length > 2
       end
     end
 
@@ -119,7 +118,7 @@ module FormHelper
     result
   end
 
-  def fill_field(locator = nil, options = {})
+  def fill_field(locator = nil, options = { wait: false })
     # Like fill_in but will work with checkboxes, radios, and input lists too.
 
     locator, options = nil, locator if locator.is_a? Hash
@@ -154,7 +153,7 @@ module FormHelper
     end
   end
 
-  def maybe_within(locator = nil, options = {}, &block)
+  def maybe_within(locator = nil, options = { wait: false }, &block)
     locator, options = nil, locator if locator.is_a? Hash
     raise "Must pass a hash" if not options.is_a?(Hash)
 
@@ -167,7 +166,7 @@ module FormHelper
     end
   end
 
-  def find_substitutions(locator = nil, options = {})
+  def find_substitutions(locator = nil, options = { wait: false })
     locator, options = nil, locator if locator.is_a? Hash
     raise "Must pass a hash" if not options.is_a?(Hash)
 
@@ -199,7 +198,7 @@ module FormHelper
     values
   end
 
-  def fill_form(locator = nil, options = {})
+  def fill_form(locator = nil, options = { wait: false })
     # Fill in all form fields with provided values, using random values for
     # any not provided.
     locator, options = nil, locator if locator.is_a? Hash
@@ -211,7 +210,7 @@ module FormHelper
       find_fields.each do |name|
         if find_fields(locator = name).length > 0
           values[name] = (with[name] || random_for(name))
-          fill_field name, with: values[name]
+          fill_field name, with: values[name], wait: false
         end
       end
     end
@@ -334,10 +333,10 @@ module FormHelper
   def find_and_click_submit_button
     submit_button = find_elements_by_xpath("//input[@class='button-save']")[0].value
     if submit_button == 'Save and continue'
-      click_on 'Save and continue'
+      click_on 'Save and continue', wait: false
       false
     else
-      click_on submit_button
+      click_on submit_button, wait: false
       true
     end
   end

--- a/features/support/helpers.rb
+++ b/features/support/helpers.rb
@@ -77,16 +77,16 @@ def find_elements_by_xpath(xpath)
   page.document.find_xpath(xpath)
 end
 
-def all_fields(locator, options = {})
+def all_fields(locator, options = { wait: false })
   results = all(:field, locator, options.merge(visible: :all)).to_a
   remove_js_hidden_fields_from_results(results)
 end
 
-def first_field(locator, options = {})
+def first_field(locator, options = { wait: false })
   all_fields(locator, options)[0]
 end
 
-def return_element(type, locator_or_element, options = {})
+def return_element(type, locator_or_element, options = { wait: false })
   if locator_or_element.is_a? Capybara::Node::Element
     element = locator_or_element
   else
@@ -109,24 +109,24 @@ def return_element(type, locator_or_element, options = {})
   element
 end
 
-def choose_radio(locator_or_radio, options = {})
+def choose_radio(locator_or_radio, options = { wait: false })
   begin
     radio = return_element('radio', locator_or_radio, options)
-    choose(radio[:id], options.merge(allow_label_click: true))
+    choose(radio[:id], options.merge(allow_label_click: true, wait: false))
   rescue Capybara::ElementNotFound
-    choose(radio[:id], allow_label_click: true)
+    choose(radio[:id], allow_label_click: true, wait: false)
   end
   puts "Radio button value: #{radio.value}"
 end
 
-def check_checkbox(locator_or_checkbox, options = {})
+def check_checkbox(locator_or_checkbox, options = { wait: false })
   checkbox = return_element('checkbox', locator_or_checkbox, options)
 
   check(checkbox[:id], options.merge(allow_label_click: true))
   puts "Checkbox value: #{checkbox.value}"
 end
 
-def uncheck_checkbox(locator_or_checkbox, options = {})
+def uncheck_checkbox(locator_or_checkbox, options = { wait: false })
   checkbox = return_element('checkbox', locator_or_checkbox, options)
 
   uncheck(checkbox[:id], options.merge(allow_label_click: true))

--- a/features/user/reset_password.feature
+++ b/features/user/reset_password.feature
@@ -3,7 +3,6 @@ Feature: Reset user password
 
 Background:
   Given I have a buyer user
-  And I wait 2 seconds to ensure the reset token is created after the user
 
 Scenario: User has forgotten their password and requests a password reset
   When I am on the homepage


### PR DESCRIPTION
 ## Summary
🚗 ⏩ 💨 💨 🚗 🏎 
Disable waiting for the majority of our calls to Capybara's matchers.
Our site is primarily static content after the page has loaded, so we
don't need Capybara to be willing to wait for theoretical ajax/dynamic
content to finish loading.

Where we do have dynamic content (such as live search on
services/briefs), we explicitly add a maximum wait time that Capybara
will respect.

Capybara's matchers/selectors work in a specific way to support dynamic
changes on the page:

When we ask Capybara to check for an element or some text on the page,
if the text is present, Capybara immediately notices this and returns
the result. If the text is *not* present, Capybara will wait for its
`max_default_wait_time` (seconds) configuration value, checking the page
every 0.05s to see if the content has appeared yet. After the wait time
has elapsed, if the content is still not present, Capybara raises an
'element not found' exception to report that the selector is missing.
This is all well and good if we expect the content to be there. An issue
arises when we use a 'look for this content' selector, and check that
the return value is `false`, to assert that content is *not* present. In
this case, we will always force Capybara to sleep out its
'max_default_wait_time' period. Where we want to do this, we should be
careful to use the negated matcher that Capybara often exposes (e.g.
there is a `has_content?` matcher for checking that content is present,
and a `has_no_content?` matcher for checking that content is *not*
present).

The above issue has been mitigated by setting the
'default_max_wait_time' configuration option to a low threshold (0.05
seconds). This means that, even if we use a suboptimal matcher, we won't
sleep for very long.

On top of this, we now specifically disable waiting for a number of
Capybara's matches by sending the option `wait: false` into the Capybara
matcher calls. These two effects combined will mean that it should be
reasonably unlikely for the issue to recur - however we should still be
conscientious when using Capybara's matchers in the future.

It will be important to be aware, in the future, that when we do add
further dynamic content/ajax-y stuff to the frontends, that we'll
specifically need to give a generous `wait` for the matchers (for which
we can use the new `dm_custom_wait_time` config value defined in
`features/support/env.rb`

Bump Capybara library version - required for correct passing of
`options`/`wait: false` down Capybara's matcher chain.

## Results (run-parallel against Preview from a developer laptop over VPN)

## Before
```
218 scenarios (1 skipped, 217 passed)
2622 steps (25 skipped, 2597 passed)

Took 847 seconds (14:07)
```

## After
```
218 scenarios (1 skipped, 217 passed)
2621 steps (25 skipped, 2596 passed)

Took 375 seconds (6:15)
```

🎉 🎉 🎉  These will probably run even faster on the Jenkins box. 🎉 🎉 🎉 