### PR TITLE
assets tests: disable temporarily until we can fix this

### DIFF
--- a/features/public/assets.feature
+++ b/features/public/assets.feature
@@ -1,8 +1,7 @@
-@assets @skip-local
+@assets @skip @skip-local
 Feature: Favicon.ico should return a blank, transparent gif on assets. domain
 
 Scenario: Request favicon from assets domain
   Given I visit the assets /favicon.ico page
   Then the response code should be 200
   And the response header content_type should be image/gif
-  


### PR DESCRIPTION
@benvand will be back imminently and can take a look at why this is failing.

Once we bring it back, might actually be nice to bring it back to the smoulder tests instead so we get this checking on production.