### PR TITLE
Functional test for new list flow and some tweaks.

### DIFF
--- a/features/buyer/tell_us_about_contract.feature
+++ b/features/buyer/tell_us_about_contract.feature
@@ -127,7 +127,6 @@ Scenario: User awards contract
   And I award the contract to 'NCCIS' for the 'my cloud project' search
   And I am on the 'my cloud project' page
   Then I see a success banner message containing 'You’ve updated ‘my cloud project’'
-  #And I see 'Contract awarded to CareerVision Ltd: NCCIS' text on the page
   And I see the 'Award a contract' instruction list item status showing as 'Contract awarded to CareerVision Ltd: NCCIS'
 
 Scenario: User does not award contract as work is cancelled
@@ -138,7 +137,6 @@ Scenario: User does not award contract as work is cancelled
   And I am on the 'my cloud project' page
   Then I see a success banner message containing 'You’ve updated ‘my cloud project’'
   And I see the 'Award a contract' instruction list item status showing as 'The work has been cancelled'
-  #And I see 'The work has been cancelled' text on the page
 
 Scenario: User does not award contract as there are no suitable services
   Given I am logged in as a buyer user
@@ -148,7 +146,6 @@ Scenario: User does not award contract as there are no suitable services
   And I am on the 'my cloud project' page
   Then I see a success banner message containing 'You’ve updated ‘my cloud project’'
   And I see the 'Award a contract' instruction list item status showing as 'No suitable services found'
-  #And I see 'No suitable services found' text on the page
 
 Scenario: User is still assessing services - via the saved searches dashboard
   Given I am logged in as a buyer user

--- a/features/buyer/tell_us_about_contract.feature
+++ b/features/buyer/tell_us_about_contract.feature
@@ -61,28 +61,64 @@ Scenario: User edits existing search
   And I click 'Save and continue'
   Then I am on the 'my cloud project' page
 
-Scenario: User exports and downloads results
+Scenario: User exports results
   Given I am logged in as a buyer user
-  And I have created and saved a search called 'my cloud project'
+  And I have created and saved a search called 'export limit test project'
   And I visit the /buyers page
   When I click the 'View your saved searches' link
-  And I click the 'my cloud project' link
-  Then I am on the 'my cloud project' page
+  And I click the 'export limit test project' link
+  Then I am on the 'export limit test project' page
+  And I see the 'Export your results' instruction list item has a warning message of 'You have too many services to assess. Refine your search until you have no more than 30 results.'
+  And I see the 'Export your results' instruction list item status showing as 'Can’t start yet'
+  When I visit the /g-cloud/search?q=cloud+software+nhs&lot=cloud-hosting page
+  And I click 'Save your search'
+  Then I am on the 'Save your search' page
+  And I choose the 'export limit test project' radio button
+  And I click 'Save and continue'
+  And I see the 'Save a search' instruction list item status showing as 'Completed'
   When I click the 'Export your results' link
   Then I am on the 'Before you export your results' page
   When I check 'I understand that I cannot edit my search again after I export my results' checkbox
   And I click the 'Export results and continue' button
-  Then I am on the 'my cloud project' page
-  When I click the 'Download search results' link
+  Then I am on the 'Download your results' page
+  And I see a success banner message containing 'Results exported. Your files are ready to download.'
+  When I click the 'Return to your task list' link
+  Then I see the 'Export your results' instruction list item status showing as 'Completed'
+
+Scenario: User download results
+  Given I am logged in as a buyer user
+  And I have created and saved a search called 'my cloud project'
+  And I have exported my results for the 'my cloud project' saved search
   Then I am on the 'Download your results' page
   When I click the 'Download search results as a spreadsheet' link
   Then I should get a download file of type 'ods'
   When I click the 'Return to your task list' link
   Then I am on the 'my cloud project' page
-  When I click the 'Download your results again' link
+  When I click the 'Download your results' link
   Then I am on the 'Download your results' page
   When I click the 'Download search results as comma-separated values' link
   Then I should get a download file of type 'csv'
+
+Scenario: User downloads results - via the saved searches dashboard
+  Given I am logged in as a buyer user
+  And I am ready to tell the outcome for the 'my cloud project' saved search
+  When I visit the /buyers/direct-award/g-cloud page
+  And I click the 'Download results' link
+  Then I am on the 'Download your results' page
+  When I click the 'Download search results as a spreadsheet' link
+  Then I should get a download file of type 'ods'
+
+Scenario: User confirms understanding how to assess services
+  Given I am logged in as a buyer user
+  And I have created and saved a search called 'my cloud project'
+  And I have exported my results for the 'my cloud project' saved search
+  And I click the 'Return to your task list' link
+  Then I see the 'Export your results' instruction list item status showing as 'Completed'
+  And I see the 'Award a contract' instruction list item status showing as 'Can’t start yet'
+  When I click the 'Confirm you have read and understood how to assess services' button
+  Then I am on the 'my cloud project' page
+  And I see a success banner message containing 'You’ve confirmed that you have read and understood how to assess services.'
+  And I see the 'Start assessing services' instruction list item status showing as 'Completed'
 
 Scenario: User awards contract
   Given I am logged in as a buyer user
