### PR TITLE
deactivate_supplier_user feature background: expect 'active' users

### DIFF
--- a/features/admin/deactivate_supplier_user.feature
+++ b/features/admin/deactivate_supplier_user.feature
@@ -7,9 +7,11 @@ Background:
   And that supplier has a user with:
     | name          | Deactivate a suppliers contributor feature User #1 |
     | email_address | user-one@example.com                               |
+    | active        | true                                               |
   And that supplier has a user with:
     | name          | Deactivate a suppliers contributor feature User #2 |
     | email_address | user-two@example.com                               |
+    | active        | true                                               |
 
 Scenario Outline: Correct users can deactivate and reactivate a supplier's contributor
   Given I am logged in as the existing <role> user


### PR DESCRIPTION
This won't actually *fix* the situation if the data exists and is out of kilter, but will abort early and make it more obvious that it's a data problem and not code. It basically results in the error:

```
User specified by email address exists but doesn't match requested properties ({"active"=>"true"})
```

which is a bit better than just random mysterious failures.

If we get more ballsy about this it could be possible to start fixing up the data if it's not to our liking, but this is a first step.