### PR TITLE
add basic "Supplier upload signed agreement" journey test

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Tags are used to include/exclude given tests on certain environments. The follow
 | notify                      | Tests whether an email was sent.                      |
 | mailchimp                   | Tests updating a mailing list.                        |
 | file-upload                 | Tests uploading files.                                |
+| file-download               | Tests downloading files                               |
 | requires-credentials        | All tests which require API tokens.                   |
 | requires-aws-credentials    | All tests which require AWS credentials.              |
 | smoke-tests                 |                                                       |
@@ -83,7 +84,7 @@ Tags are used to include/exclude given tests on certain environments. The follow
 | requirements                |                                                       |
 | direct-award                |                                                       |
 | brief-response              |                                                       |
-| with-_type_-user |                                                       |
+| with-_type_-user            |                                                       |
 | skip                        | Skip this test everywhere (e.g. temporarily disabled) |
 | skip-preview                | Will not run on the preview environment.              |
 | skip-staging                | Will not run on the staging environment.              |

--- a/features/admin/download_user_research_csvs.feature
+++ b/features/admin/download_user_research_csvs.feature
@@ -21,10 +21,13 @@ Scenario Outline: Correct users cannot view the link to download buyer user rese
     | admin-ccs-category        |
     | admin-ccs-data-controller |
 
+@file-download
 Scenario Outline: Correct users can access the page to download supplier user research participants
   Given I am logged in as the existing <role> user
   And I click the 'Download lists of potential user research participants' link
   Then I am on the 'Download lists of potential user research participants' page
+  When I click a link with text containing 'User research participants on'
+  Then I should get a download file with filename ending '.csv' and content-type 'text/csv'
 
   Examples:
     | role                    |

--- a/features/buyer/tell_us_about_contract.feature
+++ b/features/buyer/tell_us_about_contract.feature
@@ -85,6 +85,7 @@ Scenario: User exports results
   When I click the 'Return to your task list' link
   Then I see the 'Export your results' instruction list item status showing as 'Completed'
 
+@file-download
 Scenario: User download results
   Given I am logged in as a buyer user
   And I have created and saved a search called 'my cloud project'
@@ -99,6 +100,7 @@ Scenario: User download results
   When I click the 'Download search results as comma-separated values' link
   Then I should get a download file with filename ending '.csv' and content type 'text/csv; header=present; charset=utf-8'
 
+@file-download
 Scenario: User downloads results - via the saved searches dashboard
   Given I am logged in as a buyer user
   And I am ready to tell the outcome for the 'my cloud project' saved search
@@ -147,6 +149,7 @@ Scenario: User does not award contract as there are no suitable services
   Then I see a success banner message containing 'You’ve updated ‘my cloud project’'
   And I see the 'Award a contract' instruction list item status showing as 'No suitable services found'
 
+@file-download
 Scenario: User is still assessing services - via the saved searches dashboard
   Given I am logged in as a buyer user
   And I am ready to tell the outcome for the 'my cloud project' saved search

--- a/features/buyer/tell_us_about_contract.feature
+++ b/features/buyer/tell_us_about_contract.feature
@@ -91,13 +91,13 @@ Scenario: User download results
   And I have exported my results for the 'my cloud project' saved search
   Then I am on the 'Download your results' page
   When I click the 'Download search results as a spreadsheet' link
-  Then I should get a download file of type 'ods'
+  Then I should get a download file with filename ending '.ods' and content type 'application/vnd.oasis.opendocument.spreadsheet'
   When I click the 'Return to your task list' link
   Then I am on the 'my cloud project' page
   When I click the 'Download your results' link
   Then I am on the 'Download your results' page
   When I click the 'Download search results as comma-separated values' link
-  Then I should get a download file of type 'csv'
+  Then I should get a download file with filename ending '.csv' and content type 'text/csv; header=present; charset=utf-8'
 
 Scenario: User downloads results - via the saved searches dashboard
   Given I am logged in as a buyer user
