### PR TITLE
Company details feature

### DIFF
--- a/features/admin/company_details.feature
+++ b/features/admin/company_details.feature
@@ -1,0 +1,49 @@
+@admin @company-details
+Feature: Company details page
+
+Background:
+  Given I have the latest live g-cloud framework with the cloud-support lot
+  And I have a supplier with:
+      | name                 | DM Functional Test Supplier - Company details feature |
+      | registeredName       | DM Functional Test Suppliers Ltd.                     |
+      | companiesHouseNumber | 87654321                                              |
+  And that supplier has a user with:
+      | name   | DM Functional Test - Supplier Mr Muffins |
+      | email  | muffins@example.com |
+  And that supplier has applied to be on that framework
+  And we accepted that suppliers application to the framework
+  And that supplier has returned a signed framework agreement for the framework
+  And that supplier has a service on the cloud-support lot
+
+Scenario Outline: Correct admin roles can view a supplier's details
+  Given I am logged in as the existing <role> user
+  And I am on the 'Admin' page
+  When I click '<link-name>'
+  Then I am on the '<page-title>' page
+  And I enter 'DM Functional Test Supplier - Company details feature' in the 'Find a supplier by name' field
+  And I click the 'find_supplier_by_name_search' button
+  Then I see an entry in the 'Suppliers' table with:
+    | Supplier Name                                         | Users | Services |
+    | DM Functional Test Supplier - Company details feature | Users | Services |
+  And I click the 'DM Functional Test Supplier - Company details feature' link
+  Then I am on the 'DM Functional Test Supplier - Company details feature' page
+  And I see the 'Company details for G-Cloud 10' summary table filled with:
+    | field                        | value                                            |
+    | Company registered name      | DM Functional Test Suppliers Ltd.                |
+    | Company registration number  | 87654321                                         |
+    | DUNS Number                  | <ANY>                                            |
+    | Address                      | 10 Downing Street London AB1 2CD United Kingdom  |
+  And I see an entry in the 'Frameworks' table with:
+    | field       | link1         | link2           |
+    | G-Cloud 10  | View services | View agreements |
+  When I click the 'Users' link
+  Then I am on the 'DM Functional Test Supplier - Company details feature' page
+  And I see an entry in the 'Users' table with:
+    | Name                                     | Email address   | Last login | Pwd changed | Locked | Status |
+    | DM Functional Test - Supplier Mr Muffins | <ANY>           | <ANY>      | <ANY>       | No     | <ANY>  |
+
+  Examples:
+    | role                      | link-name                               | page-title                              |
+    | admin                     | Edit supplier accounts or view services | Edit supplier accounts or view services |
+    | admin-ccs-category        | Edit suppliers and services             | Edit suppliers and services             |
+    | admin-ccs-data-controller | View and edit suppliers                 | Search for suppliers                    |

--- a/features/admin/company_details.feature
+++ b/features/admin/company_details.feature
@@ -1,4 +1,4 @@
-@admin @company-details
+@admin @company-details @skip-staging
 Feature: Company details page
 
 Background:

--- a/features/admin/deactivate_supplier_user.feature
+++ b/features/admin/deactivate_supplier_user.feature
@@ -11,6 +11,7 @@ Background:
     | name          | Deactivate a suppliers contributor feature User #2 |
     | email_address | user-two@example.com                               |
 
+@skip-staging
 Scenario Outline: Correct users can deactivate and reactivate a supplier's contributor
   Given I am logged in as the existing <role> user
   And I click the 'Edit supplier accounts or view services' link
@@ -30,13 +31,32 @@ Scenario Outline: Correct users can deactivate and reactivate a supplier's contr
     | role  |
     | admin |
 
