### PR TITLE
Add framework clarification question tests

### DIFF
--- a/features/step_definitions/antivirus_steps.rb
+++ b/features/step_definitions/antivirus_steps.rb
@@ -18,13 +18,18 @@ Then /^I receive a notification regarding that file within ([0-9]+) minutes?$/ d
   etag = @s3_obj_response.etag.downcase.gsub(/[^a-z0-9]/, '')
   minutes = minutes_string.to_i
 
+  expected_ref = "eicar-found-#{etag}-#{dm_environment}"
+  puts "Notify ref: #{expected_ref}"
+
   messages = nil
   (0..(minutes * 6)).each {
     sleep(10)
-    messages = DMNotify.get_email_raw("eicar-found-#{etag}-#{dm_environment}")
+    messages = DMNotify.get_email_raw(expected_ref)
     if messages.collection.length != 0
       break
     end
   }
   expect(messages.collection.length).to eq(1)
+  @email = messages.collection[0]
+  puts "Notify id: #{@email.id}"
 end

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -38,7 +38,7 @@ Given /^I have the latest live (.*) framework(?: with the (.*) lot)?$/ do |metaf
   end
   expect(frameworks).not_to be_empty, _error(response, "No live '#{metaframework_slug}' frameworks found with lot '#{lot_slug}'")
   @framework = frameworks.sort_by! { |framework| framework[:id] }.reverse![0]
-  puts @framework['slug']
+  puts "Framework: #{@framework['slug']}"
 end
 
 Given /^I have a random g-cloud service from the API$/ do

--- a/features/step_definitions/emails.rb
+++ b/features/step_definitions/emails.rb
@@ -13,19 +13,29 @@ module DMNotify
     )
   end
 
+  def self.hash_string(string_in)
+    # equivalent of function in digitalmarketplace-utils
+    Base64.urlsafe_encode64(Digest::SHA256.digest(string_in))
+  end
+
   def self.get_email(message_type, email_address)
-    email_hash = Base64.urlsafe_encode64(Digest::SHA256.digest(email_address))
+    email_hash = self.hash_string(email_address)
     self.get_email_raw("#{message_type}-#{email_hash}")
   end
 end
 
