### PR TITLE
Split out new smoke tests for preview

### DIFF
--- a/features/admin/access_a_service.feature
+++ b/features/admin/access_a_service.feature
@@ -4,6 +4,7 @@ Feature: Admins viewing, editing, removing and publishing supplier services
 Background:
   Given I have a published service on a live G-Cloud framework
 
+@skip-staging
 Scenario: Admin with Service Manager role can edit, remove and publish a service
   Given I am logged in as the existing admin-ccs-category user
   And I am on the 'Admin' page
@@ -46,6 +47,7 @@ Scenario Outline: Admins with Framework Manager and Support roles can view, but 
     | admin                   | Edit supplier accounts or view services   |
 
 
+@skip-staging
 Scenario Outline: Admins with Admin Manager and Auditor roles cannot access supplier services
   Given I am logged in as the existing <role> user
   And I visit the /admin/search page

--- a/features/smoke-tests/admin/search.feature
+++ b/features/smoke-tests/admin/search.feature
@@ -1,7 +1,26 @@
 @smoke-tests
 Feature: Admin users can search for objects
 
-@with-admin-user
+@with-admin-user @skip-preview @skip-local
+Scenario: Admin can find a supplier by name
+  Given I am logged in as the existing admin user
+  And I visit the /admin/find-suppliers-and-services page
+  And I have a random supplier from the API
+  When I enter that supplier.name in the 'Find a supplier by name' field and click its associated 'Search' button
+  Then I am on the 'Suppliers' page
+  And I see that supplier in the list of suppliers
+
+@with-admin-user @skip-preview @skip-local
+Scenario: Admin can find a supplier by DUNS number
+  Given I am logged in as the existing admin user
+  And I visit the /admin/find-suppliers-and-services page
+  And I have a random supplier from the API
+  When I enter that supplier.dunsNumber in the 'Find a supplier by DUNS number' field and click its associated 'Search' button
+  Then I am on the 'Suppliers' page
+  And I see the number of suppliers listed is 1
+  And I see that supplier in the list of suppliers
+
+@with-admin-user @skip-staging @skip-production
 Scenario: Admin can find a supplier by name
   Given I am logged in as the existing admin user
   And I visit the /admin/search page
@@ -10,7 +29,7 @@ Scenario: Admin can find a supplier by name
   Then I am on the 'Suppliers' page
   And I see that supplier in the list of suppliers
 
-@with-admin-user
+@with-admin-user @skip-staging @skip-production
 Scenario: Admin can find a supplier by DUNS number
   Given I am logged in as the existing admin user
   And I visit the /admin/search page


### PR DESCRIPTION
Doesn't quite revert https://github.com/alphagov/digitalmarketplace-functional-tests/pull/600

Hopefully this should allow smoke tests to pass on all environments. Preview and local have the 'new' smoke tests, staging and prod have the old ones.

I've just skipped staging for the other (non smoke) func test for now.

