### PR TITLE
Remove skip-staging on admin changes

### DIFF
--- a/features/admin/company_details.feature
+++ b/features/admin/company_details.feature
@@ -1,4 +1,4 @@
-@admin @company-details @skip-staging
+@admin @company-details
 Feature: Company details page
 
 Background:

--- a/features/admin/deactivate_supplier_user.feature
+++ b/features/admin/deactivate_supplier_user.feature
@@ -11,7 +11,6 @@ Background:
     | name          | Deactivate a suppliers contributor feature User #2 |
     | email_address | user-two@example.com                               |
 
-@skip-staging
 Scenario Outline: Correct users can deactivate and reactivate a supplier's contributor
   Given I am logged in as the existing <role> user
   And I click the 'Edit supplier accounts or view services' link
@@ -31,26 +30,6 @@ Scenario Outline: Correct users can deactivate and reactivate a supplier's contr
     | role  |
     | admin |
 
-@skip-preview @skip-local
-Scenario Outline: Correct users can deactivate and reactivate a supplier's contributor
-  Given I am logged in as the existing <role> user
-  And I click the 'Edit supplier accounts or view services' link
-  And I enter 'DM Functional Test Supplier - Deactivate a suppliers contributor feature' in the 'Find a supplier by name' field
-  And I click the 'find_supplier_by_name_search' button
-  And I click a summary table 'Users' link for 'DM Functional Test Supplier - Deactivate a suppliers contributor feature'
-  When I click the summary table 'Deactivate' button for 'Deactivate a suppliers contributor feature User #1'
-  Then I see an entry in the 'Users' table with:
-    | Name                                               | Email address        | Last login  | Pwd changed | Locked |
-    | Deactivate a suppliers contributor feature User #1 | user-one@example.com | <ANY>       | <ANY>       | No     |
-  When I click the summary table 'Activate' button for 'Deactivate a suppliers contributor feature User #1'
-  Then I see an entry in the 'Users' table with:
-    | Name                                               | Email address        | Last login  | Pwd changed | Locked |
-    | Deactivate a suppliers contributor feature User #1 | user-one@example.com | <ANY>       | <ANY>       | No     |
-  Examples:
-    | role  |
-    | admin |
-
-@skip-staging
 Scenario Outline: Correct users can view but not deactivate suppliers users
   Given I am logged in as the existing <role> user
   And I click the '<link-name>' link
@@ -64,25 +43,6 @@ Scenario Outline: Correct users can view but not deactivate suppliers users
     | Name                                               | Email address        | Last login  | Pwd changed | Locked | Status |
     | Deactivate a suppliers contributor feature User #2 | user-two@example.com | <ANY>       | <ANY>       | No     | Active |
 
-  Examples:
-    | role                    | link-name                   |
-    | admin-ccs-category      | Edit suppliers and services |
-    | admin-framework-manager | View suppliers and services |
-
-@skip-preview @skip-local
-Scenario Outline: Correct users can view but not deactivate suppliers users
-  Given I am logged in as the existing <role> user
-  And I click the '<link-name>' link
-  And I enter 'DM Functional Test Supplier - Deactivate a suppliers contributor feature' in the 'Find a supplier by name' field
-  And I click the 'find_supplier_by_name_search' button
-  When I click a summary table 'Users' link for 'DM Functional Test Supplier - Deactivate a suppliers contributor feature'
-  Then I don't see the 'Deactivate' button
-  And I see an entry in the 'Users' table with:
-    | Name                                               | Email address        | Last login  | Pwd changed | Locked | Status |
-    | Deactivate a suppliers contributor feature User #1 | user-one@example.com | <ANY>       | <ANY>       | No     | Active |
-  And I see an entry in the 'Users' table with:
-    | Name                                               | Email address        | Last login  | Pwd changed | Locked | Status |
-    | Deactivate a suppliers contributor feature User #2 | user-two@example.com | <ANY>       | <ANY>       | No     | Active |
   Examples:
     | role                    | link-name                   |
     | admin-ccs-category      | Edit suppliers and services |

--- a/features/admin/invite_supplier_contributor.feature
+++ b/features/admin/invite_supplier_contributor.feature
@@ -1,7 +1,7 @@
 @admin @invite-supplier-contributor
 Feature: Invite a contributor to a supplier account
 