+@skip-preview @skip-local
+Scenario Outline: Correct users can deactivate and reactivate a supplier's contributor
+  Given I am logged in as the existing <role> user
+  And I click the 'Edit supplier accounts or view services' link
+  And I enter 'DM Functional Test Supplier - Deactivate a suppliers contributor feature' in the 'Find a supplier by name' field
+  And I click the 'find_supplier_by_name_search' button
+  And I click a summary table 'Users' link for 'DM Functional Test Supplier - Deactivate a suppliers contributor feature'
+  When I click the summary table 'Deactivate' button for 'Deactivate a suppliers contributor feature User #1'
+  Then I see an entry in the 'Users' table with:
+    | Name                                               | Email address        | Last login  | Pwd changed | Locked |
+    | Deactivate a suppliers contributor feature User #1 | user-one@example.com | <ANY>       | <ANY>       | No     |
+  When I click the summary table 'Activate' button for 'Deactivate a suppliers contributor feature User #1'
+  Then I see an entry in the 'Users' table with:
+    | Name                                               | Email address        | Last login  | Pwd changed | Locked |
+    | Deactivate a suppliers contributor feature User #1 | user-one@example.com | <ANY>       | <ANY>       | No     |
+  Examples:
+    | role  |
+    | admin |
+
+@skip-staging
 Scenario Outline: Correct users can view but not deactivate suppliers users
   Given I am logged in as the existing <role> user
   And I click the '<link-name>' link
   And I enter 'DM Functional Test Supplier - Deactivate a suppliers contributor feature' in the 'Find a supplier by name' field
   And I click the 'find_supplier_by_name_search' button
   When I click the summary table 'Users' link for the 'DM Functional Test Supplier - Deactivate a suppliers contributor feature' link
-  Then I don't see the 'Deactivate' button
   And I see an entry in the 'Users' table with:
     | Name                                               | Email address        | Last login  | Pwd changed | Locked | Status |
     | Deactivate a suppliers contributor feature User #1 | user-one@example.com | <ANY>       | <ANY>       | No     | Active |
@@ -44,6 +64,25 @@ Scenario Outline: Correct users can view but not deactivate suppliers users
     | Name                                               | Email address        | Last login  | Pwd changed | Locked | Status |
     | Deactivate a suppliers contributor feature User #2 | user-two@example.com | <ANY>       | <ANY>       | No     | Active |
 
+  Examples:
+    | role                    | link-name                   |
+    | admin-ccs-category      | Edit suppliers and services |
+    | admin-framework-manager | View suppliers and services |
+
+@skip-preview @skip-local
+Scenario Outline: Correct users can view but not deactivate suppliers users
+  Given I am logged in as the existing <role> user
+  And I click the '<link-name>' link
+  And I enter 'DM Functional Test Supplier - Deactivate a suppliers contributor feature' in the 'Find a supplier by name' field
+  And I click the 'find_supplier_by_name_search' button
+  When I click a summary table 'Users' link for 'DM Functional Test Supplier - Deactivate a suppliers contributor feature'
+  Then I don't see the 'Deactivate' button
+  And I see an entry in the 'Users' table with:
+    | Name                                               | Email address        | Last login  | Pwd changed | Locked | Status |
+    | Deactivate a suppliers contributor feature User #1 | user-one@example.com | <ANY>       | <ANY>       | No     | Active |
+  And I see an entry in the 'Users' table with:
+    | Name                                               | Email address        | Last login  | Pwd changed | Locked | Status |
+    | Deactivate a suppliers contributor feature User #2 | user-two@example.com | <ANY>       | <ANY>       | No     | Active |
   Examples:
     | role                    | link-name                   |
     | admin-ccs-category      | Edit suppliers and services |

--- a/features/admin/deactivate_supplier_user.feature
+++ b/features/admin/deactivate_supplier_user.feature
@@ -16,7 +16,7 @@ Scenario Outline: Correct users can deactivate and reactivate a supplier's contr
   And I click the 'Edit supplier accounts or view services' link
   And I enter 'DM Functional Test Supplier - Deactivate a suppliers contributor feature' in the 'Find a supplier by name' field
   And I click the 'find_supplier_by_name_search' button
-  And I click a summary table 'Users' link for 'DM Functional Test Supplier - Deactivate a suppliers contributor feature'
+  And I click the summary table 'Users' link for the 'DM Functional Test Supplier - Deactivate a suppliers contributor feature' link
   When I click the summary table 'Deactivate' button for 'Deactivate a suppliers contributor feature User #1'
   Then I see an entry in the 'Users' table with:
     | Name                                               | Email address        | Last login  | Pwd changed | Locked |
