### PR TITLE
Update mailchimp subscribe error message

### DIFF
--- a/features/supplier/subscribe_mailing_list.feature
+++ b/features/supplier/subscribe_mailing_list.feature
@@ -25,7 +25,7 @@ Scenario: Initially-rejected mailing-list subscription
   When I enter 'example@example.com' in the 'email_address' field
   And I click 'Subscribe'
   Then I am on the 'Sign up for Digital Marketplace email alerts' page
-  And I see a destructive banner message containing 'The service is unavailable at the moment. If the problem continues please contact enquiries@digitalmarketplace.service.gov.uk'
+  And I see a destructive banner message containing 'This email address cannot be used to sign up for Digital Marketplace alerts. Please use a different email address or contact enquiries@digitalmarketplace.service.gov.uk'
   # but this page should still be a valid, working form
   And I see 'example@example.com' as the value of the 'email_address' field
   When I enter 'functional-test-email@user.marketplace.team' in the 'email_address' field

--- a/features/supplier/subscribe_mailing_list.feature
+++ b/features/supplier/subscribe_mailing_list.feature
@@ -19,7 +19,7 @@ Scenario: Successful mailing-list subscription from the home page
   Then I am on the 'Digital Marketplace' page
   And I see a success banner message containing 'You will receive email notifications to functional-test-email@user.marketplace.team when applications are opening.'
 
-@requires-credentials @mailchimp
+@requires-credentials @mailchimp @skip-staging
 Scenario: Initially-rejected mailing-list subscription
   # example@example.com should be rejected by mailchimp as an obvious fake address
   When I enter 'example@example.com' in the 'email_address' field


### PR DESCRIPTION
Trello: https://trello.com/c/pzAoSoTC/434-mailchimp-resubscribe-for-users-who-have-unsubscribed

The error message content has changed for invalid emails.