@@ -91,7 +127,8 @@ Scenario: User awards contract
   And I award the contract to 'NCCIS' for the 'my cloud project' search
   And I am on the 'my cloud project' page
   Then I see a success banner message containing 'You’ve updated ‘my cloud project’'
-  And I see 'Contract awarded to CareerVision Ltd: NCCIS' text on the page
+  #And I see 'Contract awarded to CareerVision Ltd: NCCIS' text on the page
+  And I see the 'Award a contract' instruction list item status showing as 'Contract awarded to CareerVision Ltd: NCCIS'
 
 Scenario: User does not award contract as work is cancelled
   Given I am logged in as a buyer user
@@ -100,7 +137,8 @@ Scenario: User does not award contract as work is cancelled
   And I do not award the contract because 'The work has been cancelled'
   And I am on the 'my cloud project' page
   Then I see a success banner message containing 'You’ve updated ‘my cloud project’'
-  And I see 'The work has been cancelled' text on the page
+  And I see the 'Award a contract' instruction list item status showing as 'The work has been cancelled'
+  #And I see 'The work has been cancelled' text on the page
 
 Scenario: User does not award contract as there are no suitable services
   Given I am logged in as a buyer user
@@ -109,11 +147,13 @@ Scenario: User does not award contract as there are no suitable services
   And I do not award the contract because 'There were no suitable services'
   And I am on the 'my cloud project' page
   Then I see a success banner message containing 'You’ve updated ‘my cloud project’'
-  And I see 'No suitable services found' text on the page
+  And I see the 'Award a contract' instruction list item status showing as 'No suitable services found'
+  #And I see 'No suitable services found' text on the page
 
 Scenario: User is still assessing services - via the saved searches dashboard
   Given I am logged in as a buyer user
   And I am ready to tell the outcome for the 'my cloud project' saved search
+  And I have downloaded the search results as a file of type 'csv'
   When I visit the /buyers/direct-award/g-cloud page
   When I click the 'Tell us the outcome' link
   And I choose the 'We are still assessing services' radio button

--- a/features/buyer/tell_us_about_contract.feature
+++ b/features/buyer/tell_us_about_contract.feature
@@ -61,6 +61,7 @@ Scenario: User edits existing search
   And I click 'Save and continue'
   Then I am on the 'my cloud project' page
 
+@skip-staging
 Scenario: User exports results
   Given I am logged in as a buyer user
   And I have created and saved a search called 'export limit test project'
@@ -85,6 +86,7 @@ Scenario: User exports results
   When I click the 'Return to your task list' link
   Then I see the 'Export your results' instruction list item status showing as 'Completed'
 
+@skip-staging
 Scenario: User download results
   Given I am logged in as a buyer user
   And I have created and saved a search called 'my cloud project'
@@ -99,6 +101,7 @@ Scenario: User download results
   When I click the 'Download search results as comma-separated values' link
   Then I should get a download file of type 'csv'
 
+@skip-staging
 Scenario: User downloads results - via the saved searches dashboard
   Given I am logged in as a buyer user
   And I am ready to tell the outcome for the 'my cloud project' saved search
@@ -108,6 +111,7 @@ Scenario: User downloads results - via the saved searches dashboard
   When I click the 'Download search results as a spreadsheet' link
   Then I should get a download file of type 'ods'
 
+@skip-staging
 Scenario: User confirms understanding how to assess services
   Given I am logged in as a buyer user
   And I have created and saved a search called 'my cloud project'
@@ -120,6 +124,7 @@ Scenario: User confirms understanding how to assess services
   And I see a success banner message containing 'You’ve confirmed that you have read and understood how to assess services.'
   And I see the 'Start assessing services' instruction list item status showing as 'Completed'
 
+@skip-staging
 Scenario: User awards contract
   Given I am logged in as a buyer user
   And I am ready to tell the outcome for the 'my cloud project' saved search
@@ -129,6 +134,7 @@ Scenario: User awards contract
   Then I see a success banner message containing 'You’ve updated ‘my cloud project’'
   And I see the 'Award a contract' instruction list item status showing as 'Contract awarded to CareerVision Ltd: NCCIS'
 
+@skip-staging
 Scenario: User does not award contract as work is cancelled
   Given I am logged in as a buyer user
   And I am ready to tell the outcome for the 'my cloud project' saved search
