### PR TITLE
add basic test for "degenerate URLs" to smoulder tests

### DIFF
--- a/features/smoulder-tests/public/urls.feature
+++ b/features/smoulder-tests/public/urls.feature
@@ -1,0 +1,14 @@
+@smoulder-tests
+Feature: Handling of various degenerate URL cases
+
+Scenario: Use of leading double-slashes in URL path
+  Given I visit the //user/login page
+  Then I am on the 'Log in to the Digital Marketplace' page
+
+Scenario: Use of trailing slashes in URL path
+  Given I visit the /user/login/ page
+  Then I am on the 'Log in to the Digital Marketplace' page
+
+Scenario: Use of relative URL path components
+  Given I visit the /user/../help page
+  Then I am on the 'What do you need help with?' page


### PR DESCRIPTION
To make sure https://trello.com/c/ZniGEuve/256-nginx-handling-of-double-forward-slashes stays fixed.

Can anyone think of any more degenerate URLs we should be testing?