### PR TITLE
Add 'requires-credentials' tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,16 +55,21 @@ To run features with a specific tag run
 
 `make ARGS='--tags ...' run`
 
-To include or exclude tags see [the cucumber documentation](https://github.com/cucumber/cucumber/wiki/Tags#running-a-subset-of-scenarios)
+To include or exclude tags see [the cucumber documentation](https://docs.cucumber.io/cucumber/api/#running-a-subset-of-scenarios)
 
 ## Tags
 Tags are used to include/exclude given tests on certain environments. The following tags are currently supported:
 
 | Tag Name                    | Description                                           |
 |-----------------------------|-------------------------------------------------------|
+| notify                      | Tests whether an email was sent.                      |
+| mailchimp                   | Tests updating a mailing list.                        |
+| file-upload                 | Tests uploading files.                                |
+| requires-credentials        | All tests which require API tokens.                   |
 | smoke-tests                 |                                                       |
 | opportunities               |                                                       |               
 | requirements                |                                                       |
+| direct-award                |                                                       |
 | brief-response              |                                                       |
 | with-production-<type>-user |                                                       |
 | skip                        | Skip this test everywhere (e.g. temporarily disabled) |

--- a/features/admin/invite_admin_user.feature
+++ b/features/admin/invite_admin_user.feature
@@ -1,7 +1,7 @@
 @admin @invite-admin-user
 Feature: Admin manager can manage users
 
-@notify
+@requires-credentials @notify
 Scenario Outline: Admin Manager user can log in and invite admin users
   Given I am logged in as the production <role> user
   And I click the 'View and edit admin accounts' link

--- a/features/admin/invite_supplier_contributor.feature
+++ b/features/admin/invite_supplier_contributor.feature
@@ -1,7 +1,7 @@
 @admin @invite-supplier-contributor
 Feature: Invite a contributor to a supplier account
 
-@notify
+@requires-credentials @notify
 Scenario Outline: Correct users can invite a contributors to a supplier account
   Given I am logged in as the production <role> user
   And I have a supplier with:

--- a/features/buyer/buyer_creation.feature
+++ b/features/buyer/buyer_creation.feature
@@ -1,7 +1,7 @@
 @buyer @newbuyer @skip-staging
 Feature: Create buyer account
 
-@notify
+@requires-credentials @notify
 Scenario: Create a new buyer account when trying to create a requirement from the home page
   Given I visit the homepage
   When I click 'Find an individual specialist'

--- a/features/supplier/subscribe_mailing_list.feature
+++ b/features/supplier/subscribe_mailing_list.feature
@@ -12,14 +12,14 @@ Background:
   Then I am on the 'Sign up for Digital Marketplace email alerts' page
   And I don't see a banner message
 
-@mailchimp
+@requires-credentials @mailchimp
 Scenario: Successful mailing-list subscription from the home page
   When I enter 'functional-test-email@user.marketplace.team' in the 'email_address' field
   And I click 'Subscribe'
   Then I am on the 'Digital Marketplace' page
   And I see a success banner message containing 'You will receive email notifications to functional-test-email@user.marketplace.team when applications are opening.'
 
-@mailchimp
+@requires-credentials @mailchimp
 Scenario: Initially-rejected mailing-list subscription
   # example@example.com should be rejected by mailchimp as an obvious fake address
   When I enter 'example@example.com' in the 'email_address' field

--- a/features/supplier/subscribe_mailing_list.feature
+++ b/features/supplier/subscribe_mailing_list.feature
@@ -12,12 +12,14 @@ Background:
   Then I am on the 'Sign up for Digital Marketplace email alerts' page
   And I don't see a banner message
 
+@mailchimp
 Scenario: Successful mailing-list subscription from the home page
   When I enter 'functional-test-email@user.marketplace.team' in the 'email_address' field
   And I click 'Subscribe'
   Then I am on the 'Digital Marketplace' page
   And I see a success banner message containing 'You will receive email notifications to functional-test-email@user.marketplace.team when applications are opening.'
 
+@mailchimp
 Scenario: Initially-rejected mailing-list subscription
   # example@example.com should be rejected by mailchimp as an obvious fake address
   When I enter 'example@example.com' in the 'email_address' field

--- a/features/supplier/supplier_account.feature
+++ b/features/supplier/supplier_account.feature
@@ -367,7 +367,7 @@ Scenario: Supplier user can provide and change supplier details before confirmin
     And I see 'that supplier.dunsNumber' text on the page
 
 
-@notify @skip-staging
+@requires-credentials @notify @skip-staging
 Scenario: Supplier user can add and remove contributors
   When I click 'Contributors'
   Then I am on the 'Invite or remove contributors' page

--- a/features/supplier/supplier_applies_for_an_opportunity.feature
+++ b/features/supplier/supplier_applies_for_an_opportunity.feature
@@ -381,7 +381,7 @@ Scenario: Supplier changes their answers after submission
   When I click the 'Tea drinker' link
   Then I am on the 'Your application for ‘Tea drinker’' page
 
-@opportunity-clarification-question
+@requires-credentials @notify @opportunity-clarification-question
 Scenario: Supplier asks a clarification question
   Given that supplier has applied to be on that framework
   And we accept that suppliers application to the framework

--- a/features/supplier/view_and_edit_g_cloud_services.feature
+++ b/features/supplier/view_and_edit_g_cloud_services.feature
@@ -54,7 +54,7 @@ Scenario: Supplier user can edit the features and benefits of a service
     | field                         | value                                                                                  |
     | Service features and benefits | Service features Feature 1 New Feature 2 Service benefits Benefit 1 Updated Benefit 2  |
 
-@file-upload
+@requires-credentials @file-upload
 Scenario: Supplier user can replace the service definition document
   When I click the top-level summary table 'Edit' link for the section 'Documents'
   Then I am on the 'Documents' page
@@ -63,7 +63,7 @@ Scenario: Supplier user can replace the service definition document
   Then I am on the 'Test cloud support service' page
   And I see a success banner message containing 'You’ve edited your service. The changes are now live on the Digital Marketplace.'
 
-@file-upload
+@requires-credentials @file-upload
 Scenario: Supplier user can not replace the service definition document with a non-pdf file
   When I click the top-level summary table 'Edit' link for the section 'Documents'
   Then I am on the 'Documents' page
@@ -72,7 +72,7 @@ Scenario: Supplier user can not replace the service definition document with a n
   Then I am on the 'Documents' page
   And I see a validation message containing 'Your document is not in an open format. Please save as an Open Document Format (ODF) or PDF/A (eg .pdf, .odt).'
 
-@file-upload
+@requires-credentials @file-upload
 Scenario: Supplier user can not replace the service definition document with a file over 5MB
   When I click the top-level summary table 'Edit' link for the section 'Documents'
   Then I am on the 'Documents' page

--- a/features/user/change_password.feature
+++ b/features/user/change_password.feature
@@ -1,4 +1,4 @@
-@user @password-change @notify @skip-staging
+@user @password-change @requires-credentials @notify @skip-staging
 Feature: Password change
 Background:
 

--- a/features/user/reset_password.feature
+++ b/features/user/reset_password.feature
@@ -1,4 +1,4 @@
-@user @reset-password @notify @skip-staging
+@user @reset-password @requires-credentials @notify @skip-staging
 Feature: Reset user password
 
 Background:


### PR DESCRIPTION
A number of functional tests use services that require API tokens to use, such as Notify and S3. While these have individual tags, it is a pain to add exclusions for all of them when running functional tests without clearance and/or tokens.

This commit adds an additional `@requires-clearance` tag to all scenarios with `@notify`, `@mailchimp` and `@file-upload` so that they can be easily excluded as a group.