@@ -35,7 +35,7 @@ Scenario Outline: Correct users can view but not deactivate suppliers users
   And I click the '<link-name>' link
   And I enter 'DM Functional Test Supplier - Deactivate a suppliers contributor feature' in the 'Find a supplier by name' field
   And I click the 'find_supplier_by_name_search' button
-  When I click a summary table 'Users' link for 'DM Functional Test Supplier - Deactivate a suppliers contributor feature'
+  When I click the summary table 'Users' link for the 'DM Functional Test Supplier - Deactivate a suppliers contributor feature' link
   Then I don't see the 'Deactivate' button
   And I see an entry in the 'Users' table with:
     | Name                                               | Email address        | Last login  | Pwd changed | Locked | Status |

--- a/features/admin/invite_supplier_contributor.feature
+++ b/features/admin/invite_supplier_contributor.feature
@@ -9,7 +9,7 @@ Scenario Outline: Correct users can invite a contributors to a supplier account
   And I click the 'Edit supplier accounts or view services' link
   And I enter 'DM Functional Test Supplier - Invite a contributor feature' in the 'supplier_name' field and click its associated 'Search' button
   And I click the summary table 'Users' link for the 'DM Functional Test Supplier - Invite a contributor feature' link
-  When I enter 'simulate-delivered@notifications.service.gov.uk' in the 'Email address' field
+  When I enter 'functional-test-supplier-contributor@example.gov.uk' in the 'Email address' field
   And I click the 'Send invitation' button
   Then I see a success banner message containing 'User invited'
 
@@ -48,7 +48,7 @@ Scenario Outline: Correct users can invite a contributors to a supplier account
   And I click the 'Edit supplier accounts or view services' link
   And I enter 'DM Functional Test Supplier - Invite a contributor feature' in the 'supplier_name' field and click its associated 'Search' button
   And I click a summary table 'Users' link for 'DM Functional Test Supplier - Invite a contributor feature'
-  When I enter 'simulate-delivered@notifications.service.gov.uk' in the 'Email address' field
+  When I enter 'functional-test-supplier-contributor@example.gov.uk' in the 'Email address' field
   And I click the 'Send invitation' button
   Then I see a success banner message containing 'User invited'
 

--- a/features/admin/invite_supplier_contributor.feature
+++ b/features/admin/invite_supplier_contributor.feature
@@ -8,7 +8,7 @@ Scenario Outline: Correct users can invite a contributors to a supplier account
     | name          | DM Functional Test Supplier - Invite a contributor feature |
   And I click the 'Edit supplier accounts or view services' link
   And I enter 'DM Functional Test Supplier - Invite a contributor feature' in the 'supplier_name' field and click its associated 'Search' button
-  And I click a summary table 'Users' link for 'DM Functional Test Supplier - Invite a contributor feature'
+  And I click the summary table 'Users' link for the 'DM Functional Test Supplier - Invite a contributor feature' link
   When I enter 'simulate-delivered@notifications.service.gov.uk' in the 'Email address' field
   And I click the 'Send invitation' button
   Then I see a success banner message containing 'User invited'
@@ -30,7 +30,7 @@ Scenario Outline: Prohibited user roles cannot manage supplier users
 Scenario Outline: Prohibited user roles cannot invite users to a supplier
   Given I am logged in as the existing <role> user
   When I visit the /admin/suppliers?supplier_name=DM+Functional+Test+Supplier+-+Invite+a+contributor+feature page
-  And I click the summary table 'Users' link for 'DM Functional Test Supplier - Invite a contributor feature'
+  And I click the summary table 'Users' link for the 'DM Functional Test Supplier - Invite a contributor feature' link
   Then I don't see the 'Send invitation' button
 
   Examples:

--- a/features/admin/invite_supplier_contributor.feature
+++ b/features/admin/invite_supplier_contributor.feature
@@ -1,7 +1,7 @@
 @admin @invite-supplier-contributor
 Feature: Invite a contributor to a supplier account
 
