### PR TITLE
Antivirus test tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,11 +68,12 @@ Tags are used to include/exclude given tests on certain environments. The follow
 | requires-credentials        | All tests which require API tokens.                   |
 | requires-aws-credentials    | All tests which require AWS credentials.              |
 | smoke-tests                 |                                                       |
+| antivirus                   |                                                       |
 | opportunities               |                                                       |
 | requirements                |                                                       |
 | direct-award                |                                                       |
 | brief-response              |                                                       |
-| with-production-<type>-user |                                                       |
+| with-production-_type_-user |                                                       |
 | skip                        | Skip this test everywhere (e.g. temporarily disabled) |
 | skip-preview                | Will not run on the preview environment.              |
 | skip-staging                | Will not run on the staging environment.              |

--- a/config/common.sh
+++ b/config/common.sh
@@ -6,6 +6,7 @@ export DM_API_DOMAIN=${DM_API_DOMAIN:=https://api.${DM_ENVIRONMENT}.marketplace.
 export DM_API_ACCESS_TOKEN=${DM_API_ACCESS_TOKEN:=myToken}
 export DM_SEARCH_API_DOMAIN=${DM_SEARCH_API_DOMAIN:=https://search-api.${DM_ENVIRONMENT}.marketplace.team}
 export DM_SEARCH_API_ACCESS_TOKEN=${DM_SEARCH_API_ACCESS_TOKEN:=myToken}
+export DM_ANTIVIRUS_API_DOMAIN=${DM_ANTIVIRUS_API_DOMAIN:=https://antivirus-api.${DM_ENVIRONMENT}.marketplace.team}
 export DM_FRONTEND_DOMAIN=${DM_FRONTEND_DOMAIN:=https://www.${DM_ENVIRONMENT}.marketplace.team}
 
 export DM_NOTIFY_API_KEY=${DM_NOTIFY_API_KEY}

--- a/features/antivirus/antivirus.feature
+++ b/features/antivirus/antivirus.feature
@@ -1,6 +1,6 @@
 Feature: Antivirus scanning
 
-@notify @file-upload @requires-aws-credentials
+@notify @file-upload @requires-aws-credentials @skip-local
 Scenario: Uploading an infected file to a bucket should generate a warning email
   Given I have a randomized file containing the eicar test signature
   When I upload that file to the documents bucket under the key 'functional_tests/bad.pdf'

--- a/features/antivirus/antivirus.feature
+++ b/features/antivirus/antivirus.feature
@@ -1,6 +1,6 @@
 Feature: Antivirus scanning
 
-@notify @file-upload @requires-aws-credentials @skip-local
+@antivirus @notify @file-upload @requires-aws-credentials @skip-local
 Scenario: Uploading an infected file to a bucket should generate a warning email
   Given I have a randomized file containing the eicar test signature
   When I upload that file to the documents bucket under the key 'functional_tests/bad.pdf'

--- a/features/smoke-tests/apps_status.feature
+++ b/features/smoke-tests/apps_status.feature
@@ -13,6 +13,12 @@ Feature: Apps /_status is ok
     Then I see 'ok' as the value of the 'status' JSON field
     And Display the value of the 'version' JSON field as 'Release version'
 
+  @status @antivirus-api
+  Scenario: Check the antivirus API /_status
+    Given I visit the antivirus-api /_status page
+    Then I see 'ok' as the value of the 'status' JSON field
+    And Display the value of the 'version' JSON field as 'Release version'
+
   @status @user-frontend
   Scenario: Check the user frontend /_status
     Given I visit the frontend /user/_status page

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -34,6 +34,8 @@ def domain_for_app(app)
     dm_api_domain
   when "search-api"
     dm_search_api_domain
+  when "antivirus-api"
+    dm_antivirus_api_domain
   when "frontend"
     dm_frontend_domain
   else
@@ -59,6 +61,10 @@ end
 
 def dm_search_api_access_token
   ENV['DM_SEARCH_API_ACCESS_TOKEN'] || 'myToken'
+end
+
+def dm_antivirus_api_domain
+  ENV['DM_ANTIVIRUS_API_DOMAIN'] || 'http://localhost:5008'
 end
 
 def dm_frontend_domain


### PR DESCRIPTION
Missed a couple of things here a few weeks ago. Add `@skip-local` tag to antivirus test, also add antivirus-api to app status checks.

Mustn't get merged before a corresponding change to the jenkins config has made it in to supply `DM_ANTIVIRUS_API_DOMAIN` to the jobs.