### PR TITLE
Award flow via link on saved search dashboard

### DIFF
--- a/features/buyer/tell_us_about_contract.feature
+++ b/features/buyer/tell_us_about_contract.feature
@@ -110,7 +110,7 @@ Scenario: User does not award contract as there are no suitable services
   And I am on the 'my cloud project' page
   Then I see a success banner message containing 'You’ve updated ‘my cloud project’'
   And I see 'No suitable services found' text on the page
-@test
+
 Scenario: User is still assessing services - via the saved searches dashboard
   Given I am logged in as a buyer user
   And I am ready to tell the coutcome for the 'my cloud project' saved search

--- a/features/buyer/tell_us_about_contract.feature
+++ b/features/buyer/tell_us_about_contract.feature
@@ -86,7 +86,7 @@ Scenario: User exports and downloads results
 
 Scenario: User awards contract
   Given I am logged in as a buyer user
-  And I am ready to tell the coutcome for the 'my cloud project' saved search
+  And I am ready to tell the outcome for the 'my cloud project' saved search
   When I click the 'Tell us the outcome' link
   And I award the contract to 'NCCIS' for the 'my cloud project' search
   And I am on the 'my cloud project' page
@@ -95,7 +95,7 @@ Scenario: User awards contract
 
 Scenario: User does not award contract as work is cancelled
   Given I am logged in as a buyer user
-  And I am ready to tell the coutcome for the 'my cloud project' saved search
+  And I am ready to tell the outcome for the 'my cloud project' saved search
   When I click the 'Tell us the outcome' link
   And I do not award the contract because 'The work has been cancelled'
   And I am on the 'my cloud project' page
@@ -104,7 +104,7 @@ Scenario: User does not award contract as work is cancelled
 
 Scenario: User does not award contract as there are no suitable services
   Given I am logged in as a buyer user
-  And I am ready to tell the coutcome for the 'my cloud project' saved search
+  And I am ready to tell the outcome for the 'my cloud project' saved search
   When I click the 'Tell us the outcome' link
   And I do not award the contract because 'There were no suitable services'
   And I am on the 'my cloud project' page
@@ -113,7 +113,7 @@ Scenario: User does not award contract as there are no suitable services
 
 Scenario: User is still assessing services - via the saved searches dashboard
   Given I am logged in as a buyer user
-  And I am ready to tell the coutcome for the 'my cloud project' saved search
+  And I am ready to tell the outcome for the 'my cloud project' saved search
   When I visit the /buyers/direct-award/g-cloud page
   When I click the 'Tell us the outcome' link
   And I choose the 'We are still assessing services' radio button

--- a/features/buyer/tell_us_about_contract.feature
+++ b/features/buyer/tell_us_about_contract.feature
@@ -120,12 +120,11 @@ Scenario: User does not award contract as there are no suitable services
   Then I see a success banner message containing 'You’ve updated ‘my cloud project’'
   And I see 'No suitable services found' text on the page
 
-Scenario: User is still assessing services
+Scenario: User is still assessing services - via the saved searches dashboard
   Given I am logged in as a buyer user
   And I have created and ended a search called 'my cloud project'
   And I have downloaded the search results as a file of type 'ods'
-  And I click the 'Return to your tasklist' link
-  And I am on the 'my cloud project' page
+  When I visit the /buyers/direct-award/g-cloud page
   When I click the 'Tell us the outcome' link
   And I choose the 'We are still assessing services' radio button
   And I click 'Save and continue'

--- a/features/buyer/tell_us_about_contract.feature
+++ b/features/buyer/tell_us_about_contract.feature
@@ -86,10 +86,7 @@ Scenario: User exports and downloads results
 
 Scenario: User awards contract
   Given I am logged in as a buyer user
-  And I have created and ended a search called 'my cloud project'
-  And I have downloaded the search results as a file of type 'ods'
-  And I click the 'Return to your tasklist' link
-  And I am on the 'my cloud project' page
+  And I am ready to tell the coutcome for the 'my cloud project' saved search
   When I click the 'Tell us the outcome' link
   And I award the contract to 'NCCIS' for the 'my cloud project' search
   And I am on the 'my cloud project' page