-@requires-credentials @notify
+@requires-credentials @notify @skip-staging
 Scenario Outline: Correct users can invite a contributors to a supplier account
   Given I am logged in as the existing <role> user
   And I have a supplier with:
@@ -27,10 +27,40 @@ Scenario Outline: Prohibited user roles cannot manage supplier users
     | admin-ccs-sourcing      |
     | admin-manager           |
 
+@skip-staging
 Scenario Outline: Prohibited user roles cannot invite users to a supplier
   Given I am logged in as the existing <role> user
   When I visit the /admin/suppliers?supplier_name=DM+Functional+Test+Supplier+-+Invite+a+contributor+feature page
   And I click the summary table 'Users' link for the 'DM Functional Test Supplier - Invite a contributor feature' link
+  Then I don't see the 'Send invitation' button
+
+  Examples:
+    | role                      |
+    | admin-framework-manager   |
+    | admin-ccs-category        |
+    | admin-ccs-data-controller |
+
+@requires-credentials @notify @skip-preview @skip-local
+Scenario Outline: Correct users can invite a contributors to a supplier account
+  Given I am logged in as the existing <role> user
+  And I have a supplier with:
+    | name          | DM Functional Test Supplier - Invite a contributor feature |
+  And I click the 'Edit supplier accounts or view services' link
+  And I enter 'DM Functional Test Supplier - Invite a contributor feature' in the 'supplier_name' field and click its associated 'Search' button
+  And I click a summary table 'Users' link for 'DM Functional Test Supplier - Invite a contributor feature'
+  When I enter 'simulate-delivered@notifications.service.gov.uk' in the 'Email address' field
+  And I click the 'Send invitation' button
+  Then I see a success banner message containing 'User invited'
+
+  Examples:
+    | role                    |
+    | admin                   |
+
+@skip-preview @skip-local
+Scenario Outline: Prohibited user roles cannot invite users to a supplier
+  Given I am logged in as the existing <role> user
+  When I visit the /admin/suppliers?supplier_name=DM+Functional+Test+Supplier+-+Invite+a+contributor+feature page
+  And I click a summary table 'Users' link for 'DM Functional Test Supplier - Invite a contributor feature'
   Then I don't see the 'Send invitation' button
 
   Examples:

--- a/features/admin/search_for_suppliers.feature
+++ b/features/admin/search_for_suppliers.feature
@@ -1,5 +1,5 @@
 @admin
-Feature: Search by registered supplier name
+Feature: Search for suppliers by registered name, DUNS number and companies house number
 
 @search-supplier-name
 Scenario Outline: Correct users search for a supplier by registered name
@@ -18,20 +18,7 @@ Scenario Outline: Correct users search for a supplier by registered name
     | role                      | link-name                               |
     | admin                     | Edit supplier accounts or view services |
     | admin-ccs-category        | Edit suppliers and services             |
-
-
-@search-supplier-name @with-admin-ccs-data-controller-user
-Scenario: Admin data controller user can search for a supplier by registered name
-  Given I am logged in as the existing admin-ccs-data-controller user
-  And I have a supplier with:
-    | name           | DM Functional Test Supplier - Search supplier name feature |
-    | registeredName | DM Functional Test Supplier - Search registered supplier name |
-  And I click the 'View and edit suppliers' link
-  And I enter 'Functional Test Supplier - Search registered' in the 'Find a supplier by name' field
-  And I click the 'find_supplier_by_name_search' button
-  Then I see an entry in the 'Suppliers' table with:
-    | Name                                                       | Users | Services |
-    | DM Functional Test Supplier - Search supplier name feature | Users | Services |
+    | admin-ccs-data-controller | View and edit suppliers                 |
 
 
 @search-supplier-duns @with-admin-ccs-data-controller-user

--- a/features/admin/search_for_suppliers.feature
+++ b/features/admin/search_for_suppliers.feature
@@ -11,8 +11,8 @@ Scenario Outline: Correct users search for a supplier by registered name
   And I enter 'Functional Test Supplier - Search registered' in the 'Find a supplier by name' field
   And I click the 'find_supplier_by_name_search' button
   Then I see an entry in the 'Suppliers' table with:
