### PR TITLE
CCS category support permissions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  - 2.3.1
+  - 2.5.1
 install:
   - gem install govuk-lint
 script:

--- a/features/admin/add_buyer_domain.feature
+++ b/features/admin/add_buyer_domain.feature
@@ -20,8 +20,9 @@ Scenario Outline: Admin user can see invalid format message for invalid domain s
   Then I see a destructive banner message containing '‘test’ is not a valid format'
 
   Examples:
-    | role  |
-    | admin |
+    | role                      |
+    | admin                     |
+    | admin-ccs-category        |
 
 Scenario Outline: Correct users cannot access the add a buyer domain
   Given I am logged in as the existing <role> user
@@ -33,5 +34,4 @@ Scenario Outline: Correct users cannot access the add a buyer domain
     | admin-framework-manager   |
     | admin-ccs-sourcing        |
     | admin-manager             |
-    | admin-ccs-category        |
     | admin-ccs-data-controller |

--- a/features/admin/add_buyer_domain.feature
+++ b/features/admin/add_buyer_domain.feature
@@ -1,4 +1,4 @@
-@admin @add-buyer-domain
+@admin @add-buyer-domain @skip-staging
 Feature: Admin buyer domains
 
 Scenario Outline: Admin user can attempt to add domain and sees duplicate domain error message when domain exists

--- a/features/admin/deactivate_supplier_user.feature
+++ b/features/admin/deactivate_supplier_user.feature
@@ -11,6 +11,7 @@ Background:
     | name          | Deactivate a suppliers contributor feature User #2 |
     | email_address | user-two@example.com                               |
 
+@skip-staging
 Scenario Outline: Correct users can deactivate and reactivate a supplier's contributor
   Given I am logged in as the existing <role> user
   And I click the '<link-name>' link
@@ -31,6 +32,7 @@ Scenario Outline: Correct users can deactivate and reactivate a supplier's contr
     | admin               | Edit supplier accounts or view services |
     | admin-ccs-category  | Edit suppliers and services             |
 
+@skip-staging
 Scenario Outline: Correct users can view but not deactivate suppliers users
   Given I am logged in as the existing <role> user
   And I click the '<link-name>' link

--- a/features/admin/deactivate_supplier_user.feature
+++ b/features/admin/deactivate_supplier_user.feature
@@ -13,7 +13,7 @@ Background:
 
 Scenario Outline: Correct users can deactivate and reactivate a supplier's contributor
   Given I am logged in as the existing <role> user
-  And I click the 'Edit supplier accounts or view services' link
+  And I click the '<link-name>' link
   And I enter 'DM Functional Test Supplier - Deactivate a suppliers contributor feature' in the 'Find a supplier by name' field
   And I click the 'find_supplier_by_name_search' button
   And I click the summary table 'Users' link for the 'DM Functional Test Supplier - Deactivate a suppliers contributor feature' link
@@ -27,8 +27,9 @@ Scenario Outline: Correct users can deactivate and reactivate a supplier's contr
     | Deactivate a suppliers contributor feature User #1 | user-one@example.com | <ANY>       | <ANY>       | No     |
 
   Examples:
-    | role  |
-    | admin |
+    | role                | link-name                               |
+    | admin               | Edit supplier accounts or view services |
+    | admin-ccs-category  | Edit suppliers and services             |
 
 Scenario Outline: Correct users can view but not deactivate suppliers users
   Given I am logged in as the existing <role> user
@@ -45,7 +46,6 @@ Scenario Outline: Correct users can view but not deactivate suppliers users
 
   Examples:
     | role                    | link-name                   |
-    | admin-ccs-category      | Edit suppliers and services |
     | admin-framework-manager | View suppliers and services |
 
 Scenario Outline: Correct users cannot view suppliers users

--- a/features/admin/download_user_research_csvs.feature
+++ b/features/admin/download_user_research_csvs.feature
@@ -1,4 +1,4 @@
-@admin @download-user-research-participants
+@admin @download-user-research-participants @skip-staging
 Feature: Download user research participants
 
 Scenario Outline: Correct users can view the link to download buyer user research participants

--- a/features/admin/download_user_research_csvs.feature
+++ b/features/admin/download_user_research_csvs.feature
@@ -3,11 +3,11 @@ Feature: Download user research participants
 
 Scenario Outline: Correct users can view the link to download buyer user research participants
   Given I am logged in as the existing <role> user
-  Then I see the 'Download list of potential user research participants' link
+  Then I see the 'Download potential user research participants (buyers)' link
 
   Examples:
     | role                    |
