### PR TITLE
Include step for clicking tabbed search

### DIFF
--- a/features/admin/access_a_service.feature
+++ b/features/admin/access_a_service.feature
@@ -9,6 +9,7 @@ Scenario: Admin with Service Manager role can edit, remove and publish a service
   And I am on the 'Admin' page
   When I click 'Edit suppliers and services'
   Then I am on the 'Edit suppliers and services' page
+  And I click the 'Service ID' link
   When I enter that service id in the 'service_id' field and click its associated 'Search' button
   Then I am on that service's page
 
@@ -33,6 +34,7 @@ Scenario Outline: Admins with Framework Manager and Support roles can view, but 
   And I am on the 'Admin' page
   When I click '<link_name>'
   Then I am on the '<link_name>' page
+  And I click the 'Service ID' link
   When I enter that service id in the 'service_id' field and click its associated 'Search' button
   Then I am on that service's page
   And I don't see the 'Edit' link
@@ -46,8 +48,8 @@ Scenario Outline: Admins with Framework Manager and Support roles can view, but 
 
 Scenario Outline: Admins with Admin Manager and Auditor roles cannot access supplier services
   Given I am logged in as the existing <role> user
-  And I visit the /admin/find-suppliers-and-services page
-  Then I don't see 'Find a service by service ID' text on the page
+  And I visit the /admin/search page
+  Then I don't see 'Service ID' text on the page
 
   Examples:
     | role                      |

--- a/features/smoke-tests/admin/search.feature
+++ b/features/smoke-tests/admin/search.feature
@@ -4,7 +4,7 @@ Feature: Admin users can search for objects
 @with-admin-user
 Scenario: Admin can find a supplier by name
   Given I am logged in as the existing admin user
-  And I visit the /admin/find-suppliers-and-services page
+  And I visit the /admin/search page
   And I have a random supplier from the API
   When I enter that supplier.name in the 'Find a supplier by name' field and click its associated 'Search' button
   Then I am on the 'Suppliers' page
@@ -13,8 +13,9 @@ Scenario: Admin can find a supplier by name
 @with-admin-user
 Scenario: Admin can find a supplier by DUNS number
   Given I am logged in as the existing admin user
-  And I visit the /admin/find-suppliers-and-services page
+  And I visit the /admin/search page
   And I have a random supplier from the API
+  And I click the 'DUNS Number' link
   When I enter that supplier.dunsNumber in the 'Find a supplier by DUNS number' field and click its associated 'Search' button
   Then I am on the 'Suppliers' page
   And I see the number of suppliers listed is 1


### PR DESCRIPTION
Recent admin changes broke some smoke tests that we missed.

This PR:
- adds the step to click the tab for the relevant search (DUNS, Service ID etc)
- updates the old URL to the new `/admin/search`