-    | Name                                                       | Change name | Users | Services |
-    | DM Functional Test Supplier - Search supplier name feature | Change name | Users | Services |
+    | Name                                                       | Users | Services |
+    | DM Functional Test Supplier - Search supplier name feature | Users | Services |
 
   Examples:
     | role                      | link-name                               |

--- a/features/admin/search_for_suppliers.feature
+++ b/features/admin/search_for_suppliers.feature
@@ -54,7 +54,7 @@ Scenario: Admin data controller user can search for a supplier by registered nam
     | DM Functional Test Supplier - Search supplier name feature | Users | Services |
 
 
-@search-supplier-duns @with-admin-ccs-data-controller-user
+@search-supplier-duns @with-admin-ccs-data-controller-user @skip-staging
 Scenario: Admin data controller user can search for a supplier by DUNS number
   Given I am logged in as the existing admin-ccs-data-controller user
   And I have a random supplier from the API

--- a/features/admin/search_for_suppliers.feature
+++ b/features/admin/search_for_suppliers.feature
@@ -1,7 +1,7 @@
 @admin
 Feature: Search for suppliers by registered name, DUNS number and companies house number
 
-@search-supplier-name
+@search-supplier-name @skip-staging
 Scenario Outline: Correct users search for a supplier by registered name
   Given I am logged in as the existing <role> user
   And I have a supplier with:
@@ -19,6 +19,39 @@ Scenario Outline: Correct users search for a supplier by registered name
     | admin                     | Edit supplier accounts or view services |
     | admin-ccs-category        | Edit suppliers and services             |
     | admin-ccs-data-controller | View and edit suppliers                 |
+
+
+@search-supplier-name @skip-preview @skip-local
+Scenario Outline: Correct users search for a supplier by registered name
+  Given I am logged in as the existing <role> user
+  And I have a supplier with:
+    | name           | DM Functional Test Supplier - Search supplier name feature |
+    | registeredName | DM Functional Test Supplier - Search registered supplier name |
+  And I click the '<link-name>' link
+  And I enter 'Functional Test Supplier - Search registered' in the 'Find a supplier by name' field
+  And I click the 'find_supplier_by_name_search' button
+  Then I see an entry in the 'Suppliers' table with:
+    | Name                                                       | Change name | Users | Services |
+    | DM Functional Test Supplier - Search supplier name feature | Change name | Users | Services |
+
+  Examples:
+    | role                      | link-name                               |
+    | admin                     | Edit supplier accounts or view services |
+    | admin-ccs-category        | Edit suppliers and services             |
+
+
+@search-supplier-name @with-admin-ccs-data-controller-user @skip-preview @skip-local
+Scenario: Admin data controller user can search for a supplier by registered name
+  Given I am logged in as the existing admin-ccs-data-controller user
+  And I have a supplier with:
+    | name           | DM Functional Test Supplier - Search supplier name feature |
+    | registeredName | DM Functional Test Supplier - Search registered supplier name |
+  And I click the 'View and edit suppliers' link
+  And I enter 'Functional Test Supplier - Search registered' in the 'Find a supplier by name' field
+  And I click the 'find_supplier_by_name_search' button
+  Then I see an entry in the 'Suppliers' table with:
+    | Name                                                       | Users | Services |
+    | DM Functional Test Supplier - Search supplier name feature | Users | Services |
 
 
 @search-supplier-duns @with-admin-ccs-data-controller-user

--- a/features/admin/update_supplier_name.feature
+++ b/features/admin/update_supplier_name.feature
@@ -8,18 +8,24 @@ Scenario Outline: Correct users can edit a supplier name
   And I click the '<link-name>' link
   And I enter 'DM Functional Test Supplier - Update supplier name feature' in the 'Find a supplier by name' field
   And I click the 'find_supplier_by_name_search' button