-    | admin                   |
+    | admin-framework-manager |
 
 Scenario Outline: Correct users cannot view the link to download buyer user research participants
   Given I am logged in as the existing <role> user
@@ -15,7 +15,7 @@ Scenario Outline: Correct users cannot view the link to download buyer user rese
 
   Examples:
     | role                      |
-    | admin-framework-manager   |
+    | admin                     |
     | admin-ccs-sourcing        |
     | admin-manager             |
     | admin-ccs-category        |
@@ -24,14 +24,14 @@ Scenario Outline: Correct users cannot view the link to download buyer user rese
 @file-download
 Scenario Outline: Correct users can access the page to download supplier user research participants
   Given I am logged in as the existing <role> user
-  And I click the 'Download lists of potential user research participants' link
+  And I click the 'Download potential user research participants (suppliers)' link
   Then I am on the 'Download lists of potential user research participants' page
   When I click a link with text containing 'User research participants on'
   Then I should get a download file with filename ending '.csv' and content-type 'text/csv'
 
   Examples:
     | role                    |
-    | admin                   |
+    | admin-framework-manager |
 
 Scenario Outline: Correct users cannot access the page to download supplier user research participants
   Given I am logged in as the existing <role> user
@@ -39,7 +39,7 @@ Scenario Outline: Correct users cannot access the page to download supplier user
 
   Examples:
     | role                      |
-    | admin-framework-manager   |
+    | admin                     |
     | admin-ccs-sourcing        |
     | admin-manager             |
     | admin-ccs-category        |

--- a/features/admin/invite_supplier_contributor.feature
+++ b/features/admin/invite_supplier_contributor.feature
@@ -1,7 +1,7 @@
 @admin @invite-supplier-contributor
 Feature: Invite a contributor to a supplier account
 
-@requires-credentials @notify
+@requires-credentials @notify @skip-staging
 Scenario Outline: Correct users can invite a contributors to a supplier account
   Given I am logged in as the existing <role> user
   And I have a supplier with:
@@ -28,6 +28,7 @@ Scenario Outline: Prohibited user roles cannot manage supplier users
     | admin-ccs-sourcing      |
     | admin-manager           |
 
+@skip-staging
 Scenario Outline: Prohibited user roles cannot invite users to a supplier
   Given I am logged in as the existing <role> user
   When I visit the /admin/suppliers?supplier_name=DM+Functional+Test+Supplier+-+Invite+a+contributor+feature page

--- a/features/admin/invite_supplier_contributor.feature
+++ b/features/admin/invite_supplier_contributor.feature
@@ -6,7 +6,7 @@ Scenario Outline: Correct users can invite a contributors to a supplier account
   Given I am logged in as the existing <role> user
   And I have a supplier with:
     | name          | DM Functional Test Supplier - Invite a contributor feature |
-  And I click the 'Edit supplier accounts or view services' link
+  And I click the '<link-text>' link
   And I enter 'DM Functional Test Supplier - Invite a contributor feature' in the 'supplier_name' field and click its associated 'Search' button
   And I click the summary table 'Users' link for the 'DM Functional Test Supplier - Invite a contributor feature' link
   When I enter 'functional-test-supplier-contributor@example.gov.uk' in the 'Email address' field
@@ -14,8 +14,9 @@ Scenario Outline: Correct users can invite a contributors to a supplier account
   Then I see a success banner message containing 'User invited'
 
   Examples:
-    | role                    |
-    | admin                   |
+    | role                    | link-text                               |
+    | admin                   | Edit supplier accounts or view services |
+    | admin-ccs-category      | Edit suppliers and services             |
 
 Scenario Outline: Prohibited user roles cannot manage supplier users
   Given I am logged in as the existing <role> user
@@ -36,5 +37,4 @@ Scenario Outline: Prohibited user roles cannot invite users to a supplier
   Examples:
     | role                      |
     | admin-framework-manager   |
-    | admin-ccs-category        |
     | admin-ccs-data-controller |


### PR DESCRIPTION
Trello: https://trello.com/c/vo2OA8oM/465-add-user-support-permissions-for-ccs-category-admins

Dependent on https://github.com/alphagov/digitalmarketplace-admin-frontend/pull/506.

Looks like we don't have any coverage for unlocking a user or moving a contributor to a different supplier at present.

~TBC - Needs a `@skip-staging`~ Skips now added. ~However the linter is still unhappy.~ Adds Ruby 2.5.x to keep Travis happy.