### PR TITLE
Remove skip-prod tags from admin smoke tests

### DIFF
--- a/features/smoke-tests/admin/search.feature
+++ b/features/smoke-tests/admin/search.feature
@@ -1,7 +1,7 @@
 @smoke-tests
 Feature: Admin users can search for objects
 
-@with-admin-user @skip-production
+@with-admin-user
 Scenario: Admin can find a supplier by name
   Given I am logged in as the existing admin user
   And I visit the /admin/search page
@@ -10,7 +10,7 @@ Scenario: Admin can find a supplier by name
   Then I am on the 'Suppliers' page
   And I see that supplier in the list of suppliers
 
-@with-admin-user @skip-production
+@with-admin-user
 Scenario: Admin can find a supplier by DUNS number
   Given I am logged in as the existing admin user
   And I visit the /admin/search page


### PR DESCRIPTION
Trello: https://trello.com/c/dzBKRR5E/339-tabbed-admin-search-for-category-team-and-data-controller

Finally, let's remove `@skip-production` from the admin smoke tests, as this feature (will shortly be) in production and we'd like some test coverage for it 😸