-  And I click a summary table 'Change name' link for 'DM Functional Test Supplier - Update supplier name feature'
+  And I click the 'DM Functional Test Supplier - Update supplier name feature' link
+  And I am on the 'DM Functional Test Supplier - Update supplier name feature' page
+  When I click the 'Edit supplier name' link
+  Then I am on the 'Change supplier name' page
   When I enter 'DM Functional Test Supplier - Update supplier name feature - Changed Name' in the 'New name' field
   And I click the 'Save' button
   Then I see an entry in the 'Suppliers' table with:
-    | Name                                                                      | Change name | Users | Services |
-    | DM Functional Test Supplier - Update supplier name feature - Changed Name | Change name | Users | Services |
-  When I click a summary table 'Change name' link for 'DM Functional Test Supplier - Update supplier name feature - Changed Name'
+    | Name                                                                      | Users | Services |
+    | DM Functional Test Supplier - Update supplier name feature - Changed Name | Users | Services |
+  When I click the 'DM Functional Test Supplier - Update supplier name feature - Changed Name' link
+  Then I am on the 'DM Functional Test Supplier - Update supplier name feature - Changed Name' page
+  When I click the 'Edit supplier name' link
+  Then I am on the 'Change supplier name' page
   And I enter 'DM Functional Test Supplier - Update supplier name feature' in the 'New name' field
   And I click the 'Save' button
   Then I see an entry in the 'Suppliers' table with:
-    | Name                                                       | Change name | Users | Services |
-    | DM Functional Test Supplier - Update supplier name feature | Change name | Users | Services |
+    | Name                                                       | Users | Services |
+    | DM Functional Test Supplier - Update supplier name feature | Users | Services |
 
   Examples:
     | role                    | link-name                               |
@@ -29,7 +35,9 @@ Scenario Outline: Correct users can edit a supplier name
 Scenario Outline: Correct users cannot update the supplier name
   Given I am logged in as the existing <role> user
   When I visit the /admin/suppliers?supplier_name=DM+Functional+Test+Supplier+-+Update+supplier+name+feature page
-  Then I don't see the 'Change name' link
+  When I click the 'DM Functional Test Supplier - Update supplier name feature' link
+  And I am on the 'DM Functional Test Supplier - Update supplier name feature' page
+  Then I don't see the 'Edit supplier name' link
 
   Examples:
     | role                      |

--- a/features/admin/update_supplier_name.feature
+++ b/features/admin/update_supplier_name.feature
@@ -14,18 +14,12 @@ Scenario Outline: Correct users can edit a supplier name
   Then I am on the 'Change supplier name' page
   When I enter 'DM Functional Test Supplier - Update supplier name feature - Changed Name' in the 'New name' field
   And I click the 'Save' button
-  Then I see an entry in the 'Suppliers' table with:
-    | Name                                                                      | Users | Services |
-    | DM Functional Test Supplier - Update supplier name feature - Changed Name | Users | Services |
-  When I click the 'DM Functional Test Supplier - Update supplier name feature - Changed Name' link
   Then I am on the 'DM Functional Test Supplier - Update supplier name feature - Changed Name' page
   When I click the 'Edit supplier name' link
   Then I am on the 'Change supplier name' page
   And I enter 'DM Functional Test Supplier - Update supplier name feature' in the 'New name' field
   And I click the 'Save' button
-  Then I see an entry in the 'Suppliers' table with:
-    | Name                                                       | Users | Services |
-    | DM Functional Test Supplier - Update supplier name feature | Users | Services |
+  Then I am on the 'DM Functional Test Supplier - Update supplier name feature' page
 
   Examples:
     | role                      | link-name                               |

--- a/features/admin/update_supplier_name.feature
+++ b/features/admin/update_supplier_name.feature
@@ -1,6 +1,7 @@
 @admin @update-supplier-name
 Feature: Update supplier name
 
+@skip-staging
 Scenario Outline: Correct users can edit a supplier name
   Given I am logged in as the existing <role> user
   And I have a supplier with:
@@ -27,6 +28,7 @@ Scenario Outline: Correct users can edit a supplier name
     | admin-ccs-category        | Edit suppliers and services             |
     | admin-ccs-data-controller | View and edit suppliers                 |
 
