### PR TITLE
Update company details feature for digitalmarketplace-admin-frontend#516

### DIFF
--- a/features/admin/company_details.feature
+++ b/features/admin/company_details.feature
@@ -15,6 +15,7 @@ Background:
   And that supplier has returned a signed framework agreement for the framework
   And that supplier has a service on the cloud-support lot
 
+@skip-local @skip-preview
 Scenario Outline: Correct admin roles can view a supplier's details
   Given I am logged in as the existing <role> user
   And I am on the 'Admin' page
@@ -28,6 +29,40 @@ Scenario Outline: Correct admin roles can view a supplier's details
   And I click the 'DM Functional Test Supplier - Company details feature' link
   Then I am on the 'DM Functional Test Supplier - Company details feature' page
   And I see the 'Company details for G-Cloud 10' summary table filled with:
+    | field                        | value                                            |
+    | Company registered name      | DM Functional Test Suppliers Ltd.                |
+    | Company registration number  | 87654321                                         |
+    | DUNS Number                  | <ANY>                                            |
+    | Address                      | 10 Downing Street London AB1 2CD United Kingdom  |
+  And I see an entry in the 'Frameworks' table with:
+    | field       | link1         | link2           |
+    | G-Cloud 10  | View services | View agreements |
+  When I click the 'Users' link
+  Then I am on the 'DM Functional Test Supplier - Company details feature' page
+  And I see an entry in the 'Users' table with:
+    | Name                                     | Email address   | Last login | Pwd changed | Locked | Status |
+    | DM Functional Test - Supplier Mr Muffins | <ANY>           | <ANY>      | <ANY>       | No     | <ANY>  |
+
+  Examples:
+    | role                      | link-name                               | page-title                              |
+    | admin                     | Edit supplier accounts or view services | Edit supplier accounts or view services |
+    | admin-ccs-category        | Edit suppliers and services             | Edit suppliers and services             |
+    | admin-ccs-data-controller | View and edit suppliers                 | Search for suppliers                    |
+
+@skip-staging
+Scenario Outline: Correct admin roles can view a supplier's details
+  Given I am logged in as the existing <role> user
+  And I am on the 'Admin' page
+  When I click '<link-name>'
+  Then I am on the '<page-title>' page
+  And I enter 'DM Functional Test Supplier - Company details feature' in the 'Find a supplier by name' field
+  And I click the 'find_supplier_by_name_search' button
+  Then I see an entry in the 'Suppliers' table with:
+    | Supplier Name                                         | Users | Services |
+    | DM Functional Test Supplier - Company details feature | Users | Services |
+  And I click the 'DM Functional Test Supplier - Company details feature' link
+  Then I am on the 'DM Functional Test Supplier - Company details feature' page
+  And I see the 'Company details for supplier account' summary table filled with:
     | field                        | value                                            |
     | Company registered name      | DM Functional Test Suppliers Ltd.                |
     | Company registration number  | 87654321                                         |

--- a/features/admin/company_details_edit.feature
+++ b/features/admin/company_details_edit.feature
@@ -15,7 +15,7 @@ Background:
   And that supplier has returned a signed framework agreement for the framework
   And that supplier has a service on the cloud-support lot
 
-@with-admin-ccs-data-controller-user
+@with-admin-ccs-data-controller-user @skip-local @skip-preview
 Scenario: Admin CCS Data Controller can edit a supplier's details
   Given I am logged in as the existing admin-ccs-data-controller user
   And I am on the 'Admin' page
@@ -68,6 +68,77 @@ Scenario: Admin CCS Data Controller can edit a supplier's details
   Then I am on the 'DM Functional Test Supplier - Edit company details feature' page
   And I see a success banner message containing 'The details for ‘DM Functional Test Supplier - Edit company details feature’ have been updated.'
   And I see the 'Company details for G-Cloud 10' summary table filled with:
