### PR TITLE
Data controller can edit supplier details

### DIFF
--- a/features/admin/company_details.feature
+++ b/features/admin/company_details.feature
@@ -49,7 +49,7 @@ Scenario Outline: Correct admin roles can view a supplier's details
     | admin-ccs-data-controller | View and edit suppliers                 | Search for suppliers                    |
 
 
-@with-admin-ccs-data-controller-user
+@with-admin-ccs-data-controller-user @skip-staging
 Scenario: Admin CCS Data Controller can edit a supplier's details
   Given I am logged in as the existing admin-ccs-data-controller user
   And I am on the 'Admin' page

--- a/features/admin/company_details.feature
+++ b/features/admin/company_details.feature
@@ -47,3 +47,75 @@ Scenario Outline: Correct admin roles can view a supplier's details
     | admin                     | Edit supplier accounts or view services | Edit supplier accounts or view services |
     | admin-ccs-category        | Edit suppliers and services             | Edit suppliers and services             |
     | admin-ccs-data-controller | View and edit suppliers                 | Search for suppliers                    |
+
+
+@with-admin-ccs-data-controller-user
+Scenario: Admin CCS Data Controller can edit a supplier's details
+  Given I am logged in as the existing admin-ccs-data-controller user
+  And I am on the 'Admin' page
+  When I click 'View and edit suppliers'
+  Then I am on the 'Search for suppliers' page
+  When I enter 'DM Functional Test Supplier - Company details feature' in the 'Find a supplier by name' field
+  And I click the 'find_supplier_by_name_search' button
+  Then I see an entry in the 'Suppliers' table with:
+    | Supplier Name                                         | Users | Services |
+    | DM Functional Test Supplier - Company details feature | Users | Services |
+  When I click the 'DM Functional Test Supplier - Company details feature' link
+  Then I am on the 'DM Functional Test Supplier - Company details feature' page
+
+  When I click the summary table 'Change' link for 'Company registered name'
+  Then I am on the 'Update registered company name for ‘DM Functional Test Supplier - Company details feature’' page
+  When I enter 'DM Functional Edited Ltd.' in the 'Registered company name' field and click its associated 'Save' button
+  Then I am on the 'DM Functional Test Supplier - Company details feature' page
+  And I see a success banner message containing 'The details for ‘DM Functional Test Supplier - Company details feature’ have been updated.'
+  And I see the 'Company details for G-Cloud 10' summary table filled with:
+    | field                        | value                                           |
+    | Company registered name      | DM Functional Edited Ltd.                       |
+    | Company registration number  | 87654321                                        |
+    | DUNS Number                  | <ANY>                                           |
+    | Address                      | 10 Downing Street London AB1 2CD United Kingdom |
+
+  When I click the summary table 'Change' link for 'Company registration number'
+  Then I am on the 'Update registered company number for ‘DM Functional Test Supplier - Company details feature’' page
+  And I enter '12345678' in the 'Companies House number' field and click its associated 'Save' button
+  Then I am on the 'DM Functional Test Supplier - Company details feature' page
+  And I see a success banner message containing 'The details for ‘DM Functional Test Supplier - Company details feature’ have been updated.'
+  And I see the 'Company details for G-Cloud 10' summary table filled with:
+    | field                        | value                                           |
+    | Company registered name      | DM Functional Edited Ltd.                       |
+    | Company registration number  | 12345678                                        |
+    | DUNS Number                  | <ANY>                                           |
+    | Address                      | 10 Downing Street London AB1 2CD United Kingdom |
+
+  When I click the summary table 'Change' link for 'DUNS Number'
+  Then I see 'You need to contact cloud_digital@crowncommercial.gov.uk to change a supplier DUNS number.' text on the page
+  And I click 'Return to ‘DM Functional Test Supplier - Company details feature’ company details'
+  Then I am on the 'DM Functional Test Supplier - Company details feature' page
+
+  When I click the summary table 'Change' link for 'Address'
+  Then I am on the 'Update registered company address for ‘DM Functional Test Supplier - Company details feature’' page
+  And I enter '11 Downing Street' in the 'Building and street' field
+  And I enter 'New London' in the 'Town or city' field
+  And I enter 'EF1 2GH' in the 'Postcode' field
+  And I enter 'France' in the 'location-autocomplete' field and click the selected autocomplete option
+  And I click the 'Save' button
+  Then I am on the 'DM Functional Test Supplier - Company details feature' page
+  And I see a success banner message containing 'The details for ‘DM Functional Test Supplier - Company details feature’ have been updated.'
+  And I see the 'Company details for G-Cloud 10' summary table filled with:
+    | field                        | value                                       |
+    | Company registered name      | DM Functional Edited Ltd.                   |
+    | Company registration number  | 12345678                                    |
+    | DUNS Number                  | <ANY>                                       |
+    | Address                      | 11 Downing Street New London EF1 2GH France |
+
+  # Reset details for next test run
+  When I click the summary table 'Change' link for 'Company registered name'
+  When I enter 'DM Functional Test Suppliers Ltd.' in the 'Registered company name' field and click its associated 'Save' button
+  When I click the summary table 'Change' link for 'Company registration number'
+  And I enter '87654321' in the 'Companies House number' field and click its associated 'Save' button
+  When I click the summary table 'Change' link for 'Address'
+  And I enter '10 Downing Street' in the 'Building and street' field
+  And I enter 'London' in the 'Town or city' field
+  And I enter 'AB1 2CD' in the 'Postcode' field
+  And I enter 'United Kingdom' in the 'location-autocomplete' field and click the selected autocomplete option
+  And I click the 'Save' button

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -222,6 +222,14 @@ When /^I enter #{MAYBE_VAR} in the '(.*)' field( and click its associated '(.*)'
   end
 end
 
+When /^I enter #{MAYBE_VAR} in the '(.*)' field and click the selected autocomplete option?$/ do |value, field_name|
+  field_element = page.find_field field_name
+  field_element.set value
+  # Find the sibling <ul>'s focused autocomplete <li> and click it
+  focused_dropdown_item = field_element.find(:xpath, "following-sibling::ul[contains(@class, 'autocomplete__menu')]/li[contains(@class, 'autocomplete__option--focused')]")
+  focused_dropdown_item.click
+end
+
 When(/^I choose a random uppercase letter$/) do
   @letter = ('A'..'Z').to_a.sample
   puts "letter: #{@letter}"


### PR DESCRIPTION
Trello: https://trello.com/c/lw9XhnQS/403-data-controller-can-edit-supplier-details-in-admin

Includes a new step for clicking on the accessible auto-complete field. For some (frontend-y?) reason the existing step in the Supplier FE that uses the same auto-complete field doesn't work with the new step, while the old step in the `supplier_account` scenario (https://github.com/alphagov/digitalmarketplace-functional-tests/blob/master/features/supplier/supplier_account.feature#L36) doesn't work for the new Admin FE auto-complete field. However the new step feels more like a real simulation of the user action - type the country name, then click/select the suggestion.

Edit: just realised this will fail because the details table in the Admin has a `<strong>` tag in the first column - see https://github.com/alphagov/digitalmarketplace-admin-frontend/pull/495