### PR TITLE
Assert the supplier name, not the invited user name

### DIFF
--- a/features/supplier/supplier_account.feature
+++ b/features/supplier/supplier_account.feature
@@ -207,7 +207,7 @@ Scenario: Supplier user can add and remove contributors
   Given I enter 'New collaborator' in the 'Your name' field
   And I enter 'Password1234' in the 'Password' field
   When I click 'Create account'
-  Then I am on the 'New collaborator' page
+  Then I am on that supplier.name page
 
   When I click 'Contributors'
   Then I see 'that user.emailAddress' text on the page


### PR DESCRIPTION
When an invited supplier creates their account, they are taken to their dashboard at `/suppliers`. The `<h1>` here is the supplier name, not the user account name.

This failure wasn't picked up in pre-merge checks as we were ignoring Notify failures (which happened before this step) - lesson learned!