### PR TITLE
Remove hardcoded supplier/service from direct award scenario

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  - 2.3.1
+  - 2.5.1
 install:
   - gem install govuk-lint
 script:

--- a/features/buyer/tell_us_about_contract.feature
+++ b/features/buyer/tell_us_about_contract.feature
@@ -126,10 +126,10 @@ Scenario: User awards contract
   Given I am logged in as a buyer user
   And I am ready to tell the outcome for the 'my cloud project' saved search
   When I click the 'Tell us the outcome' link
-  And I award the contract to 'NCCIS' for the 'my cloud project' search
+  And I award the contract for the 'my cloud project' search
   And I am on the 'my cloud project' page
   Then I see a success banner message containing 'You’ve updated ‘my cloud project’'
-  And I see the 'Award a contract' instruction list item status showing as 'Contract awarded to CareerVision Ltd: NCCIS'
+  And I see the 'Award a contract' instruction list item status showing as 'Contract awarded'
 
 Scenario: User does not award contract as work is cancelled
   Given I am logged in as a buyer user

--- a/features/step_definitions/direct_award_steps.rb
+++ b/features/step_definitions/direct_award_steps.rb
@@ -34,13 +34,13 @@ When (/^I have exported my results for the '(.*)' saved search$/) do |search_nam
   }
 end
 
-When (/^I award the contract to '(.*)' for the '(.*)' search$/) do |supplier_name, search_name|
+When (/^I award the contract for the '(.*)' search$/) do |search_name|
   steps %{
     Given I am on the 'Did you award a contract for ‘#{search_name}’?' page
     And I choose the 'Yes' radio button
     And I click 'Save and continue'
     Then I am on the 'Which service won the contract?' page
-    And I choose the '#{supplier_name}' radio button
+    And I choose a random 'which_service_won_the_contract' radio button
     And I click 'Save and continue'
     Then I am on the 'Tell us about your contract' page
     And I enter '20' in the 'input-start_date-day' field


### PR DESCRIPTION
Following a recent DB refresh on staging, a change in supplier name meant that the G-Cloud direct award scenario failed consistently.

This change makes the assertion less strict, and chooses a random service option. This brings it in line with how we assert the equivalent DOS award flow scenario (picking a random brief response and just asserting the string `Awarded to:`). It's a quick fix to unblock the pipeline.

The longer term fix would involve storing the choice and asserting the full `Awarded to <supplier_name>: <service_name>` value. Fixing that properly would take some effort: the input value is the service ID, and the supplier/service strings are nested in a span within the option label. 