-@requires-credentials @notify @skip-staging
+@requires-credentials @notify
 Scenario Outline: Correct users can invite a contributors to a supplier account
   Given I am logged in as the existing <role> user
   And I have a supplier with:
@@ -27,40 +27,10 @@ Scenario Outline: Prohibited user roles cannot manage supplier users
     | admin-ccs-sourcing      |
     | admin-manager           |
 
-@skip-staging
 Scenario Outline: Prohibited user roles cannot invite users to a supplier
   Given I am logged in as the existing <role> user
   When I visit the /admin/suppliers?supplier_name=DM+Functional+Test+Supplier+-+Invite+a+contributor+feature page
   And I click the summary table 'Users' link for the 'DM Functional Test Supplier - Invite a contributor feature' link
-  Then I don't see the 'Send invitation' button
-
-  Examples:
-    | role                      |
-    | admin-framework-manager   |
-    | admin-ccs-category        |
-    | admin-ccs-data-controller |
-
-@requires-credentials @notify @skip-preview @skip-local
-Scenario Outline: Correct users can invite a contributors to a supplier account
-  Given I am logged in as the existing <role> user
-  And I have a supplier with:
-    | name          | DM Functional Test Supplier - Invite a contributor feature |
-  And I click the 'Edit supplier accounts or view services' link
-  And I enter 'DM Functional Test Supplier - Invite a contributor feature' in the 'supplier_name' field and click its associated 'Search' button
-  And I click a summary table 'Users' link for 'DM Functional Test Supplier - Invite a contributor feature'
-  When I enter 'functional-test-supplier-contributor@example.gov.uk' in the 'Email address' field
-  And I click the 'Send invitation' button
-  Then I see a success banner message containing 'User invited'
-
-  Examples:
-    | role                    |
-    | admin                   |
-
-@skip-preview @skip-local
-Scenario Outline: Prohibited user roles cannot invite users to a supplier
-  Given I am logged in as the existing <role> user
-  When I visit the /admin/suppliers?supplier_name=DM+Functional+Test+Supplier+-+Invite+a+contributor+feature page
-  And I click a summary table 'Users' link for 'DM Functional Test Supplier - Invite a contributor feature'
   Then I don't see the 'Send invitation' button
 
   Examples:

--- a/features/admin/search_for_suppliers.feature
+++ b/features/admin/search_for_suppliers.feature
@@ -1,7 +1,7 @@
 @admin
 Feature: Search for suppliers by registered name, DUNS number and companies house number
 
-@search-supplier-name @skip-staging
+@search-supplier-name
 Scenario Outline: Correct users search for a supplier by registered name
   Given I am logged in as the existing <role> user
   And I have a supplier with:
@@ -20,41 +20,7 @@ Scenario Outline: Correct users search for a supplier by registered name
     | admin-ccs-category        | Edit suppliers and services             |
     | admin-ccs-data-controller | View and edit suppliers                 |
 
-
-@search-supplier-name @skip-preview @skip-local
-Scenario Outline: Correct users search for a supplier by registered name
-  Given I am logged in as the existing <role> user
-  And I have a supplier with:
-    | name           | DM Functional Test Supplier - Search supplier name feature |
-    | registeredName | DM Functional Test Supplier - Search registered supplier name |
-  And I click the '<link-name>' link
-  And I enter 'Functional Test Supplier - Search registered' in the 'Find a supplier by name' field
-  And I click the 'find_supplier_by_name_search' button
-  Then I see an entry in the 'Suppliers' table with:
-    | Name                                                       | Change name | Users | Services |
-    | DM Functional Test Supplier - Search supplier name feature | Change name | Users | Services |
-
-  Examples:
-    | role                      | link-name                               |
-    | admin                     | Edit supplier accounts or view services |
-    | admin-ccs-category        | Edit suppliers and services             |
-
-
-@search-supplier-name @with-admin-ccs-data-controller-user @skip-preview @skip-local
-Scenario: Admin data controller user can search for a supplier by registered name
-  Given I am logged in as the existing admin-ccs-data-controller user
-  And I have a supplier with:
-    | name           | DM Functional Test Supplier - Search supplier name feature |
-    | registeredName | DM Functional Test Supplier - Search registered supplier name |
-  And I click the 'View and edit suppliers' link
-  And I enter 'Functional Test Supplier - Search registered' in the 'Find a supplier by name' field
-  And I click the 'find_supplier_by_name_search' button
-  Then I see an entry in the 'Suppliers' table with:
-    | Name                                                       | Users | Services |
-    | DM Functional Test Supplier - Search supplier name feature | Users | Services |
-
-
-@search-supplier-duns @with-admin-ccs-data-controller-user @skip-staging
+@search-supplier-duns @with-admin-ccs-data-controller-user
 Scenario: Admin data controller user can search for a supplier by DUNS number
   Given I am logged in as the existing admin-ccs-data-controller user
   And I have a random supplier from the API

