### PR TITLE
brief response creation: don't bother outputting an informational line

### DIFF
--- a/features/step_definitions/brief_response_steps.rb
+++ b/features/step_definitions/brief_response_steps.rb
@@ -46,7 +46,6 @@ end
 
 Given 'that supplier has filled in their response to that brief but not submitted it' do
   @brief_response = create_brief_response(@brief['lotSlug'], @brief['id'], @supplier['id'])
-  puts "brief response id: #{@brief_response['id']}"
 end
 
 Given 'that supplier submits their response to that brief' do


### PR DESCRIPTION
This was a last second addition to my previous PR, stupid in hindsight.

It's not worth finding out what ruby's got wrong with it.