@@ -106,7 +106,7 @@ Scenario: User downloads results - via the saved searches dashboard
   And I click the 'Download results' link
   Then I am on the 'Download your results' page
   When I click the 'Download search results as a spreadsheet' link
-  Then I should get a download file of type 'ods'
+  Then I should get a download file with filename ending '.ods' and content type 'application/vnd.oasis.opendocument.spreadsheet'
 
 Scenario: User confirms understanding how to assess services
   Given I am logged in as a buyer user

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -129,11 +129,15 @@ When /I click #{MAYBE_VAR} ?(button|link)?$/ do |button_link_name, elem_type|
   end
 end
 
-When /I click a link with text #{MAYBE_VAR}(?: in #{MAYBE_VAR})?$/ do |link_text, element|
+When /I click a link with text( containing)? #{MAYBE_VAR}(?: in #{MAYBE_VAR})?$/ do |maybe_containing, link_text, element|
   expect(element).not_to be_a(String), "It's not yet decided what a plain String should mean in this context"
 
   region = element || page
-  found_links = region.all(:xpath, "//a[normalize-space(string())=normalize-space(#{escape_xpath(link_text)})]")
+  if maybe_containing
+    found_links = region.all(:xpath, "//a[contains(normalize-space(string()), normalize-space(#{escape_xpath(link_text)}))]")
+  else
+    found_links = region.all(:xpath, "//a[normalize-space(string())=normalize-space(#{escape_xpath(link_text)})]")
+  end
   if found_links.length > 1
     puts "Warning: #{found_links.length} '#{link_text}' links found"
   end

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -2,12 +2,12 @@ require 'date'
 require 'securerandom'
 require 'uri'
 
-Given /^I visit the homepage$/ do
+Given /^I (?:re-?)?visit the homepage$/ do
   page.visit("#{dm_frontend_domain}")
   expect(page).to have_content("Digital Marketplace")
 end
 
-Given /^I visit the (.* )?(\/.*) page$/ do |app, url|
+Given /^I (?:re-?)?visit the (.* )?(\/.*) page$/ do |app, url|
   # If the app is set, then send the request using rest-client instead of capybara
   # and store the result in @response. Otherwise, poltergeist/phantomjs try to wrap
   # the response JSON in HTML.
@@ -239,12 +239,12 @@ Then /^I see #{MAYBE_VAR} breadcrumb$/ do |breadcrumb_text|
   expect(breadcrumb.text).to eq(breadcrumb_text)
 end
 
