### PR TITLE
Update rack

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,7 +90,7 @@ GEM
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
     public_suffix (3.0.3)
-    rack (2.0.5)
+    rack (2.0.6)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rainbow (2.2.2)


### PR DESCRIPTION
A [snyk report] highlighted a vulnerability in `rack@2.0.5`, and suggested we upgrade a bunch of our immediate dependencies to mitigate this issue.

However, I spent a little time reading the [`bundle` manual][bundle rationale] and realised that all we needed to do was run

```bash
    bundle update rack
```

+1 for RTFM :grinning:

The [ticket] suggests that we need to update Capybara to close this ticket, however I think that if Snyk is happy with this branch then we consider the issue closed. Let me know if you disagree.

[bundle rationale]: https://bundler.io/v1.3/rationale.html
[snyk report]: https://app.snyk.io/org/digital-marketplace/project/fb32c449-df7b-4456-897b-f3fa8c9a17c1
[ticket]: https://trello.com/c/kob8MMeL/509-upgrade-capybara-to-v3