### PR TITLE
add declaration reuse scenario

### DIFF
--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -137,7 +137,7 @@ When /I click #{MAYBE_VAR} ?(button|link)?$/ do |button_link_name, elem_type|
   end
 end
 
-When /I click a link with text( containing)? #{MAYBE_VAR}(?: in #{MAYBE_VAR})?$/ do |maybe_containing, link_text, element|
+When /I click a( random)? link with text( containing)? #{MAYBE_VAR}(?: in #{MAYBE_VAR})?$/ do |maybe_random, maybe_containing, link_text, element|
   expect(element).not_to be_a(String), "It's not yet decided what a plain String should mean in this context"
 
   region = element || page
@@ -146,10 +146,12 @@ When /I click a link with text( containing)? #{MAYBE_VAR}(?: in #{MAYBE_VAR})?$/
   else
     found_links = region.all(:xpath, "//a[normalize-space(string())=normalize-space(#{escape_xpath(link_text)})]")
   end
-  if found_links.length > 1
+
+  if found_links.length > 1 && !maybe_random
     puts "Warning: #{found_links.length} '#{link_text}' links found"
   end
-  found_links[0].click
+
+  (maybe_random ? found_links.sample : found_links[0]).click
 end
 
 When /I click the (Next|Previous) Page link$/ do |next_or_previous|

--- a/features/step_definitions/framework_application_steps.rb
+++ b/features/step_definitions/framework_application_steps.rb
@@ -12,17 +12,16 @@ Then /^I click #{MAYBE_VAR} link for that framework application$/ do |link_title
   step "I click a link with text '#{link_title}'"
 end
 