+@skip-staging
 Scenario Outline: Admin framework manager user can view but not update the supplier name
   Given I am logged in as the existing <role> user
   When I visit the /admin/suppliers?supplier_name=DM+Functional+Test+Supplier+-+Update+supplier+name+feature page
@@ -37,3 +39,42 @@ Scenario Outline: Admin framework manager user can view but not update the suppl
   Examples:
     | role                      |
     | admin-framework-manager   |
+
+
+@skip-preview @skip-local
+Scenario Outline: Correct users can edit a supplier name
+  Given I am logged in as the existing <role> user
+  And I have a supplier with:
+    | name          | DM Functional Test Supplier - Update supplier name feature |
+  And I click the '<link-name>' link
+  And I enter 'DM Functional Test Supplier - Update supplier name feature' in the 'Find a supplier by name' field
+  And I click the 'find_supplier_by_name_search' button
+  And I click a summary table 'Change name' link for 'DM Functional Test Supplier - Update supplier name feature'
+  When I enter 'DM Functional Test Supplier - Update supplier name feature - Changed Name' in the 'New name' field
+  And I click the 'Save' button
+  Then I see an entry in the 'Suppliers' table with:
+    | Name                                                                      | Change name | Users | Services |
+    | DM Functional Test Supplier - Update supplier name feature - Changed Name | Change name | Users | Services |
+  When I click a summary table 'Change name' link for 'DM Functional Test Supplier - Update supplier name feature - Changed Name'
+  And I enter 'DM Functional Test Supplier - Update supplier name feature' in the 'New name' field
+  And I click the 'Save' button
+  Then I see an entry in the 'Suppliers' table with:
+    | Name                                                       | Change name | Users | Services |
+    | DM Functional Test Supplier - Update supplier name feature | Change name | Users | Services |
+
+  Examples:
+    | role                    | link-name                               |
+    | admin                   | Edit supplier accounts or view services |
+    | admin-ccs-category      | Edit suppliers and services             |
+
+Scenario Outline: Correct users cannot update the supplier name
+  Given I am logged in as the existing <role> user
+  When I visit the /admin/suppliers?supplier_name=DM+Functional+Test+Supplier+-+Update+supplier+name+feature page
+  Then I don't see the 'Change name' link
+
+  Examples:
+    | role                      |
+    | admin-framework-manager   |
+    | admin-ccs-sourcing        |
+    | admin-manager             |
+    | admin-ccs-data-controller |

--- a/features/admin/update_supplier_name.feature
+++ b/features/admin/update_supplier_name.feature
@@ -28,11 +28,12 @@ Scenario Outline: Correct users can edit a supplier name
     | DM Functional Test Supplier - Update supplier name feature | Users | Services |
 
   Examples:
-    | role                    | link-name                               |
-    | admin                   | Edit supplier accounts or view services |
-    | admin-ccs-category      | Edit suppliers and services             |
+    | role                      | link-name                               |
+    | admin                     | Edit supplier accounts or view services |
+    | admin-ccs-category        | Edit suppliers and services             |
+    | admin-ccs-data-controller | View and edit suppliers                 |
 
-Scenario Outline: Correct users cannot update the supplier name
+Scenario Outline: Admin framework manager user can view but not update the supplier name
   Given I am logged in as the existing <role> user
   When I visit the /admin/suppliers?supplier_name=DM+Functional+Test+Supplier+-+Update+supplier+name+feature page
   When I click the 'DM Functional Test Supplier - Update supplier name feature' link
@@ -42,6 +43,3 @@ Scenario Outline: Correct users cannot update the supplier name
   Examples:
     | role                      |
     | admin-framework-manager   |
