### PR TITLE
Update one test for new ccs-sourcing admin view

### DIFF
--- a/features/admin/search_for_suppliers.feature
+++ b/features/admin/search_for_suppliers.feature
@@ -20,6 +20,20 @@ Scenario Outline: Correct users search for a supplier by registered name
     | admin-ccs-category        | Edit suppliers and services             |
     | admin-ccs-data-controller | View and edit suppliers                 |
 
+
+@search-supplier-name @with-admin-ccs-sourcing-user
+  Scenario: CCS Sourcing user can search for a supplier by registered name
+  Given I am logged in as the existing admin-ccs-sourcing user
+  And I have a supplier with:
+    | name           | DM Functional Test Supplier - Search supplier name feature |
+    | registeredName | DM Functional Test Supplier - Search registered supplier name |
+  And I click the 'Edit supplier declarations' link
+  And I enter 'Functional Test Supplier - Search registered' in the 'Find a supplier by name' field
+  And I click the 'find_supplier_by_name_search' button
+  Then I see an entry in the 'Suppliers' table with:
+    | Name                                                       |
+    | DM Functional Test Supplier - Search supplier name feature |
+
 @search-supplier-duns @with-admin-ccs-data-controller-user
 Scenario: Admin data controller user can search for a supplier by DUNS number
   Given I am logged in as the existing admin-ccs-data-controller user


### PR DESCRIPTION
A small tweak to the functional tests to check if ccs-sourcing-admins see what they ought to be able to see [ticket](https://trello.com/c/t6awHVr9/392-ccs-sourcing-supplier-results-page-tidy-up)