### PR TITLE
Add id to company details edit feature supplier

### DIFF
--- a/features/admin/company_details_edit.feature
+++ b/features/admin/company_details_edit.feature
@@ -4,6 +4,7 @@ Feature: Editing company details
 Background:
   Given I have the latest live g-cloud framework with the cloud-support lot
   And I have a supplier with:
+      | id                   | 712152                                                     |
       | name                 | DM Functional Test Supplier - Edit company details feature |
       | registeredName       | We Edit Company Details Ltd.                               |
       | companiesHouseNumber | 87654321                                                   |


### PR DESCRIPTION
If this feature is run in parallel it is possible that multiple
suppliers can be created. By giving the test supplier a specific id the
api helper `get_or_create_supplier` will have an unchanging reference to
the test supplier.