### PR TITLE
create_supplier: provide a default supplier address 

### DIFF
--- a/features/admin/company_details.feature
+++ b/features/admin/company_details.feature
@@ -28,11 +28,11 @@ Scenario Outline: Correct admin roles can view a supplier's details
   And I click the 'DM Functional Test Supplier - Company details feature' link
   Then I am on the 'DM Functional Test Supplier - Company details feature' page
   And I see the 'Company details for supplier account' summary table filled with:
-    | field                        | value                                            |
-    | Company registered name      | DM Functional Test Suppliers Ltd.                |
-    | Company registration number  | 87654321                                         |
-    | DUNS Number                  | <ANY>                                            |
-    | Address                      | 10 Downing Street London AB1 2CD United Kingdom  |
+    | field                        | value                                |
+    | Company registered name      | DM Functional Test Suppliers Ltd.    |
+    | Company registration number  | 87654321                             |
+    | DUNS Number                  | <ANY>                                |
+    | Address                      | 14 Duke Street Dublin H3 LY5 Ireland |
   And I see an entry in the 'Frameworks' table with:
     | field       | link1         | link2           |
     | G-Cloud 10  | View services | View agreements |

--- a/features/admin/company_details_edit.feature
+++ b/features/admin/company_details_edit.feature
@@ -39,7 +39,7 @@ Scenario: Admin CCS Data Controller can edit a supplier's details
     | Company registered name      | We Have Edited These Company Details Ltd.       |
     | Company registration number  | 87654321                                        |
     | DUNS Number                  | <ANY>                                           |
-    | Address                      | 10 Downing Street London AB1 2CD United Kingdom |
+    | Address                      | 14 Duke Street Dublin H3 LY5 Ireland            |
 
   When I click the summary table 'Change' link for 'Company registration number'
   Then I am on the 'Update registered company number for ‘DM Functional Test Supplier - Edit company details feature’' page
@@ -51,7 +51,7 @@ Scenario: Admin CCS Data Controller can edit a supplier's details
     | Company registered name      | We Have Edited These Company Details Ltd.       |
     | Company registration number  | 12345678                                        |
     | DUNS Number                  | <ANY>                                           |
-    | Address                      | 10 Downing Street London AB1 2CD United Kingdom |
+    | Address                      | 14 Duke Street Dublin H3 LY5 Ireland            |
 
   When I click the summary table 'Change' link for 'DUNS Number'
   Then I see 'You need to contact cloud_digital@crowncommercial.gov.uk to change a supplier DUNS number.' text on the page
@@ -80,8 +80,8 @@ Scenario: Admin CCS Data Controller can edit a supplier's details
   When I click the summary table 'Change' link for 'Company registration number'
   And I enter '87654321' in the 'Companies House number' field and click its associated 'Save' button
   When I click the summary table 'Change' link for 'Address'
-  And I enter '10 Downing Street' in the 'Building and street' field
-  And I enter 'London' in the 'Town or city' field
-  And I enter 'AB1 2CD' in the 'Postcode' field
-  And I enter 'United Kingdom' in the 'location-autocomplete' field and click the selected autocomplete option
+  And I enter '14 Duke Street' in the 'Building and street' field
+  And I enter 'Dublin' in the 'Town or city' field
+  And I enter 'H3 LY5' in the 'Postcode' field
+  And I enter 'Ireland' in the 'location-autocomplete' field and click the selected autocomplete option
   And I click the 'Save' button

--- a/features/supplier/supplier_account.feature
+++ b/features/supplier/supplier_account.feature
@@ -28,7 +28,7 @@ Scenario: Supplier user can provide and change supplier details before confirmin
   Then I am on the 'Registered company name' page
   And I enter 'Toys "ᴙ" Us' in the 'Registered company name' field and click its associated 'Save and return' button
 
-  Then I click the summary table 'Answer required' link for 'Registered company address'
+  Then I click the summary table 'Change' link for 'Registered company address'
   And I am on the 'What is your registered office address?' page
   And I enter '101 Toys Street' in the 'Building and street' field
   And I enter 'Toytown' in the 'Town or city' field

--- a/features/support/api_helpers.rb
+++ b/features/support/api_helpers.rb
@@ -264,7 +264,11 @@ def create_supplier(custom_supplier_data = {})
       contactName: random_string,
       email: random_string + "-supplier@example.com",
       phoneNumber: '%010d' % rand(10**11 - 1),
-    }]
+      address1: "14 Duke Street",
+      city: "Dublin",
+      postcode: "H3 LY5",
+    }],
+    registrationCountry: "country:IE",
   }
   supplier_data.update(custom_supplier_data)
 

--- a/features/support/api_helpers.rb
+++ b/features/support/api_helpers.rb
@@ -272,6 +272,9 @@ def create_supplier(custom_supplier_data = {})
   }
   supplier_data.update(custom_supplier_data)
 
+  # the "create supplier" endpoint is restricted in the attributes it will allow to be set at creation time,
+  # so we have to separate these out and possibly follow the creation up with an update to set the remaining
+  # attributes
   creatable_attrs = {}
   updatable_attrs = {}
   supplier_data.each do |key, value|


### PR DESCRIPTION
https://trello.com/c/4CtHMt07

Also expect this default supplier address in tests where it should show up.

This was caused by the changes in https://trello.com/c/fY2frqFG/ only exhibiting themselves after the staging database got cleared and `get_or_create_supplier` calls had to start creating their suppliers again.

Spot the unproficient ruby programmer.

(will probably require a clearout of the preview database)