### PR TITLE
Add functionality to tests assets domain and test for favicon

### DIFF
--- a/config/common.sh
+++ b/config/common.sh
@@ -7,6 +7,7 @@ export DM_API_ACCESS_TOKEN=${DM_API_ACCESS_TOKEN:=myToken}
 export DM_SEARCH_API_DOMAIN=${DM_SEARCH_API_DOMAIN:=https://search-api.${DM_ENVIRONMENT}.marketplace.team}
 export DM_SEARCH_API_ACCESS_TOKEN=${DM_SEARCH_API_ACCESS_TOKEN:=myToken}
 export DM_ANTIVIRUS_API_DOMAIN=${DM_ANTIVIRUS_API_DOMAIN:=https://antivirus-api.${DM_ENVIRONMENT}.marketplace.team}
+export DM_ASSETS_DOMAIN=${DM_ASSETS_DOMAIN:=https://assets.${DM_ENVIRONMENT}.marketplace.team}
 export DM_FRONTEND_DOMAIN=${DM_FRONTEND_DOMAIN:=https://www.${DM_ENVIRONMENT}.marketplace.team}
 
 export DM_NOTIFY_API_KEY=${DM_NOTIFY_API_KEY}

--- a/features/public/assets.feature
+++ b/features/public/assets.feature
@@ -1,0 +1,8 @@
+@assets @skip-local
+Feature: Favicon.ico should return a blank, transparent gif on assets. domain
+
+Scenario: Request favicon from assets domain
+  Given I visit the assets /favicon.ico page
+  Then the response code should be 200
+  And the response header content_type should be image/gif
+  

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -20,6 +20,14 @@ Given /^I (?:re-?)?visit the (.* )?(\/.*) page$/ do |app, url|
   end
 end
 
+Given /^the response (?:(header ))?(.*) should be (.*)$/ do |header, attribute, value|
+  if header
+    expect(@response.headers[attribute.to_sym].to_s).to eq(value)
+  else
+    expect(@response.send(attribute).to_s).to eq(value)
+  end
+end
+
 Given /^I have the latest live (.*) framework(?: with the (.*) lot)?$/ do |metaframework_slug, lot_slug|
   response = call_api(:get, "/frameworks")
   expect(response.code).to eq(200), _error(response, "Failed getting frameworks")

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -35,6 +35,8 @@ def domain_for_app(app)
     dm_search_api_domain
   when "antivirus-api"
     dm_antivirus_api_domain
+  when "assets"
+    dm_assets_domain
   when "frontend"
     dm_frontend_domain
   else
@@ -64,6 +66,10 @@ end
 
 def dm_antivirus_api_domain
   ENV['DM_ANTIVIRUS_API_DOMAIN'] || 'http://localhost:5008'
+end
+
+def dm_assets_domain
+  ENV['DM_ASSETS_DOMAIN']
 end
 
 def dm_frontend_domain


### PR DESCRIPTION
Tests:

https://trello.com/c/w6gv9OJ0/376-the-404-chain-reaction-browsers-requesting-favicons-from-our-assets-host
https://github.com/alphagov/digitalmarketplace-router/pull/47

Assets domain should now 200 for a favicon