-Then /^I receive a '([a-z-]+)' email for #{MAYBE_VAR}/ do |message_type, email_address|
+Then /^I( don't)? receive a(?:n)? '([a-z-]+)' email for #{MAYBE_VAR}/ do |negate, message_type, email_address|
   messages = DMNotify.get_email(message_type, email_address)
-  @email_text = messages.collection[0].body
+  if negate
+    expect(messages.collection.length).to be(0)
+  else
+    @email = messages.collection[0]
+    puts "Notify id: #{@email.id}"
+  end
 end
 
 Then /^I click the link in that email$/ do
-  page.visit(URI.extract(@email_text).select { |i| i.start_with?('http') } [0])
+  page.visit(URI.extract(@email.body).select { |i| i.start_with?('http') } [0])
 end
 
 Given /^I have an email address with an accepted buyer domain$/ do

--- a/features/step_definitions/framework_application_steps.rb
+++ b/features/step_definitions/framework_application_steps.rb
@@ -63,3 +63,28 @@ end
 Given /^that supplier has confirmed their company details for that application$/ do
   confirm_company_details_for_framework(@framework['slug'], @supplier['id'])
 end
+
+Then /^I( don't)? receive a (follow-up|clarification) question( confirmation)? email regarding that question for #{MAYBE_VAR}$/ do |negate, question_type, maybe_confirmation, target_address|
+  ref_prefix = (
+    case question_type
+    when 'follow-up'
+      expect(maybe_confirmation).to be_nil  # no such thing as a follow up confirmation
+      'fw-follow-up-question'
+    else
+      if maybe_confirmation
+        'fw-clarification-question-confirm'
+      else
+        'fw-clarification-question'
+      end
+    end
+  )
+  expected_ref = "#{ref_prefix}-#{DMNotify.hash_string(@fields['clarification_question'].strip)}-#{DMNotify.hash_string(target_address)}"
+  puts "Notify ref: #{expected_ref}"
+
+  messages = DMNotify.get_email_raw(expected_ref)
+  expect(messages.collection.length).to (negate ? eq(0) : be > 0)
+  if not negate
+    @email = messages.collection[0]
+    puts "Notify id: #{@email.id}"
+  end
+end

--- a/features/step_definitions/framework_application_steps.rb
+++ b/features/step_definitions/framework_application_steps.rb
@@ -59,3 +59,7 @@ end
 And(/^I fill in all the missing details$/) do
   answer_all_service_questions "Answer required"
 end
+
+Given /^that supplier has confirmed their company details for that application$/ do
+  confirm_company_details_for_framework(@framework['slug'], @supplier['id'])
+end

--- a/features/step_definitions/supplier_steps.rb
+++ b/features/step_definitions/supplier_steps.rb
@@ -20,17 +20,20 @@ Given 'There is at most one framework that can be applied to' do
   end
 end
 
-Given 'there is a framework that is open for applications' do
+Given /^there is a framework that is open for applications(?: with clarification questions (open|closed))?$/ do |cq_open_closed|
   response = call_api(:get, "/frameworks")
   expect(response.code).to be(200), _error(response, "Failed getting frameworks")
   frameworks = JSON.parse(response.body)['frameworks']
   frameworks.delete_if { |framework| not ['open'].include?(framework['status']) }
+  if cq_open_closed
+    frameworks.delete_if { |framework| (cq_open_closed == 'open') != framework['clarificationQuestionsOpen'] }
+  end
   if frameworks.empty?
-    puts 'SKIPPING as there are no open frameworks'
+    puts "SKIPPING as there are no open frameworks#{if cq_open_closed then " with clarification questions #{cq_open_closed}" end}"
     skip_this_scenario
   else
     @framework = frameworks[0]
-    puts "Applying to framework '#{@framework['name']}'"
+    puts "Framework: '#{@framework['slug']}'"
   end
 end
 

--- a/features/supplier/supplier_asks_a_framework_question.feature
+++ b/features/supplier/supplier_asks_a_framework_question.feature
@@ -1,0 +1,48 @@
+@supplier @supplier-framework-question
+Feature: Supplier asks a framework question
+
+
+Scenario: Supplier asks a clarification question
+  Given there is a framework that is open for applications with clarification questions open
+  And I have a supplier user
+  And that supplier has applied to be on that framework
+  And that supplier has confirmed their company details for that application
+  And that supplier is logged in
+  When I visit the /suppliers page
+  And I click the 'Continue your application' link
+  Then I see 'Apply to' in the page's h1
+  And I see the page's h1 ends in that framework.name
+  When I click 'View communications and ask clarification questions'
+  Then I see that framework.name in the page's h1
+  And I see the page's h1 ends in 'updates'
+  And I see 'The deadline for clarification questions is' text on the page
+  And I see 'will not respond to you individually' text on the page
+  When I enter a random value in the 'clarification_question' field
+  And I click the 'Ask question' button
+  Then I receive a clarification question email regarding that question for 'clarification-questions@example.gov.uk'
+  And I receive a clarification question confirmation email regarding that question for that supplier_user.emailAddress
+  And I don't receive a follow-up question email regarding that question for 'follow-up@example.gov.uk'
+  And I see a success banner message containing 'Your clarification question has been sent.'
+
+Scenario: Supplier asks a question about their application
+  Given there is a framework that is open for applications with clarification questions closed
+  And I have a supplier user
+  And that supplier has applied to be on that framework
+  And that supplier has confirmed their company details for that application
+  And that supplier is logged in
+  When I visit the /suppliers page
+  And I click the 'Continue your application' link
+  Then I see 'Apply to' in the page's h1
+  And I see the page's h1 ends in that framework.name
+  When I click 'View communications and clarification questions'
+  Then I see that framework.name in the page's h1
+  And I see the page's h1 ends in 'updates'
+  And I see 'The deadline for asking clarification questions has now passed' text on the page
+  And I see 'You'll get a private reply' text on the page
+  When I enter a random value in the 'clarification_question' field
+  And I click the 'Ask question' button
+  Then I receive a follow-up question email regarding that question for 'follow-up@example.gov.uk'
+  And I don't receive a clarification question email regarding that question for 'clarification-questions@example.gov.uk'
+  And I don't receive a clarification question confirmation email regarding that question for that supplier_user.emailAddress
+  And I see a success banner message containing 'Your question has been sent.'
+

--- a/features/support/api_helpers.rb
+++ b/features/support/api_helpers.rb
@@ -98,7 +98,15 @@ def set_supplier_on_framework(framework_slug, supplier_id, status)
     frameworkInterest: { onFramework: status },
     updated_by: "functional tests",
   })
-  expect(response.code).to eq(200), _error(response, "Failed to update agreement status #{supplier_id} #{framework_slug}")
+  expect(response.code).to eq(200), _error(response, "Failed to update supplier_framework status #{supplier_id} #{framework_slug}")
+end
+
+def confirm_company_details_for_framework(framework_slug, supplier_id)
+  response = call_api(:post, "/suppliers/#{supplier_id}/frameworks/#{framework_slug}", payload: {
+    frameworkInterest: { applicationCompanyDetailsConfirmed: true },
+    updated_by: "functional tests",
+  })
+  expect(response.code).to eq(200), _error(response, "Failed to confirm supplier's company details for framework #{supplier_id} #{framework_slug}")
 end
 
 def register_interest_in_framework(framework_slug, supplier_id)


### PR DESCRIPTION
https://trello.com/b/mNNzL8hA

Made a few changes in doing these:

 - Tried to further standardize where we output informational messages, especially outputting "Notify ids" of found emails and in many places printing the actual "Notify ref" that we're going looking for. This is helpful in debugging.
 - Record complete "found" emails as `@email` rather than just the body as `@email_text`. The following steps checking for this can perfectly well pull out `email.body` themselves and this also allows us to dig into various properties of the message through `MAYBE_VAR`.
 - Add basic ability to negate checks for emails.
 - Add ability to require that opportunistically-grabbed framework also has clarification questions either open or closed. Cycling one of our instances through these settings and re-running tests can allow us to test both paths, or just whichever one we're preparing to bring to production soon.