--- a/features/admin/update_supplier_name.feature
+++ b/features/admin/update_supplier_name.feature
@@ -1,7 +1,6 @@
 @admin @update-supplier-name
 Feature: Update supplier name
 
-@skip-staging
 Scenario Outline: Correct users can edit a supplier name
   Given I am logged in as the existing <role> user
   And I have a supplier with:
@@ -28,7 +27,6 @@ Scenario Outline: Correct users can edit a supplier name
     | admin-ccs-category        | Edit suppliers and services             |
     | admin-ccs-data-controller | View and edit suppliers                 |
 
-@skip-staging
 Scenario Outline: Admin framework manager user can view but not update the supplier name
   Given I am logged in as the existing <role> user
   When I visit the /admin/suppliers?supplier_name=DM+Functional+Test+Supplier+-+Update+supplier+name+feature page
@@ -39,33 +37,6 @@ Scenario Outline: Admin framework manager user can view but not update the suppl
   Examples:
     | role                      |
     | admin-framework-manager   |
-
-
-@skip-preview @skip-local
-Scenario Outline: Correct users can edit a supplier name
-  Given I am logged in as the existing <role> user
-  And I have a supplier with:
-    | name          | DM Functional Test Supplier - Update supplier name feature |
-  And I click the '<link-name>' link
-  And I enter 'DM Functional Test Supplier - Update supplier name feature' in the 'Find a supplier by name' field
-  And I click the 'find_supplier_by_name_search' button
-  And I click a summary table 'Change name' link for 'DM Functional Test Supplier - Update supplier name feature'
-  When I enter 'DM Functional Test Supplier - Update supplier name feature - Changed Name' in the 'New name' field
-  And I click the 'Save' button
-  Then I see an entry in the 'Suppliers' table with:
-    | Name                                                                      | Change name | Users | Services |
-    | DM Functional Test Supplier - Update supplier name feature - Changed Name | Change name | Users | Services |
-  When I click a summary table 'Change name' link for 'DM Functional Test Supplier - Update supplier name feature - Changed Name'
-  And I enter 'DM Functional Test Supplier - Update supplier name feature' in the 'New name' field
-  And I click the 'Save' button
-  Then I see an entry in the 'Suppliers' table with:
-    | Name                                                       | Change name | Users | Services |
-    | DM Functional Test Supplier - Update supplier name feature | Change name | Users | Services |
-
-  Examples:
-    | role                    | link-name                               |
-    | admin                   | Edit supplier accounts or view services |
-    | admin-ccs-category      | Edit suppliers and services             |
 
 Scenario Outline: Correct users cannot update the supplier name
   Given I am logged in as the existing <role> user

--- a/features/smoke-tests/admin/search.feature
+++ b/features/smoke-tests/admin/search.feature
@@ -1,7 +1,7 @@
 @smoke-tests
 Feature: Admin users can search for objects
 
-@with-admin-user @skip-staging @skip-production
+@with-admin-user @skip-production
 Scenario: Admin can find a supplier by name
   Given I am logged in as the existing admin user
   And I visit the /admin/search page
@@ -10,7 +10,7 @@ Scenario: Admin can find a supplier by name
   Then I am on the 'Suppliers' page
   And I see that supplier in the list of suppliers
 
-@with-admin-user @skip-staging @skip-production
+@with-admin-user @skip-production
 Scenario: Admin can find a supplier by DUNS number
   Given I am logged in as the existing admin user
   And I visit the /admin/search page


### PR DESCRIPTION
Trello: https://trello.com/c/3ZUU9xIn/340-supplier-details-admin-page

Ready for when we deploy the admin company details page to staging. Please review carefully in case I've missed any!

The `@skip-production` tag on the smoke tests is still there until we release to prod.