### PR TITLE
Change search scenarios to use a new search step

### DIFF
--- a/features/smoke-tests/buyer/catalogue.feature
+++ b/features/smoke-tests/buyer/catalogue.feature
@@ -19,10 +19,10 @@ Scenario: User is able to navigate to service detail page via selecting the serv
 Scenario: User is able to search by keywords field on the search results page to narrow down the results returned
   Given I visit the /g-cloud/search page
   And I have a random g-cloud service from the API
-  And I enter that service.id in the 'q' field
+  And I search for that service.id using the search box
   And I wait for the page to reload
   Then I see that service.id in the search summary text
-  And I see that service.id as the value of the 'q' field
+  And I see that service.id as the search query in the search box
   When I continue clicking 'Next' until I see that service in the search results
   And I click a link with text that service.serviceName in that search_result
   Then I am on that service.serviceName page

--- a/features/smoke-tests/supplier/opportunities.feature
+++ b/features/smoke-tests/supplier/opportunities.feature
@@ -20,7 +20,7 @@ Scenario Outline: User can filter by individual lot and keyword search
   And I see all the opportunities on the page are on the '<lot>' lot
   And I note the result_count
   # using the plural here helps us exercise stemming
-  When I enter 'governments' in the 'q' field
+  When I search for 'governments' using the search box
   And I wait for the page to reload
   Then I see 'governments' in the search summary text
   And I see that the stated number of results does not exceed that result_count

--- a/features/smoulder-tests/buyer/catalogue.feature
+++ b/features/smoulder-tests/buyer/catalogue.feature
@@ -13,10 +13,10 @@ Scenario: User can select a lot from the g-cloud page and see search results.
 Scenario: User is able to search by service id and have result returned.
   Given I visit the /g-cloud/search page
   And I have a random g-cloud service from the API
-  When I enter that service.id in the 'q' field
+  When I search for that service.id using the search box
   And I wait for the page to reload
   Then I see that service.id in the search summary text
-  And I see that service.id as the value of the 'q' field
+  And I see that service.id as the search query in the search box
   When I continue clicking 'Next' until I see that service in the search results
   And I click a link with text that service.serviceName in that search_result
   Then I am on that service.serviceName page
@@ -24,10 +24,10 @@ Scenario: User is able to search by service id and have result returned.
 Scenario: User is able to search by service name and have result returned.
   Given I visit the /g-cloud/search page
   And I have a random g-cloud service from the API
-  When I enter that quoted service.serviceName in the 'q' field
+  When I search for that quoted service.serviceName using the search box
   And I wait for the page to reload
   Then I see that quoted service.serviceName in the search summary text
-  And I see that quoted service.serviceName as the value of the 'q' field
+  And I see that quoted service.serviceName as the search query in the search box
   When I continue clicking 'Next' until I see that service in the search results
   And I click a link with text that service.serviceName in that search_result
   Then I am on that service.serviceName page
@@ -62,7 +62,7 @@ Scenario: User is able to paginate through search results and all of the navigat
 
 Scenario: User gets no results for an unfindable term
   Given I visit the /g-cloud/search page
-  And I enter 'metempsychosis' in the 'q' field
+  And I search for 'metempsychosis' using the search box
   And I wait for the page to reload
   Then I don't see a search result
   And I see 'metempsychosis' in the search summary text

--- a/features/smoulder-tests/supplier/opportunities.feature
+++ b/features/smoulder-tests/supplier/opportunities.feature
@@ -104,7 +104,7 @@ Scenario Outline: User can filter by status, lot, location and keyword together
   And I see all the opportunities on the page are on the '<lot>' lot
   And I see all the opportunities on the page are of the '<status>' status
   And I see all the opportunities on the page are in the '<location>' location
-  When I enter '<phrase>' in the 'q' field
+  When I search for '<phrase>' using the search box
   And I wait for the page to reload
   Then I see '<phrase>' in the search summary text
   And I see that the stated number of results does not exceed that result_count

--- a/features/step_definitions/catalogue_steps.rb
+++ b/features/step_definitions/catalogue_steps.rb
@@ -1,3 +1,12 @@
+When /^I search for #{MAYBE_VAR} using the search box$/ do |query|
+  page.fill_in "q", with: query
+  page.click_button("Search")
+end
+
+When /^I see #{MAYBE_VAR} as the search query in the search box$/ do |query|
+  expect(page.find_field("q").value).to eq(query)
+end
+
 When(/^I click a random result in the list of service results returned$/) do
   search_results = all(:xpath, "//*[@class='search-result']")
   selected_result = search_results[rand(search_results.length)]


### PR DESCRIPTION
Our current scenarios that test the search box assume that searches will
take place after text is entered into the search box, without the user
submitting the form. However, with our current live search javascript,
this requires the focus of the search box to be lost, which does not
always happen.

This commit changes the scenarios to explicitly submit the search form,
by adding a new pair of steps specifically related to the search box. We
don't want to rely on the form focus being lost; instead we test as if
the user were hitting enter or pressing the Search button.