### PR TITLE
Remove @skip-staging from supplier application

### DIFF
--- a/features/supplier/supplier_account.feature
+++ b/features/supplier/supplier_account.feature
@@ -6,7 +6,6 @@ Background:
   And that supplier is logged in
   And I visit the /suppliers page
 
-@skip-staging
 Scenario: Supplier user can provide and change supplier details before confirming them for framework applications
   When I click 'Company details'
   Then I am on the 'Company details' page


### PR DESCRIPTION
VAT numbers have now been removed from the supplier application journey on Staging (see https://github.com/alphagov/digitalmarketplace-functional-tests/pull/582). We can re-enable the staging functional tests for this scenario.