### PR TITLE
Fix tests that were failing from not being able to end a search.

### DIFF
--- a/features/step_definitions/direct_award_steps.rb
+++ b/features/step_definitions/direct_award_steps.rb
@@ -1,6 +1,6 @@
 When (/^I have created and saved a search called '(.*)'$/) do |search_name|
   steps %{
-    Given I visit the /g-cloud/search?q=email+analysis+provider page
+    Given I visit the /g-cloud/search?q=email+analysis+provider+system page
     And I click 'Save your search'
     Then I am on the 'Save your search' page
     And I enter '#{search_name}' in the 'Name your search' field


### PR DESCRIPTION
Changed keyword search from "email analysis provider" to "email analysis provider system", so that the saved search can be ended(have less than 30 results).