-Then(/^I answer all questions on that page$/) do
-  page_header_at_start = page.all(:xpath, "//h1")[0].text
+Then(/^I follow the first 'Edit' link and answer all questions on that page and those following until I'm (?:back )?on #{MAYBE_VAR} page$/) do |terminating_page_name|
   edit_links = page.all(:xpath, "//p[@class='summary-item-top-level-action']/a[text()='Edit']")
   edit_links[0].click
-  page_header = nil
-  until page_header_at_start == page.all(:xpath, "//h1")[0].text
-    if page_header == page.all(:xpath, "//h1")[0].text
+  page_name = nil
+  until page.all(:xpath, "//h1")[0].text == terminating_page_name
+    if page_name == page.all(:xpath, "//h1")[0].text
       options = get_answers_for_validated_questions
       answer = fill_form with: options
     else
-      page_header = page.all(:xpath, "//h1")[0].text
+      page_name = page.all(:xpath, "//h1")[0].text
       answer = fill_form
     end
     merge_fields_and_print_answers(answer)

--- a/features/step_definitions/framework_application_steps.rb
+++ b/features/step_definitions/framework_application_steps.rb
@@ -63,6 +63,15 @@ Given /^that supplier has confirmed their company details for that application$/
   confirm_company_details_for_framework(@framework['slug'], @supplier['id'])
 end
 
+Given /^that supplier has begun the application process for that framework$/ do
+  register_interest_in_framework(@framework['slug'], @supplier['id'])
+end
+
+Given /^that supplier has not begun the declaration for that application$/ do
+  remove_supplier_declaration(@supplier['id'], @framework['slug'])
+  set_supplier_framework_prefill_declaration(@supplier['id'], @framework['slug'], nil)
+end
+
 Then /^I( don't)? receive a (follow-up|clarification) question( confirmation)? email regarding that question for #{MAYBE_VAR}$/ do |negate, question_type, maybe_confirmation, target_address|
   ref_prefix = (
     case question_type

--- a/features/step_definitions/supplier_steps.rb
+++ b/features/step_definitions/supplier_steps.rb
@@ -67,3 +67,9 @@ Given /^that supplier has a service on the (.*) lot(?: for the (.*) role)?$/ do 
   @service = create_live_service(@framework['slug'], lot_slug, @supplier["id"], role_type)
   puts "service id: #{@service['id']}"
 end
+
+Given 'I have a supplier with a reusable declaration' do
+  @supplier = get_supplier_with_reusable_declaration
+  puts "supplier id: #{@supplier['id']}"
+end
+

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -53,10 +53,12 @@ end
 
 Given /^I have a supplier$/ do
   @supplier = create_supplier
+  puts "supplier id: #{@supplier['id']}"
 end
 
 Given /^I have a supplier with:$/ do |table|
   @supplier = get_or_create_supplier(table.rows_hash)
+  puts "supplier id: #{@supplier['id']}"
 end
 
 Given /^that supplier has a user with:$/ do |table|

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -62,10 +62,8 @@ Given /^I have a supplier with:$/ do |table|
 end
 
 Given /^that supplier has a user with:$/ do |table|
-  # To be used in conjunction with the above 2 methods to create multiple users on a supplier with specific attributes
-  custom_user_data = table.rows_hash
-  user_data = { "supplier_id" => @supplier['id'] }
-  custom_user_data.update(user_data)
+  # can be used in conjunction with the above 2 methods to create multiple users on a supplier with specific attributes
+  custom_user_data = { "supplier_id" => @supplier['id'] }.merge(table.rows_hash)
   @supplier_user = get_or_create_user(custom_user_data)
 end
 

--- a/features/supplier/supplier_applies_to_a_framework.feature
+++ b/features/supplier/supplier_applies_to_a_framework.feature
@@ -3,12 +3,12 @@ Feature: Apply to an open framework
 
 Background:
   Given there is a framework that is open for applications
-  And I have a supplier user
-  And that supplier is logged in
 
 Scenario: Supplier submits a framework application
-  Given I visit the /suppliers page
-  When I start that framework application
+  Given I have a supplier user
+  And that supplier is logged in
+  When I visit the /suppliers page
+  And I start that framework application
   Then I am on the 'Apply to framework' page for that framework application
 
   When I click 'Enter your company details'
@@ -22,7 +22,7 @@ Scenario: Supplier submits a framework application
   When I click 'Start your declaration'
   Then I am on the 'Your declaration overview' page
 
-  When I answer all questions on that page
+  When I follow the first 'Edit' link and answer all questions on that page and those following until I'm back on the 'Your declaration overview' page
   Then I click 'Make declaration' button
   And I am on the 'Apply to framework' page for that framework application
   And I see 'You’ve made the supplier declaration' text on the page

--- a/features/supplier/supplier_applies_to_a_framework.feature
+++ b/features/supplier/supplier_applies_to_a_framework.feature
@@ -21,6 +21,7 @@ Scenario: Supplier submits a framework application
   Then I am on the 'Make your supplier declaration' page
   When I click 'Start your declaration'
   Then I am on the 'Your declaration overview' page
+  And I don't see a 'Review answer' link
 
   When I follow the first 'Edit' link and answer all questions on that page and those following until I'm back on the 'Your declaration overview' page
   Then I click 'Make declaration' button
@@ -34,3 +35,29 @@ Scenario: Supplier submits a framework application
   And I click 'Back to framework application' link for that framework application
 
   And I see 'Your application will be submitted at' text on the page
+
+Scenario: Supplier re-uses a declaration
+  Given I have a supplier with a reusable declaration
+  And that supplier has a user with:
+    |active|true|
+  And that supplier has begun the application process for that framework
+  And that supplier has confirmed their company details for that application
+  And that supplier has not begun the declaration for that application
+  And that supplier is logged in
+  When I visit the /suppliers page
+  And I click 'Continue your application'
+  Then I am on the 'Apply to framework' page for that framework application
+
+  When I click 'Make supplier declaration'
+  Then I am on the 'Make your supplier declaration' page
+  When I click 'Start your declaration'
+  Then I am on the 'Reusing answers from an earlier declaration' page
+
+  When I choose the 'Yes' radio button for the 'Do you want to reuse the answers from your earlier declaration?' question
+  And I click 'Save and continue'
+  Then I am on the 'Your declaration overview' page
+
+  When I click a random link with text 'Review answer'
+  # TODO this is where we could continue onwards to make some assertions about the reused declaration data, however
+  # at time of writing we redact so much data from the test datasets as to make this infeasible. revisit this.
+

--- a/features/support/api_helpers.rb
+++ b/features/support/api_helpers.rb
@@ -349,18 +349,19 @@ def get_a_service(status, framework_type = "g-cloud")
 end
 
 def create_user(user_role, custom_user_data = {})
+  custom_user_data = custom_user_data.camelize(:lower)
   randomString = SecureRandom.hex
   password = ENV["DM_#{user_role.upcase.gsub('-', '_')}_USER_PASSWORD"]
 
   user_data = {
-    "emailAddress" => custom_user_data['emailAddress'] || custom_user_data['email_address'] || randomString + '@example.gov.uk',
+    "emailAddress" => custom_user_data['emailAddress'] || randomString + '@example.gov.uk',
     "name" => custom_user_data['name'] || "#{user_role.capitalize} Name #{randomString}",
     "password" => password,
     "role" => custom_user_data['role'] || user_role,
     "phoneNumber" => (SecureRandom.random_number(10000000) + 10000000000).to_s,
   }
 
-  user_data['supplierId'] = custom_user_data['supplierId'] || custom_user_data['supplier_id'] || 0  if user_role == 'supplier'
+  user_data['supplierId'] = custom_user_data['supplierId'] || 0  if user_role == 'supplier'
 
   response = call_api(:post, "/users", payload: { users: user_data, updated_by: 'functional_tests' })
   expect(response.code).to eq(201), response.body
@@ -421,29 +422,46 @@ def get_or_create_user(custom_user_data)
   # The possible argument combinations for the getting of a user are dependent on the available end points for users.
   # Therefore this method supports:
   # id: being the id of the user (and should not be used with any other args as it's a primary key)
-  # email_address: email_address of the account. This can be used independently.
-  # supplier_id: supplier id of the user. May result in unpredictable behaviour if there is more than one user with the
-  #     supplier_id and an email address is not specified
+  # emailAddress: email_address of the account. This can be used independently.
+  # supplierId: supplier id of the user. May result in unpredictable behaviour if there is more than one user with the
+  #     supplierId and an emailAddress is not specified
   # Should the user not be found we will attempt a post create with the provided user data.
+  custom_user_data = custom_user_data.camelize(:lower)
   if custom_user_data["id"] != nil
     response = call_api(:get, "/users/#{custom_user_data['id']}")
     @user = JSON.parse(response.body)["users"]
+    @user['password'] = ENV["DM_#{@user['role'].upcase.gsub('-', '_')}_USER_PASSWORD"]
     return @user
   end
-  if (custom_user_data["email_address"] != nil) || (custom_user_data["supplier_id"] != nil)
+  if (custom_user_data["emailAddress"] != nil) || (custom_user_data["supplierId"] != nil)
     response = call_api(
       :get,
       "/users",
       params: {
-        email_address: custom_user_data['email_address'],
+        email_address: custom_user_data['emailAddress'],
         supplier_id: custom_user_data['supplierId']
       }
     )
     @user = response.code == 200 ? JSON.parse(response.body)["users"][0] : nil
+
+    if @user != nil
+      @user['password'] = ENV["DM_#{@user['role'].upcase.gsub('-', '_')}_USER_PASSWORD"]
+
+      mismatched_properties = custom_user_data.map.reject do |k, v|
+        v == nil || @user[k] == nil || detect_boolean_strings(v) == detect_boolean_strings(@user[k])
+      end.to_h
+
+      if mismatched_properties.empty?
+        return @user
+      end
+
+      expect(custom_user_data["emailAddress"]).to be(
+        nil,
+        "User specified by email address exists but doesn't match requested properties (#{mismatched_properties})"
+      )
+    end
   end
-  if not @user
-    role = custom_user_data['role'] || (custom_user_data['supplier_id'] ? 'supplier' : 'buyer')
-    @user = create_user(role, custom_user_data)
-  end
-  @user
+
+  role = custom_user_data['role'] || (custom_user_data['supplierId'] ? 'supplier' : 'buyer')
+  @user = create_user(role, custom_user_data)
 end

--- a/features/support/api_helpers.rb
+++ b/features/support/api_helpers.rb
@@ -116,7 +116,7 @@ def register_interest_in_framework(framework_slug, supplier_id)
     response = call_api(:put, path, payload: {
       updated_by: "functional tests"
     })
-    expect(response.code).to match(/20[01]/), _error(response, "Failed to register interest in framework #{framework_slug} #{supplier_id}")
+    expect(response.code).to be_between(200, 201), _error(response, "Failed to register interest in framework #{framework_slug} #{supplier_id}")
   end
 end
 

--- a/features/support/helpers.rb
+++ b/features/support/helpers.rb
@@ -175,6 +175,34 @@ RSpec::Matchers.define :include_url do |expected|
   end
 end
 
+class String
+  def camelize(arg = :lower)
+    return self if self !~ /_/ && self =~ /[A-Z]+.*/
+
+    split('_').map.with_index { |e, i| i == 0 && arg == :lower ? e.downcase : e.capitalize }.join
+  end
+end
+
+class Hash
+  def camelize(arg = :lower)
+    # this both squashes out entries with nil values (to ensure they don't override a colliding key with a real value
+    # and converts keys to camelcase
+    map.reject { |k, v| v == nil }.map { |k, v| [k.camelize(arg), v] }.to_h
+  end
+end
+
+def detect_boolean_strings(input)
+  input_norm = input.respond_to?(:downcase) ? input.downcase : input
+  if %w[f false].include? input_norm
+    return false
+  end
+  if %w[t true].include? input_norm
+    return true
+  end
+
+  input
+end
+
 # from https://github.com/ilyakatz/capybara/blob/c0844c8cf43801fa1d88e502b71b8e75ed6da017/lib/capybara/xpath.rb#L8
 def escape_xpath(string)
   if string.include?("'")


### PR DESCRIPTION
https://trello.com/c/K3zhpgda

This adds a basic scenario which runs through the flow when a supplier reuses declaration details. It doesn't _specifically_ add any assertions about the resultant answers though - just that the answers are valid. How I might add such assertions is an open question.

To do this I needed to refactor `get_or_create_user` to be slightly less stupid. Previously we were completely ignoring extra requested properties of the user if they specified the `id` or `emailAddress` key - the only reason these have not been causing problems is that those users _do indeed_ exist in the requested state on preview/staging because they were _created_ in that state by the same call when initially run on a fresh database. However, make a change to the tests without cleaning out the database and you'll get weird failures. Here, at least the failure will explicitly tell you why it's failed.

I realize that in cases we find a property mismatch, we _could_ actually go ahead and update the found user to match the requested properties. I've held back on doing this for now though - it has the potential to create a lot of churn on our db and allow us to introduce more race problems for parallel tests.

So ... thoughts ...