@@ -138,6 +144,7 @@ Scenario: User does not award contract as work is cancelled
   Then I see a success banner message containing 'You’ve updated ‘my cloud project’'
   And I see the 'Award a contract' instruction list item status showing as 'The work has been cancelled'
 
+@skip-staging
 Scenario: User does not award contract as there are no suitable services
   Given I am logged in as a buyer user
   And I am ready to tell the outcome for the 'my cloud project' saved search
@@ -147,6 +154,7 @@ Scenario: User does not award contract as there are no suitable services
   Then I see a success banner message containing 'You’ve updated ‘my cloud project’'
   And I see the 'Award a contract' instruction list item status showing as 'No suitable services found'
 
+@skip-staging
 Scenario: User is still assessing services - via the saved searches dashboard
   Given I am logged in as a buyer user
   And I am ready to tell the outcome for the 'my cloud project' saved search

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -118,10 +118,11 @@ Given /^I have a random dos brief from the API$/ do
   puts "Brief ID: #{@brief['id']}"
   puts "Brief name: #{ERB::Util.h @brief['title']}"
 end
-
+#//button[contains(normalize-space(text()), 'Confirm you have read and understood how to assess services')]
 When /I click #{MAYBE_VAR} ?(button|link)?$/ do |button_link_name, elem_type|
   if elem_type == 'button'
-    page.all(:xpath, "//input[@value='#{button_link_name}'] | //input[@name='#{button_link_name}'] | //button[text()='#{button_link_name}']")[0].click
+    #page.all(:xpath, "//input[@value='#{button_link_name}'] | //input[@name='#{button_link_name}'] | //button[text()='#{button_link_name}']")[0].click
+    page.all(:xpath, "//input[@value='#{button_link_name}'] | //input[@name='#{button_link_name}'] | //button[contains(normalize-space(text()), '#{button_link_name}')]")[0].click
   elsif elem_type == 'link'
     page.click_link(button_link_name)
   else

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -118,10 +118,9 @@ Given /^I have a random dos brief from the API$/ do
   puts "Brief ID: #{@brief['id']}"
   puts "Brief name: #{ERB::Util.h @brief['title']}"
 end
-#//button[contains(normalize-space(text()), 'Confirm you have read and understood how to assess services')]
+
 When /I click #{MAYBE_VAR} ?(button|link)?$/ do |button_link_name, elem_type|
   if elem_type == 'button'
-    #page.all(:xpath, "//input[@value='#{button_link_name}'] | //input[@name='#{button_link_name}'] | //button[text()='#{button_link_name}']")[0].click
     page.all(:xpath, "//input[@value='#{button_link_name}'] | //input[@name='#{button_link_name}'] | //button[contains(normalize-space(text()), '#{button_link_name}')]")[0].click
   elsif elem_type == 'link'
     page.click_link(button_link_name)

--- a/features/step_definitions/direct_award_steps.rb
+++ b/features/step_definitions/direct_award_steps.rb
@@ -1,6 +1,6 @@
 When (/^I have created and saved a search called '(.*)'$/) do |search_name|
   case search_name
-  when 'my cloud project' , 'my cloud project - existing'
+    when 'my cloud project', 'my cloud project - existing'
       steps "Given I visit the /g-cloud/search?q=email+analysis+provider+system page"
     when 'export limit test project'
       steps "Given I visit the /g-cloud/search?q=cloud+software+nhs page"

--- a/features/step_definitions/direct_award_steps.rb
+++ b/features/step_definitions/direct_award_steps.rb
@@ -1,6 +1,11 @@
 When (/^I have created and saved a search called '(.*)'$/) do |search_name|
