### PR TITLE
get_or_create_user: fix rspec syntax

### DIFF
--- a/features/support/api_helpers.rb
+++ b/features/support/api_helpers.rb
@@ -455,8 +455,8 @@ def get_or_create_user(custom_user_data)
         return @user
       end
 
-      expect(custom_user_data["emailAddress"]).to be(
-        nil,
+      expect(custom_user_data["emailAddress"]).to(
+        be(nil),
         "User specified by email address exists but doesn't match requested properties (#{mismatched_properties})"
       )
     end


### PR DESCRIPTION
I was sure I'd tested this after my rubocop-placating reformatting.

Damn ruby....