### PR TITLE
"Supplier user can add and remove contributors": capitalization fix

### DIFF
--- a/features/supplier/supplier_account.feature
+++ b/features/supplier/supplier_account.feature
@@ -204,7 +204,7 @@ Scenario: Supplier user can add and remove contributors
   And I don't see 'that user.emailAddress' text on the page
 
   Given I click 'Log out'
-  Then That user can not log in using their correct password
+  Then that user can not log in using their correct password
   # TODO: And the user is shown as 'not active' on the admin users page
 
 Scenario: New users should have a link to join the use research mailing list


### PR DESCRIPTION
I fixed the capitalization of this step definition earlier (https://github.com/alphagov/digitalmarketplace-functional-tests/pull/618) but didn't catch all uses of it clearly.