-Then /^I (don't |)see the '(.*)' (button|link)$/ do |negative, selector_text, selector_type|
+Then /^I (don't |)see (?:the|a) '(.*)' (button|link)$/ do |negative, selector_text, selector_type|
   expect(page).to have_selector(:link_or_button, selector_text) if negative.empty?
   expect(page).not_to have_selector(:link_or_button, selector_text) unless negative.empty?
 end
 
-Then /^I wait to see the '(.*)' link with href '(.*)'$/ do |selector_text, href|
+Then /^I wait to see (?:the|a) '(.*)' link with href '(.*)'$/ do |selector_text, href|
   find(:xpath, "//a[substring(@href, string-length(@href) - (string-length('#{href}')) + 1) = '#{href}'][normalize-space(text()) = '#{selector_text}']", wait: dm_custom_wait_time)
 end
 

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -347,7 +347,7 @@ Then /^I see the '(.*)' summary table filled with:$/ do |table_heading, table|
   end
 end
 
-Then /^I see '(.*)' in the '(.*)' summary table$/ do |content, table_heading|
+Then /^I see #{MAYBE_VAR} in the '(.*)' summary table$/ do |content, table_heading|
   result_table_rows = get_table_rows_by_caption(table_heading)
   expect(result_table_rows.any? { |row| row.text.include?(content) }).to be true
 end

--- a/features/step_definitions/direct_award_steps.rb
+++ b/features/step_definitions/direct_award_steps.rb
@@ -82,7 +82,7 @@ When (/^I have downloaded the search results as a file of type '(.*)'$/) do |fil
   else
     puts "The file type '#{file_type}' is not recognised"
   end
-  steps "And I should get a download file of type '#{file_type}'"
+  steps "And I should get a download file with filename ending '.#{file_type}'"
 end
 
 And (/^I see the '(.*)' instruction list item status showing as '(.*)'$/) do |list_item, status|

--- a/features/step_definitions/supplier_steps.rb
+++ b/features/step_definitions/supplier_steps.rb
@@ -40,11 +40,11 @@ Given /^that(?: (micro|small|medium|large))? supplier has applied to be on that 
   submit_supplier_declaration(@framework['slug'], @supplier["id"], 'status': 'complete', 'nameOfOrganisation': 'foobarbaz', 'primaryContactEmail': 'foo.bar@example.com')
 end
 
-Given 'we accept that suppliers application to the framework' do
+Given 'we accepted that suppliers application to the framework' do
   set_supplier_on_framework(@framework['slug'], @supplier["id"], true)
 end
 
-Given 'that supplier returns a signed framework agreement for the framework' do
+Given 'that supplier has returned a signed framework agreement for the framework' do
   sign_framework_agreement(@framework['slug'], @supplier['id'], @supplier_user['id'])
 end
 

--- a/features/step_definitions/supplier_steps.rb
+++ b/features/step_definitions/supplier_steps.rb
@@ -37,7 +37,7 @@ end
 Given /^that(?: (micro|small|medium|large))? supplier has applied to be on that framework$/ do |organisation_size|
   organisation_size ||= %w[micro small medium large].sample
   update_supplier(@supplier["id"], 'organisationSize': organisation_size)
-  submit_supplier_declaration(@framework['slug'], @supplier["id"], 'status': 'complete', 'nameOfOrganisation': 'foobarbaz', 'primaryContactEmail': 'foo.bar@example.com')
+  @declaration = submit_supplier_declaration(@framework['slug'], @supplier["id"], 'status': 'complete', 'nameOfOrganisation': 'foobarbaz', 'primaryContactEmail': 'foo.bar@example.com')
 end
 
 Given 'we accepted that suppliers application to the framework' do
@@ -50,4 +50,5 @@ end
 
 Given /^that supplier has a service on the (.*) lot(?: for the (.*) role)?$/ do |lot_slug, role_type|
   @service = create_live_service(@framework['slug'], lot_slug, @supplier["id"], role_type)
+  puts "service id: #{@service['id']}"
 end

--- a/features/supplier/supplier_applies_for_an_opportunity.feature
+++ b/features/supplier/supplier_applies_for_an_opportunity.feature
@@ -17,8 +17,8 @@ Scenario: Supplier is not eligible as they are not on the framework
 
 Scenario: Supplier is not eligible as they are not on the digital-specialists lot
   Given that supplier has applied to be on that framework
-  And we accept that suppliers application to the framework
-  And that supplier returns a signed framework agreement for the framework
+  And we accepted that suppliers application to the framework
+  And that supplier has returned a signed framework agreement for the framework
   And that supplier has a service on the digital-outcomes lot
   And I go to that brief page
   And I click 'Apply'
@@ -28,8 +28,8 @@ Scenario: Supplier is not eligible as they are not on the digital-specialists lo
 
 Scenario: Supplier is not eligible as they can not provide the developer role
   Given that supplier has applied to be on that framework
-  And we accept that suppliers application to the framework
-  And that supplier returns a signed framework agreement for the framework
+  And we accepted that suppliers application to the framework
+  And that supplier has returned a signed framework agreement for the framework
   And that supplier has a service on the digital-specialists lot for the designer role
   And I go to that brief page
   And I click 'Apply'
@@ -39,8 +39,8 @@ Scenario: Supplier is not eligible as they can not provide the developer role
 
 Scenario: Supplier applies for a digital-specialists brief
   Given that supplier has applied to be on that framework
-  And we accept that suppliers application to the framework
-  And that supplier returns a signed framework agreement for the framework
+  And we accepted that suppliers application to the framework
+  And that supplier has returned a signed framework agreement for the framework
   And that supplier has a service on the digital-specialists lot
   And I have a live digital-specialists brief
   And I go to that brief page
@@ -106,8 +106,8 @@ Scenario: Supplier applies for a digital-specialists brief
 
 Scenario: Supplier applies for a digital-outcomes brief
   Given that supplier has applied to be on that framework
-  And we accept that suppliers application to the framework
-  And that supplier returns a signed framework agreement for the framework
+  And we accepted that suppliers application to the framework
+  And that supplier has returned a signed framework agreement for the framework
   And that supplier has a service on the digital-outcomes lot
   And I have a live digital-outcomes brief
   And I go to that brief page
@@ -163,8 +163,8 @@ Scenario: Supplier applies for a digital-outcomes brief
 
 Scenario: Supplier applies for a user-research-participants brief
   Given that supplier has applied to be on that framework
-  And we accept that suppliers application to the framework
-  And that supplier returns a signed framework agreement for the framework
+  And we accepted that suppliers application to the framework
+  And that supplier has returned a signed framework agreement for the framework
   And that supplier has a service on the user-research-participants lot
   And I have a live user-research-participants brief
   And I go to that brief page
@@ -222,8 +222,8 @@ Scenario: Supplier applies for a user-research-participants brief
 
 Scenario: Previous page links are used during response flow and existing data is replayed
   Given that supplier has applied to be on that framework
-  And we accept that suppliers application to the framework
-  And that supplier returns a signed framework agreement for the framework
+  And we accepted that suppliers application to the framework
+  And that supplier has returned a signed framework agreement for the framework
   And that supplier has a service on the digital-specialists lot
   And I have a live digital-specialists brief
   And that supplier has filled in their response to that brief but not submitted it
@@ -256,8 +256,8 @@ Scenario: Previous page links are used during response flow and existing data is
 
 Scenario: Supplier changes their answers before submission
   Given that supplier has applied to be on that framework
-  And we accept that suppliers application to the framework
-  And that supplier returns a signed framework agreement for the framework
+  And we accepted that suppliers application to the framework
+  And that supplier has returned a signed framework agreement for the framework
   And that supplier has a service on the digital-specialists lot
   And I have a live digital-specialists brief
   And that supplier has filled in their response to that brief but not submitted it
@@ -338,8 +338,8 @@ Scenario: Supplier changes their answers before submission
 
 Scenario: Supplier changes their answers after submission
   Given that supplier has applied to be on that framework
-  And we accept that suppliers application to the framework
-  And that supplier returns a signed framework agreement for the framework
+  And we accepted that suppliers application to the framework
+  And that supplier has returned a signed framework agreement for the framework
   And that supplier has a service on the digital-specialists lot
   And I have a live digital-specialists brief
   And that supplier has filled in their response to that brief but not submitted it
@@ -383,8 +383,8 @@ Scenario: Supplier changes their answers after submission
 
 Scenario: Supplier can resume incomplete application
   Given that supplier has applied to be on that framework
-  And we accept that suppliers application to the framework
-  And that supplier returns a signed framework agreement for the framework
+  And we accepted that suppliers application to the framework
+  And that supplier has returned a signed framework agreement for the framework
   And that supplier has a service on the digital-outcomes lot
   And I have a live digital-outcomes brief
   And I go to that brief page
@@ -413,8 +413,8 @@ Scenario: Supplier can resume incomplete application
 @requires-credentials @notify @opportunity-clarification-question
 Scenario: Supplier asks a clarification question
   Given that supplier has applied to be on that framework
-  And we accept that suppliers application to the framework
-  And that supplier returns a signed framework agreement for the framework
+  And we accepted that suppliers application to the framework
+  And that supplier has returned a signed framework agreement for the framework
   And that supplier has a service on the digital-specialists lot
   And I go to that brief page
   And I click 'Ask a question'
@@ -425,7 +425,7 @@ Scenario: Supplier asks a clarification question
 
 Scenario: Supplier can see sign framework agreement call to action
   Given that supplier has applied to be on that framework
-  And we accept that suppliers application to the framework
+  And we accepted that suppliers application to the framework
   And that supplier has a service on the digital-specialists lot
   And I have a live digital-specialists brief
   And that supplier has filled in their response to that brief but not submitted it
@@ -435,8 +435,8 @@ Scenario: Supplier can see sign framework agreement call to action
 @opportunities-dashboard
 Scenario: Supplier can see the link to the opportunities dashboard
   Given that supplier has applied to be on that framework
-  And we accept that suppliers application to the framework
-  And that supplier returns a signed framework agreement for the framework
+  And we accepted that suppliers application to the framework
+  And that supplier has returned a signed framework agreement for the framework
   And that supplier has a service on the digital-specialists lot
   And I have a live digital-specialists brief
   And that supplier has filled in their response to that brief but not submitted it
@@ -446,8 +446,8 @@ Scenario: Supplier can see the link to the opportunities dashboard
 @opportunities-dashboard
 Scenario: Supplier can see their draft applications on the opportunities dashboard
   Given that supplier has applied to be on that framework
-  And we accept that suppliers application to the framework
-  And that supplier returns a signed framework agreement for the framework
+  And we accepted that suppliers application to the framework
+  And that supplier has returned a signed framework agreement for the framework
   And that supplier has a service on the digital-specialists lot
   And I have a live digital-specialists brief
   And that supplier has filled in their response to that brief but not submitted it

--- a/features/supplier/supplier_uploads_signed_agreement.feature
+++ b/features/supplier/supplier_uploads_signed_agreement.feature
@@ -36,7 +36,9 @@ Scenario: Supplier successfully uploads a signed agreement for a framework
   And I see the 'I have the authority to return' checkbox is not checked
   When I check the 'I have the authority to return' checkbox
   And I click the 'Return signed signature page' button
-  Then I see that framework.name in the page's h1
+  Then I receive a 'contract-review-agreement' email for that declaration.primaryContactEmail
+  And I receive a 'contract-review-agreement' email for that supplier_user.emailAddress
+  And I see that framework.name in the page's h1
   And I see the page's h1 ends in 'documents'
   And I see a success banner message containing 'Your framework agreement has been returned to the Crown Commercial Service to be countersigned'
   And I see an entry in the 'Agreement details' table with:

--- a/features/supplier/supplier_uploads_signed_agreement.feature
+++ b/features/supplier/supplier_uploads_signed_agreement.feature
@@ -1,0 +1,57 @@
+@supplier @file-upload @requires-credentials
+Feature: Supplier uploads a signed agreement for a framework
+
+Background:
+  Given I have the latest live g-cloud framework
+  And I have a supplier user
+  And that supplier has applied to be on that framework
+  And we accepted that suppliers application to the framework
+  And that supplier has a service on the 'cloud-support' lot
+  And that supplier is logged in
+
+Scenario: Supplier successfully uploads a signed agreement for a framework
+  Given I visit the /suppliers page
+  Then I don't see a 'View documents and ask a question' link
+  And I don't see a 'View services' link
+  When I click the 'You must sign the framework agreement to sell these services' link
+  Then I see the page's h1 ends in 'framework agreement'
+  And I see that framework.name in the page's h1
+  # TODO set up this supplier's draft services so the lot table on this page can be asserted - however this
+  # is tricky to set up as it currently requires switching framework states to achieve
+  When I click the 'Return your signed signature page' button
+  Then I see 'Details of the person' in the page's h1
+  And I see the page's h1 ends in that declaration.nameOfOrganisation
+  When I enter 'Mr Cornelius Kelleher' in the 'Full name' field
+  And I enter 'Manager' in the 'Role at the company' field
+  And I click the 'Save and continue' button
+  Then I am on the 'Upload your signed signature' page
+  When I choose file 'test.pdf' for the field 'signature_page'
+  And I click the 'Save and continue' button
+  Then I see 'Check the details' in the page's h1
+  And I see the page's h1 ends in that declaration.nameOfOrganisation
+  And I see the 'Supplier information' summary table filled with:
+    |field            |value                        |
+    |Person who signed|Mr Cornelius Kelleher Manager|
+    |Signature page   |test.pdf                     |
+  And I see the 'I have the authority to return' checkbox is not checked
+  When I check the 'I have the authority to return' checkbox
+  And I click the 'Return signed signature page' button
+  Then I see that framework.name in the page's h1
+  And I see the page's h1 ends in 'documents'
+  And I see a success banner message containing 'Your framework agreement has been returned to the Crown Commercial Service to be countersigned'
+  And I see an entry in the 'Agreement details' table with:
+    |field            |value                        |
+    |Person who signed|Mr Cornelius Kelleher Manager|
+  And I see an entry in the 'Agreement details' table with:
+    |field           |value                         |
+    |Countersignature|Waiting for CCS to countersign|
+  And I see that supplier_user.name in the 'Agreement details' summary table
+  And I see that supplier_user.emailAddress in the 'Agreement details' summary table
+  When I click 'Download your ‘original’ framework agreement signature page'
+  Then I should get an inline file with filename ending '.pdf' and content type 'application/pdf' in a new window
+
+  When I re-visit the /suppliers page
+  Then I see a 'View documents and ask a question' link
+  And I see a 'View services' link
+  And I don't see a 'You must sign the framework agreement to sell these services' link
+

--- a/features/supplier/supplier_uploads_signed_agreement.feature
+++ b/features/supplier/supplier_uploads_signed_agreement.feature
@@ -1,4 +1,4 @@
-@supplier @file-upload @requires-credentials
+@supplier @file-upload @file-download @requires-credentials
 Feature: Supplier uploads a signed agreement for a framework
 
 Background:

--- a/features/supplier/view_and_edit_dos_services.feature
+++ b/features/supplier/view_and_edit_dos_services.feature
@@ -6,8 +6,8 @@ Background:
   And I have a supplier user
   And that supplier is logged in
   And that supplier has applied to be on that framework
-  And we accept that suppliers application to the framework
-  And that supplier returns a signed framework agreement for the framework
+  And we accepted that suppliers application to the framework
+  And that supplier has returned a signed framework agreement for the framework
 
 Scenario Outline: Supplier coming from dashboard to view the detail page for one of their services
   Given that supplier has a service on the <lot_slug> lot

--- a/features/supplier/view_and_edit_g_cloud_services.feature
+++ b/features/supplier/view_and_edit_g_cloud_services.feature
@@ -6,8 +6,8 @@ Background:
   And I have a supplier user
   And that supplier is logged in
   And that supplier has applied to be on that framework
-  And we accept that suppliers application to the framework
-  And that supplier returns a signed framework agreement for the framework
+  And we accepted that suppliers application to the framework
+  And that supplier has returned a signed framework agreement for the framework
   And that supplier has a service on the cloud-support lot
   When I visit the /suppliers page
   # The following step only works by virtue of there only being a single service for this supplier - multiple services on

--- a/features/support/api_helpers.rb
+++ b/features/support/api_helpers.rb
@@ -300,7 +300,7 @@ def create_live_service(framework_slug, lot_slug, supplier_id, role = nil)
     when 'cloud-support'
       service_data['services'] = Fixtures.cloud_support_service
     else
-      puts 'Lot slug not recoginsed'
+      puts 'Lot slug not recognised'
   end
 
   # Set attributes not included in the fixture


### PR DESCRIPTION
https://trello.com/c/EhN9iCiv

I ended up also renovating a few of the steps to make them more flexible/clearer:

 - biggest change is the step checking for "downloads" is now able to (separately) check file extension, content-type, whether the file is `inline` or an `attachment` *or* if it's being opened in a new window (e.g. through `target="_blank"`). I don't know if people will think it's overkill checking for e.g. `and content type 'text/csv; header=present; charset=utf-8'`, but I think a lot of these things don't get checked by anything else, where they're relying on S3 to supply the final header value.
 - change tense of some setup steps' language to make it clearer they're not the active step under test and are only being "simulated"
 - syntactic sugar to allow people to write slightly more illustrative sentences in some cases.