@@ -98,10 +95,7 @@ Scenario: User awards contract
 
 Scenario: User does not award contract as work is cancelled
   Given I am logged in as a buyer user
-  And I have created and ended a search called 'my cloud project'
-  And I have downloaded the search results as a file of type 'ods'
-  And I click the 'Return to your tasklist' link
-  And I am on the 'my cloud project' page
+  And I am ready to tell the coutcome for the 'my cloud project' saved search
   When I click the 'Tell us the outcome' link
   And I do not award the contract because 'The work has been cancelled'
   And I am on the 'my cloud project' page
@@ -110,20 +104,16 @@ Scenario: User does not award contract as work is cancelled
 
 Scenario: User does not award contract as there are no suitable services
   Given I am logged in as a buyer user
-  And I have created and ended a search called 'my cloud project'
-  And I have downloaded the search results as a file of type 'csv'
-  And I click the 'Return to your tasklist' link
-  And I am on the 'my cloud project' page
+  And I am ready to tell the coutcome for the 'my cloud project' saved search
   When I click the 'Tell us the outcome' link
   And I do not award the contract because 'There were no suitable services'
   And I am on the 'my cloud project' page
   Then I see a success banner message containing 'You’ve updated ‘my cloud project’'
   And I see 'No suitable services found' text on the page
-
+@test
 Scenario: User is still assessing services - via the saved searches dashboard
   Given I am logged in as a buyer user
-  And I have created and ended a search called 'my cloud project'
-  And I have downloaded the search results as a file of type 'ods'
+  And I am ready to tell the coutcome for the 'my cloud project' saved search
   When I visit the /buyers/direct-award/g-cloud page
   When I click the 'Tell us the outcome' link
   And I choose the 'We are still assessing services' radio button

--- a/features/step_definitions/direct_award_steps.rb
+++ b/features/step_definitions/direct_award_steps.rb
@@ -8,7 +8,7 @@ When (/^I have created and saved a search called '(.*)'$/) do |search_name|
   }
 end
 
-When (/^I have created and ended a search called '(.*)'$/) do |search_name|
+When (/^I am ready to tell the coutcome for the '(.*)' saved search$/) do |search_name|
   steps %{
     And I have created and saved a search called '#{search_name}'
     And I visit the /buyers page
@@ -16,9 +16,13 @@ When (/^I have created and ended a search called '(.*)'$/) do |search_name|
     Then I click the '#{search_name}' link
     Then I am on the '#{search_name}' page
     And I click the 'Export your results' link
-    Then I am on the 'End your search' page
-    And I click the 'End search and continue' button
-    Then I am on the '#{search_name}' page
+    Then I am on the 'Before you export your results' page
+    And I check 'I understand that I cannot edit my search again after I export my results' checkbox
+    And I click the 'Export results and continue' button
+    Then I am on the 'my cloud project' page
+    When I have downloaded the search results as a file of type 'ods'
+    And I click the 'Return to your task list' link
+    Then I am on the 'my cloud project' page
   }
 end
 

--- a/features/step_definitions/direct_award_steps.rb
+++ b/features/step_definitions/direct_award_steps.rb
@@ -8,7 +8,7 @@ When (/^I have created and saved a search called '(.*)'$/) do |search_name|
   }
 end
 
-When (/^I am ready to tell the coutcome for the '(.*)' saved search$/) do |search_name|
+When (/^I am ready to tell the outcome for the '(.*)' saved search$/) do |search_name|
   steps %{
     And I have created and saved a search called '#{search_name}'
     And I visit the /buyers page


### PR DESCRIPTION
Modified current scenario "Scenario: User is still assessing service" to be completed via the saved search dashboard "Tell us the outcome link". This reduced the need to have a separate scenario to test this route of awarding a contract. Other scenarios already cover awarding contract via the the link on the project page.

NOTE: This can't be merged before:
https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/781