### PR TITLE
phantomjs: add --ssl-protocol=tlsv1.2 option to force this now that PaaS really is switching tlsv1.1 off

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -23,7 +23,7 @@ else
 
   Capybara.register_driver :poltergeist do |app|
     Capybara::Poltergeist::Driver.new(
-      app, timeout: 180, phantomjs_logger: File.open(File::NULL, "w"), phantomjs_options: [])
+      app, timeout: 180, phantomjs_logger: File.open(File::NULL, "w"), phantomjs_options: ["--ssl-protocol=tlsv1.2"])
   end
 end
 


### PR DESCRIPTION
Fixes https://trello.com/c/IF2arX4p