### PR TITLE
Fetch latest live framework

### DIFF
--- a/features/buyer/requirements.feature
+++ b/features/buyer/requirements.feature
@@ -139,7 +139,7 @@ Scenario: Create user research participants
 
 @copy-requirements
 Scenario Outline: Copy requirements
-  Given I have a live digital-outcomes-and-specialists framework
+  Given I have the latest live digital-outcomes-and-specialists framework
   And I have a buyer user
   And that buyer is logged in
   And I have a <status> digital-specialists brief
@@ -159,7 +159,7 @@ Scenario Outline: Copy requirements
 
 
 Scenario Outline: View requirement in a dashboard
-  Given I have a live digital-outcomes-and-specialists framework
+  Given I have the latest live digital-outcomes-and-specialists framework
   And I have a buyer user
   And that buyer is logged in
   And I have a <status> digital-specialists brief

--- a/features/public/public.feature
+++ b/features/public/public.feature
@@ -2,7 +2,7 @@
 Feature: Published requirements can be viewed by the public
 
 Scenario: Public views the publish requirements. Details presented matches what was publisehd.
-  Given I have a live digital-outcomes-and-specialists framework
+  Given I have the latest live digital-outcomes-and-specialists framework
   And I have a buyer user
   And that buyer is logged in
   And I have a live digital-specialists brief

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -20,7 +20,7 @@ Given /^I visit the (.* )?(\/.*) page$/ do |app, url|
   end
 end
 
-Given /^I have a live (.*) framework(?: with the (.*) lot)?$/ do |metaframework_slug, lot_slug|
+Given /^I have the latest live (.*) framework(?: with the (.*) lot)?$/ do |metaframework_slug, lot_slug|
   response = call_api(:get, "/frameworks")
   expect(response.code).to eq(200), _error(response, "Failed getting frameworks")
   frameworks = JSON.parse(response.body)['frameworks']
@@ -29,7 +29,7 @@ Given /^I have a live (.*) framework(?: with the (.*) lot)?$/ do |metaframework_
     frameworks.delete_if { |framework| framework['lots'].select { |lot| lot["slug"] == lot_slug }.to_a.empty? }
   end
   expect(frameworks).not_to be_empty, _error(response, "No live '#{metaframework_slug}' frameworks found with lot '#{lot_slug}'")
-  @framework = frameworks[0]
+  @framework = frameworks.sort_by! { |framework| framework[:id] }.reverse![0]
   puts @framework['slug']
 end
 

--- a/features/supplier/supplier_applies_for_an_opportunity.feature
+++ b/features/supplier/supplier_applies_for_an_opportunity.feature
@@ -2,7 +2,7 @@
 Feature: Supplier applies for an opportunity
 
 Background:
-  Given I have a live digital-outcomes-and-specialists framework
+  Given I have the latest live digital-outcomes-and-specialists framework
   And I have a buyer user
   And I have a live digital-specialists brief
   And I have a supplier user

--- a/features/supplier/view_and_edit_dos_services.feature
+++ b/features/supplier/view_and_edit_dos_services.feature
@@ -2,7 +2,7 @@
 Feature: Supplier being able to view their DOS services
 
 Background:
-  Given I have a live digital-outcomes-and-specialists framework
+  Given I have the latest live digital-outcomes-and-specialists framework
   And I have a supplier user
   And that supplier is logged in
   And that supplier has applied to be on that framework

--- a/features/supplier/view_and_edit_g_cloud_services.feature
+++ b/features/supplier/view_and_edit_g_cloud_services.feature
@@ -2,7 +2,7 @@
 Feature: G-Cloud supplier can view and edit their G-Cloud services
 
 Background:
-  Given I have a live g-cloud framework with the cloud-support lot
+  Given I have the latest live g-cloud framework with the cloud-support lot
   And I have a supplier user
   And that supplier is logged in
   And that supplier has applied to be on that framework
@@ -13,7 +13,7 @@ Background:
   # The following step only works by virtue of there only being a single service for this supplier - multiple services on
   # multiple frameworks will cause multiple "View services" links to be present
   And I click 'View services'
-  Then I am on the 'G-Cloud 9 services' page
+  Then I am on the 'G-Cloud 10 services' page
   When I click 'Test cloud support service'
   Then I am on the 'Test cloud support service' page
 

--- a/features/supplier/withdraw_opportunity.feature
+++ b/features/supplier/withdraw_opportunity.feature
@@ -2,7 +2,7 @@
 Feature: Withdraw opportunity supplier journey
 
 Scenario: See detail page for a withdrawn brief
-  Given I have a live digital-outcomes-and-specialists framework
+  Given I have the latest live digital-outcomes-and-specialists framework
   And I have a buyer user
   And I have a withdrawn digital-specialists brief
   When I go to that brief page


### PR DESCRIPTION
I've run these locally against preview and all passed.

<img width="423" alt="screen shot 2018-10-01 at 11 25 33" src="https://user-images.githubusercontent.com/13836290/46283746-37054700-c56d-11e8-8768-442addc94a6a.png">


We had a step to fetch a live framework from a particular family. This
was taking the first framework returned from _all_ live frameworks for
that family. Normally that's fine as 95% of the time there is only one
live framework on a particular family. However g-cloud has an overlap.
This update means that we'll always use the latest live framework and so
we should see failures due to changes in framework state earlier.