### PR TITLE
Scenario for admins searching by supplier registered name

### DIFF
--- a/features/admin/deactivate_supplier_user.feature
+++ b/features/admin/deactivate_supplier_user.feature
@@ -49,6 +49,7 @@ Scenario Outline: Correct users can view but not deactivate suppliers users
     | admin-ccs-category      | Edit suppliers and services |
     | admin-framework-manager | View suppliers and services |
 
+@skip-staging
 Scenario Outline: Correct users cannot view suppliers users
   Given I am logged in as the production <role> user
   When I visit the /admin/suppliers?supplier_name=DM+Functional+Test+Supplier+-+Deactivate+a+supplier's+contributor+feature page

--- a/features/admin/deactivate_supplier_user.feature
+++ b/features/admin/deactivate_supplier_user.feature
@@ -51,7 +51,7 @@ Scenario Outline: Correct users can view but not deactivate suppliers users
 
 Scenario Outline: Correct users cannot view suppliers users
   Given I am logged in as the production <role> user
-  When I visit the /admin/suppliers?supplier_name_prefix=DM+Functional+Test+Supplier+-+Deactivate+a+supplier's+contributor+feature page
+  When I visit the /admin/suppliers?supplier_name=DM+Functional+Test+Supplier+-+Deactivate+a+supplier's+contributor+feature page
   Then I don't see the 'Users' link
 
   Examples:

--- a/features/admin/invite_supplier_contributor.feature
+++ b/features/admin/invite_supplier_contributor.feature
@@ -7,7 +7,7 @@ Scenario Outline: Correct users can invite a contributors to a supplier account
   And I have a supplier with:
     | name          | DM Functional Test Supplier - Invite a contributor feature |
   And I click the 'Edit supplier accounts or view services' link
-  And I enter 'DM Functional Test Supplier - Invite a contributor feature' in the 'supplier_name_prefix' field and click its associated 'Search' button
+  And I enter 'DM Functional Test Supplier - Invite a contributor feature' in the 'supplier_name' field and click its associated 'Search' button
   And I click a summary table 'Users' link for 'DM Functional Test Supplier - Invite a contributor feature'
   When I enter 'simulate-delivered@notifications.service.gov.uk' in the 'Email address' field
   And I click the 'Send invitation' button
@@ -19,7 +19,7 @@ Scenario Outline: Correct users can invite a contributors to a supplier account
 
 Scenario Outline: Prohibited user roles cannot manage supplier users
   Given I am logged in as the production <role> user
-  When I visit the /admin/suppliers?supplier_name_prefix=DM+Functional+Test+Supplier+-+Invite+a+contributor+feature page
+  When I visit the /admin/suppliers?supplier_name=DM+Functional+Test+Supplier+-+Invite+a+contributor+feature page
   Then I don't see the 'Users' link
 
   Examples:
@@ -29,7 +29,7 @@ Scenario Outline: Prohibited user roles cannot manage supplier users
 
 Scenario Outline: Prohibited user roles cannot invite users to a supplier
   Given I am logged in as the production <role> user
-  When I visit the /admin/suppliers?supplier_name_prefix=DM+Functional+Test+Supplier+-+Invite+a+contributor+feature page
+  When I visit the /admin/suppliers?supplier_name=DM+Functional+Test+Supplier+-+Invite+a+contributor+feature page
   And I click the summary table 'Users' link for 'DM Functional Test Supplier - Invite a contributor feature'
   Then I don't see the 'Send invitation' button
 

--- a/features/admin/invite_supplier_contributor.feature
+++ b/features/admin/invite_supplier_contributor.feature
@@ -1,4 +1,4 @@
-@admin @invite-supplier-contributor
+@admin @invite-supplier-contributor @skip-staging
 Feature: Invite a contributor to a supplier account
 
 @requires-credentials @notify

--- a/features/admin/search_for_suppliers.feature
+++ b/features/admin/search_for_suppliers.feature
@@ -1,0 +1,19 @@
+@admin @search-supplier-name
+Feature: Search by registered supplier name
+
+Scenario Outline: Correct users search for a supplier by registered name
+  Given I am logged in as the production <role> user
+  And I have a supplier with:
+    | name           | DM Functional Test Supplier - Search supplier name feature |
+    | registeredName | DM Functional Test Supplier - Search registered supplier name |
+  And I click the '<link-name>' link
+  And I enter 'Functional Test Supplier - Search registered' in the 'Find a supplier by name' field
+  And I click the 'find_supplier_by_name_search' button
+  Then I see an entry in the 'Suppliers' table with:
+    | Name                                                       | Change name | Users | Services |
+    | DM Functional Test Supplier - Search supplier name feature | Change name | Users | Services |
+
+  Examples:
+    | role                    | link-name                               |
+    | admin                   | Edit supplier accounts or view services |
+    | admin-ccs-category      | Edit suppliers and services             |