+    | field                        | value                                       |
+    | Company registered name      | We Have Edited These Company Details Ltd.   |
+    | Company registration number  | 12345678                                    |
+    | DUNS Number                  | <ANY>                                       |
+    | Address                      | 11 Downing Street New London EF1 2GH France |
+
+  # Reset details for next test run
+  When I click the summary table 'Change' link for 'Company registered name'
+  When I enter 'We Edit Company Details Ltd.' in the 'Registered company name' field and click its associated 'Save' button
+  When I click the summary table 'Change' link for 'Company registration number'
+  And I enter '87654321' in the 'Companies House number' field and click its associated 'Save' button
+  When I click the summary table 'Change' link for 'Address'
+  And I enter '10 Downing Street' in the 'Building and street' field
+  And I enter 'London' in the 'Town or city' field
+  And I enter 'AB1 2CD' in the 'Postcode' field
+  And I enter 'United Kingdom' in the 'location-autocomplete' field and click the selected autocomplete option
+  And I click the 'Save' button
+
+@with-admin-ccs-data-controller-user @skip-staging
+Scenario: Admin CCS Data Controller can edit a supplier's details
+  Given I am logged in as the existing admin-ccs-data-controller user
+  And I am on the 'Admin' page
+  When I click 'View and edit suppliers'
+  Then I am on the 'Search for suppliers' page
+  When I enter 'DM Functional Test Supplier - Edit company details feature' in the 'Find a supplier by name' field
+  And I click the 'find_supplier_by_name_search' button
+  Then I see an entry in the 'Suppliers' table with:
+    | Supplier Name                                              | Users | Services |
+    | DM Functional Test Supplier - Edit company details feature | Users | Services |
+  When I click the 'DM Functional Test Supplier - Edit company details feature' link
+  Then I am on the 'DM Functional Test Supplier - Edit company details feature' page
+
+  When I click the summary table 'Change' link for 'Company registered name'
+  Then I am on the 'Update registered company name for ‘DM Functional Test Supplier - Edit company details feature’' page
+  When I enter 'We Have Edited These Company Details Ltd.' in the 'Registered company name' field and click its associated 'Save' button
+  Then I am on the 'DM Functional Test Supplier - Edit company details feature' page
+  And I see a success banner message containing 'The details for ‘DM Functional Test Supplier - Edit company details feature’ have been updated.'
+  And I see the 'Company details for supplier account' summary table filled with:
+    | field                        | value                                           |
+    | Company registered name      | We Have Edited These Company Details Ltd.       |
+    | Company registration number  | 87654321                                        |
+    | DUNS Number                  | <ANY>                                           |
+    | Address                      | 10 Downing Street London AB1 2CD United Kingdom |
+
+  When I click the summary table 'Change' link for 'Company registration number'
+  Then I am on the 'Update registered company number for ‘DM Functional Test Supplier - Edit company details feature’' page
+  And I enter '12345678' in the 'Companies House number' field and click its associated 'Save' button
+  Then I am on the 'DM Functional Test Supplier - Edit company details feature' page
+  And I see a success banner message containing 'The details for ‘DM Functional Test Supplier - Edit company details feature’ have been updated.'
+  And I see the 'Company details for supplier account' summary table filled with:
+    | field                        | value                                           |
+    | Company registered name      | We Have Edited These Company Details Ltd.       |
+    | Company registration number  | 12345678                                        |
+    | DUNS Number                  | <ANY>                                           |
+    | Address                      | 10 Downing Street London AB1 2CD United Kingdom |
+
+  When I click the summary table 'Change' link for 'DUNS Number'
+  Then I see 'You need to contact cloud_digital@crowncommercial.gov.uk to change a supplier DUNS number.' text on the page
+  And I click 'Return to ‘DM Functional Test Supplier - Edit company details feature’ company details'
+  Then I am on the 'DM Functional Test Supplier - Edit company details feature' page
+
+  When I click the summary table 'Change' link for 'Address'
+  Then I am on the 'Update registered company address for ‘DM Functional Test Supplier - Edit company details feature’' page
+  And I enter '11 Downing Street' in the 'Building and street' field
+  And I enter 'New London' in the 'Town or city' field
+  And I enter 'EF1 2GH' in the 'Postcode' field
+  And I enter 'France' in the 'location-autocomplete' field and click the selected autocomplete option
+  And I click the 'Save' button
+  Then I am on the 'DM Functional Test Supplier - Edit company details feature' page
+  And I see a success banner message containing 'The details for ‘DM Functional Test Supplier - Edit company details feature’ have been updated.'
+  And I see the 'Company details for supplier account' summary table filled with:
     | field                        | value                                       |
     | Company registered name      | We Have Edited These Company Details Ltd.   |
     | Company registration number  | 12345678                                    |


### PR DESCRIPTION
Ticket: https://trello.com/c/fY2frqFG/490-supplier-company-details-always-show-admin-the-account-company-details

alphagov/digitalmarketplace#516 change the company details feature so that the company details are always sourced from the supplier account.

This commit tweaks the functional tests to reflect this change.