-    | admin-ccs-sourcing        |
-    | admin-manager             |
-    | admin-ccs-data-controller |

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -5,7 +5,7 @@ Then (/^I see that supplier in the list of suppliers$/) do
       # now refine with a much more precise test
       row_element.all(:css, "a").any? { |a_element|
         a_element[:href] =~ Regexp.new('^(.*\D)?' + "#{@supplier['id']}" + '(\D.*)?$')
-      } && row_element.all(:css, ".summary-item-field-first > span").any? { |span_element|
+      } && row_element.all(:css, ".summary-item-field-first-half > span").any? { |span_element|
         span_element.text == normalize_whitespace(@supplier['name'])
       }
     }.length

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -16,7 +16,7 @@ Then (/^I see the number of suppliers listed is (\d+)$/) do |supplier_count|
   expect(
     page.all(
       :xpath,
-      "//*[@class='summary-item-row'][.//*[@class='summary-item-field-first']]"
+      "//*[@class='summary-item-row'][.//*[@class='summary-item-field-first-half']]"
     ).length
   ).to eq(supplier_count.to_i)
 end

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -355,7 +355,11 @@ Then /^I see the '(.*)' summary table filled with:$/ do |table_heading, table|
   table.rows.each_with_index do |row, index|
     result_items = result_table_rows[index].all('td')
     expect(result_items[0].text).to eq(row[0])
-    expect(result_items[1].text).to eq(row[1])
+    # Skip anything with '<ANY>'
+    if row[1] != '<ANY>'
+      # Concatenate any multi-line strings
+      expect(result_items[1].text.split.join(' ')).to eq(row[1])
+    end
   end
 end
 

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -324,6 +324,16 @@ When /I click the summary table '(.*)' (link|button) for '(.*)'$/ do |link_name,
   edit_link.click
 end
 
+When /I click the summary table '(.*)' (link|button) for the '(.*)' link$/ do |link_name, elem_type, field_to_edit|
+  case elem_type
+    when 'link'
+      edit_link = page.find(:xpath, "//tr/td/*/a[normalize-space(text()) = '#{field_to_edit}']/../../..//a[contains(normalize-space(text()), '#{link_name}')]")
+    else
+      edit_link = page.find(:xpath, "//tr/td/*/a[normalize-space(text()) = '#{field_to_edit}']/../../..//input[normalize-space(@value) = '#{link_name}']")
+  end
+  edit_link.click
+end
+
 When /I click a summary table '(.*)' (link|button) for '(.*)'$/ do |link_name, elem_type, field_to_edit|
   case elem_type
     when 'link'

--- a/features/step_definitions/supplier_steps.rb
+++ b/features/step_definitions/supplier_steps.rb
@@ -40,7 +40,19 @@ end
 Given /^that(?: (micro|small|medium|large))? supplier has applied to be on that framework$/ do |organisation_size|
   organisation_size ||= %w[micro small medium large].sample
   update_supplier(@supplier["id"], 'organisationSize': organisation_size)
-  @declaration = submit_supplier_declaration(@framework['slug'], @supplier["id"], 'status': 'complete', 'nameOfOrganisation': 'foobarbaz', 'primaryContactEmail': 'foo.bar@example.com')
+  @declaration = submit_supplier_declaration(
+    @framework['slug'],
+    @supplier["id"],
+    'status': 'complete',
+    'nameOfOrganisation': 'foobarbaz',
+    'primaryContactEmail': 'foo.bar@example.com',
+    'supplierCompanyRegistrationNumber': '87654321',
+    'supplierRegisteredName': 'DM Functional Test Suppliers Ltd.',
+    'supplierRegisteredBuilding': '10 Downing Street',
+    'supplierRegisteredCountry': 'country:GB',
+    'supplierRegisteredPostcode': 'AB1 2CD',
+    'supplierRegisteredTown': 'London',
+  )
 end
 
 Given 'we accepted that suppliers application to the framework' do


### PR DESCRIPTION
Trello: https://trello.com/c/3ZUU9xIn/340-supplier-details-admin-page

Coverage for the new company details page (see https://github.com/alphagov/digitalmarketplace-admin-frontend/pull/484).

Setup required for the new feature:
- Set up a scenario where a supplier has a service on a live framework, and we can search for their details via tabbed search
- Add some fake declaration data that we're going to display
- Allow summary table assert methods to check multi-line values (for the address)
- Allow summary table assert methods to skip `<ANY>` values

Updated some other scenarios to take into account that a) the supplier name is now a link b) updating supplier name redirects to the details page c) some permissions have changed.
