### PR TITLE
Only populate document upload forms that are visible

### DIFF
--- a/features/support/form_helpers.rb
+++ b/features/support/form_helpers.rb
@@ -253,8 +253,16 @@ module FormHelper
   end
 
   def pass_document_upload_validation
-    document_questions = find_elements_by_xpath("//div[not(contains(@style, 'display:none'))]//input[@class='file-upload-input']")
-    if document_questions.length > 0
+    document_questions = find_elements_by_xpath("//input[@class='file-upload-input']")
+    if document_questions.length > 1
+      # Hack for file upload followup questions that are only shown after answering the appropriate
+      # Yes/No parent question
+      # TODO: make this less awful?
+      document_questions.first do |question|
+        attach_file(question["name"], File.join(Dir.pwd, 'fixtures', 'test.pdf'))
+      end
+      return true
+    elsif document_questions.length == 1
       document_questions.each do |question|
         attach_file(question["name"], File.join(Dir.pwd, 'fixtures', 'test.pdf'))
       end

--- a/features/support/form_helpers.rb
+++ b/features/support/form_helpers.rb
@@ -253,7 +253,7 @@ module FormHelper
   end
 
   def pass_document_upload_validation
-    document_questions = find_elements_by_xpath("//input[@class='file-upload-input']")
+    document_questions = find_elements_by_xpath("//div[not(contains(@style, 'display:none'))]//input[@class='file-upload-input']")
     if document_questions.length > 0
       document_questions.each do |question|
         attach_file(question["name"], File.join(Dir.pwd, 'fixtures', 'test.pdf'))


### PR DESCRIPTION
Trello: https://trello.com/c/x5GVLSkq/384-implement-changes-for-legislation-changes-in-application-questions

Small fix so that functional tests only need to fill out visible document upload forms (see https://ci.marketplace.team/job/functional-tests-preview/20926/functional_20test_20report/)

If you, friendly reviewer, can try running this against preview that'd be great, as I can't seem to....

~EDIT: this isn't working properly, only for test runs where `modernSlaveryTurnover` is answered with 'False' (where the file upload is optional and skipping it passes validation).~ Think it's working now...