### PR TITLE
search pages: add scenarios to test 404 pages are correctly returnedfor pages beyond the number of search results

### DIFF
--- a/features/smoke-tests/buyer/catalogue.feature
+++ b/features/smoke-tests/buyer/catalogue.feature
@@ -118,3 +118,11 @@ Scenario: User gets no results for an unfindable term
   And I wait for the page to reload
   Then I don't see a search result
   And I see 'metempsychosis' in the search summary text
+
+Scenario: User receives a 404 page when attempting to access a page beyond the number of search results
+  Given I visit the /g-cloud/search?q=metempsychosis&page=2 page
+  Then I am on the 'Page could not be found' page
+
+Scenario: User receives a 404 page when attempting to access a page absurdly beyond the number of search results
+  Given I visit the /g-cloud/search?page=50000 page
+  Then I am on the 'Page could not be found' page

--- a/features/smoke-tests/supplier/opportunities.feature
+++ b/features/smoke-tests/supplier/opportunities.feature
@@ -34,3 +34,12 @@ Scenario Outline: User can filter by individual lot and keyword search
     | Digital specialists        |
     | Digital outcomes           |
     | User research participants |
+
+Scenario: User receives a 404 page when attempting to access a page beyond the number of search results
+  Given I visit the /digital-outcomes-and-specialists/opportunities?q=metempsychosis&page=2 page
+  Then I am on the 'Page could not be found' page
+
+Scenario: User receives a 404 page when attempting to access a page absurdly beyond the number of search results
+  Given I visit the /digital-outcomes-and-specialists/opportunities?page=50000 page
+  Then I am on the 'Page could not be found' page
+


### PR DESCRIPTION
We've bumped into this one a few times in the past but we don't seem to have ever built a FT for it. It's something that can potentially break with an index misconfiguration, so adding to smoke tests so we get this tested on live.