+  case search_name
+  when 'my cloud project' , 'my cloud project - existing'
+      steps "Given I visit the /g-cloud/search?q=email+analysis+provider+system page"
+    when 'export limit test project'
+      steps "Given I visit the /g-cloud/search?q=cloud+software+nhs page"
+  end
   steps %{
-    Given I visit the /g-cloud/search?q=email+analysis+provider+system page
     And I click 'Save your search'
     Then I am on the 'Save your search' page
     And I enter '#{search_name}' in the 'Name your search' field
@@ -10,35 +15,23 @@ end
 
 When (/^I am ready to tell the outcome for the '(.*)' saved search$/) do |search_name|
   steps %{
-    And I have created and saved a search called '#{search_name}'
-    And I visit the /buyers page
-    Then I click the 'View your saved searches' link
-    Then I click the '#{search_name}' link
-    Then I am on the '#{search_name}' page
-    And I click the 'Export your results' link
-    Then I am on the 'Before you export your results' page
-    And I check 'I understand that I cannot edit my search again after I export my results' checkbox
-    And I click the 'Export results and continue' button
-    Then I am on the 'my cloud project' page
-    When I have downloaded the search results as a file of type 'ods'
+    Given I have created and saved a search called '#{search_name}'
+    And I am on the '#{search_name}' page
+    And I have exported my results for the '#{search_name}' saved search
     And I click the 'Return to your task list' link
-    Then I am on the 'my cloud project' page
+    And I click the 'Confirm you have read and understood how to assess services' button
   }
 end
 
-When (/^I have downloaded the search results as a file of type '(.*)'$/) do |file_type|
+When (/^I have exported my results for the '(.*)' saved search$/) do |search_name|
   steps %{
-    And I click the 'Download search results' link
-    And I am on the 'Download your results' page
+    Given I visit the /buyers/direct-award/g-cloud page
+    And I click the '#{search_name}' link
+    And I click the 'Export your results' link
+    And I check 'I understand that I cannot edit my search again after I export my results' checkbox
+    And I click the 'Export results and continue' button
+    Then I see a success banner message containing 'Results exported. Your files are ready to download.'
   }
-  if file_type == 'ods'
-    steps "And I click the 'Download search results as a spreadsheet' link"
-  elsif file_type == 'csv'
-    steps "And I click the 'Download search results as comma-separated values' link"
-  else
-    puts "The file type '#{file_type}' is not recognised"
-  end
-  steps "And I should get a download file of type '#{file_type}'"
 end
 
 When (/^I award the contract to '(.*)' for the '(.*)' search$/) do |supplier_name, search_name|
@@ -71,11 +64,37 @@ When (/^I do not award the contract because '(.*)'$/) do |reason|
   }
   case reason
     when 'The work has been cancelled'
-      steps "And I choose the 'The work has been cancelled' radio button"
+      step "And I choose the 'The work has been cancelled' radio button"
     when 'There were no suitable services'
-      steps "And I choose the 'There were no suitable services' radio button"
+      step "And I choose the 'There were no suitable services' radio button"
     else
       puts 'The reason for not awarding the contract is not recognised'
   end
   steps "And I click 'Save and continue'"
+end
+
+When (/^I have downloaded the search results as a file of type '(.*)'$/) do |file_type|
+  step "And I click the 'Download your results' link"
+  if file_type == 'ods'
+    steps "And I click the 'Download search results as a spreadsheet' link"
+  elsif file_type == 'csv'
+    steps "And I click the 'Download search results as comma-separated values' link"
+  else
+    puts "The file type '#{file_type}' is not recognised"
+  end
+  steps "And I should get a download file of type '#{file_type}'"
+end
+
+And (/^I see the '(.*)' instruction list item status showing as '(.*)'$/) do |list_item, status|
+  # list_item_box_status = ''
+  # if status == 'Completed'
+  #   list_item_box_status = 'complete'
+  # elsif status == "Can’t start yet"
+  #   list_item_box_status = 'inactive'
+  # end
+  page.find(:xpath, "//*[contains(@class, 'instruction-list')]//*[contains(@class, 'instruction-list-item-body')][contains(text(),'#{list_item}')]/../*[contains(@class, 'instruction-list-item-box')][contains(text(),'#{status}')]")
+end
+
+And (/^I see the '(.*)' instruction list item has a warning message of '(.*)'$/) do |list_item, message|
+  page.find(:xpath, "//*[contains(@class, 'instruction-list')]//*[contains(@class, 'instruction-list-item-body')][contains(text(),'#{list_item}')]/..//strong[contains(normalize-space(text()), '#{message}')]")
 end

--- a/features/step_definitions/direct_award_steps.rb
+++ b/features/step_definitions/direct_award_steps.rb
@@ -86,12 +86,6 @@ When (/^I have downloaded the search results as a file of type '(.*)'$/) do |fil
 end
 
 And (/^I see the '(.*)' instruction list item status showing as '(.*)'$/) do |list_item, status|
-  # list_item_box_status = ''
-  # if status == 'Completed'
-  #   list_item_box_status = 'complete'
-  # elsif status == "Can’t start yet"
-  #   list_item_box_status = 'inactive'
-  # end
   page.find(:xpath, "//*[contains(@class, 'instruction-list')]//*[contains(@class, 'instruction-list-item-body')][contains(text(),'#{list_item}')]/../*[contains(@class, 'instruction-list-item-box')][contains(text(),'#{status}')]")
 end
 


### PR DESCRIPTION
Task list flow changed. This commit address the changes, add's some missing scenarios, add's some new steps and rejigs some existing steps.
-Search >30 results can't be exported
-Export message in relation to >30 results in saved search
-Check for list item status "Can't start yet', 'Completed' 'Contract awarded to <service name>', 'The work has been cancelled', 'No suitable services found'
-Tweaked export scenario
-Tweaked download scenario
-Removed commented lines that are no longer required