### PR TITLE
Fix postcode validation

### DIFF
--- a/features/support/form_helpers.rb
+++ b/features/support/form_helpers.rb
@@ -292,7 +292,8 @@ module FormHelper
 
   def pass_postcode_validation
     options = {}
-    postcode_elements = find_elements_by_xpath("//input[contains(@name, 'Postcode')]")
+    # Match fields for both 'postcode' and 'labAddressPostcode'
+    postcode_elements = find_elements_by_xpath("//input[contains(@name, 'ostcode')]")
     if postcode_elements.length > 0
       element_name = postcode_elements[0]["name"]
       options[element_name] = "AB1 2CD"


### PR DESCRIPTION
We recently added max-length validation for the supplier company address 'postcode' field (entered during their application). The tests didn't like it.

The functional test looks at the input name in order to fill out the 'correct' value, however for postcode it was looking for upper case `Postcode` (because of the validation on `labAddressPostcode`). Fixed with a small hack.