### PR TITLE
395-force-assets-favicon-mime-type-to-image-x-icon

### DIFF
--- a/features/public/assets.feature
+++ b/features/public/assets.feature
@@ -1,7 +1,7 @@
-@assets @skip @skip-local
+@assets @skip-local
 Feature: Favicon.ico should return a blank, transparent gif on assets. domain
 
 Scenario: Request favicon from assets domain
   Given I visit the assets /favicon.ico page
   Then the response code should be 200
-  And the response header content_type should be image/gif
+  And the response header content_type should be image/x-icon


### PR DESCRIPTION
Force assets favicon mime type to image/x-icon

It looks like our other favicon has it's mime-type set to `image/x-icon`
We should set the assets one to this for consistency

https://trello.com/c/ZWvPcWdx/395-force-assets-favicon-mime-type-to-image-x-icon