### PR TITLE
 find_elements_by_xpath: use a modified call to `page.all` instead of the undocumented `page.document.find_xpath`

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -136,8 +136,8 @@ module Capybara
     class Base
       def synchronize_with_unload_wait(*args, &block)
         Timeout.timeout(dm_pre_load_wait_time) do
-          until driver.evaluate_script('window.performance.timing.navigationStart < window.performance.timing.domComplete')
-            # navigationStart has been updated more recently than domComplete, domComplete presumably still
+          until driver.evaluate_script('window.performance.timing.navigationStart < window.performance.timing.loadEventEnd')
+            # navigationStart has been updated more recently than loadEventEnd, loadEventEnd presumably still
             # carrying the value set when the *old* page got loaded - that means the dom is probably in the
             # process of loading (or at least requesting) a new page. any following page queries will
             # presumably be targeted at the upcoming page, which isn't ready.

--- a/features/support/helpers.rb
+++ b/features/support/helpers.rb
@@ -73,11 +73,14 @@ def remove_js_hidden_fields_from_results(results)
   results
 end
 
-def find_elements_by_xpath(xpath)
-  # it appears we use this semi-documented inner method of the *poltergeist* api because the standard
-  # capybara all/find_all interface doesn't allow us to specify wait: false. this is a way of achieving
-  # such an effect.
-  page.document.find_xpath(xpath)
+def find_elements_by_xpath(sel)
+  # this function is used in places where the test wants to check for "all" elements matching a selector
+  # but doesn't want to wait (effectively at all), but using an actual nil `wait` value will cause the
+  # synchronize method to not be called at all. the problem being that this will bypass the "fix" we've
+  # put in to make the test wait for the page not to be in a "loading" state (see
+  # `synchronize_with_unload_wait`). so instead we give capybara a miniscule wait time so as ensure our
+  # mechanism is called but not significantly slow down the test.
+  page.all(:xpath, sel, wait: 0.001, visible: :all)
 end
 
 def all_fields(locator, options = { wait: false })


### PR DESCRIPTION
https://trello.com/c/mKfHzrmK

Also insert miniscule wait time to allow our `synchronize_with_unload_wait` mechanism to be engaged but not slow down the test significantly.

This appears to work for me locally when tested against preview. But then again, so did the previous version. It's not an easy error condition to trigger, however my hypothesis is that this will make our FTs less flaky.