--- a/features/admin/search_for_suppliers.feature
+++ b/features/admin/search_for_suppliers.feature
@@ -1,4 +1,4 @@
-@admin @search-supplier-name
+@admin @search-supplier-name @skip-staging
 Feature: Search by registered supplier name
 
 Scenario Outline: Correct users search for a supplier by registered name

--- a/features/admin/update_supplier_name.feature
+++ b/features/admin/update_supplier_name.feature
@@ -28,7 +28,7 @@ Scenario Outline: Correct users can edit a supplier name
 
 Scenario Outline: Correct users cannot update the supplier name
   Given I am logged in as the production <role> user
-  When I visit the /admin/suppliers?supplier_name_prefix=DM+Functional+Test+Supplier+-+Update+supplier+name+feature page
+  When I visit the /admin/suppliers?supplier_name=DM+Functional+Test+Supplier+-+Update+supplier+name+feature page
   Then I don't see the 'Change name' link
 
   Examples:

--- a/features/admin/update_supplier_name.feature
+++ b/features/admin/update_supplier_name.feature
@@ -1,4 +1,4 @@
-@admin @update-supplier-name
+@admin @update-supplier-name @skip-staging
 Feature: Update supplier name
 
 Scenario Outline: Correct users can edit a supplier name

--- a/features/support/api_helpers.rb
+++ b/features/support/api_helpers.rb
@@ -380,6 +380,18 @@ def get_or_create_supplier(custom_supplier_data)
     response = call_api(:get, '/suppliers', params: { prefix: custom_supplier_data['name'] })
     @supplier = JSON.parse(response.body)['suppliers'][0]
   end
+  if custom_supplier_data["registeredName"] != nil
+    registered_name = custom_supplier_data["registeredName"]
+    response = call_api(:get, '/suppliers', params: { name: registered_name })
+    @supplier = JSON.parse(response.body)['suppliers'][0]
+    if not @supplier
+      # Create supplier without registeredName as this will fail validation
+      custom_supplier_data.delete('registeredName')
+      @supplier = create_supplier(custom_supplier_data)
+      # Update supplier with registeredName afterwards
+      update_supplier(@supplier['id'], { registeredName: registered_name })
+    end
+  end
   if not @supplier
     @supplier = create_supplier(custom_supplier_data)
   end

--- a/features/support/api_helpers.rb
+++ b/features/support/api_helpers.rb
@@ -389,7 +389,7 @@ def get_or_create_supplier(custom_supplier_data)
       custom_supplier_data.delete('registeredName')
       @supplier = create_supplier(custom_supplier_data)
       # Update supplier with registeredName afterwards
-      update_supplier(@supplier['id'], { registeredName: registered_name })
+      update_supplier(@supplier['id'], registeredName: registered_name)
     end
   end
   if not @supplier


### PR DESCRIPTION
Trello: https://trello.com/c/aSOduJAQ/319-admin-search-for-registered-name-as-well-as-supplier-name

To test changes in https://github.com/alphagov/digitalmarketplace-admin-frontend/pull/464 (this PR is blocked on that being merged - also we'll need to remove the `@skip-staging` tag here once the Admin FE gets released).

Two main notes for reviewers:
- We can't create a supplier object with `registeredName` in the payload, as it doesn't pass the API's schema validation (this reflects what happens when a supplier creates an account - they only supply a registered name when they're applying to a framework). So in order to set up a test supplier  with a specific registered name, I had to change the helper method to create a supplier without a registered name first, then update it afterwards. Not particularly elegant but then neither is the rest of our `api_helpers.rb`...
- I've kept this as its own feature rather than include in the smoke tests (see https://github.com/alphagov/digitalmarketplace-functional-tests/blob/master/features/smoke-tests/admin/search.feature), as we can't pick a random supplier - there's no guarantee a random supplier will have a 'registeredName' different enough from the 'name' to confirm that the result was matched on its 'registeredName'). So we have to create one, therefore it's unsuitable as a smoke test.