### PR TITLE
add a (temporary, nastily implemented) detailed debugging log output …

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -137,6 +137,7 @@ module Capybara
       def synchronize_with_unload_wait(*args, &block)
         Timeout.timeout(dm_pre_load_wait_time) do
           until driver.evaluate_script('window.performance.timing.navigationStart < window.performance.timing.loadEventEnd')
+            DEBUG_FILE.write "#{Time.now.getutc}: #{caller.to_a.select { |pth| pth.include? '/features/' }}\n"
             # navigationStart has been updated more recently than loadEventEnd, loadEventEnd presumably still
             # carrying the value set when the *old* page got loaded - that means the dom is probably in the
             # process of loading (or at least requesting) a new page. any following page queries will

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -9,3 +9,10 @@ end
 Before do
   Capybara.reset_sessions!
 end
+
+DEBUG_FILE = File.open("debug.out", "w+")
+
+AfterStep do |result, test_step|
+  DEBUG_FILE.write "#{Time.now.getutc}: #{test_step.location}\n"
+end
+


### PR DESCRIPTION
Anyone's welcome to make this less nasty for me, but it should at least let us know when the `synchronize_with_unload_wait` mechanism has been engaged for a step. Inside the `synchronize_with_unload_wait` loop we output an abbreviated version of the call stack, including only paths including `/features/` - this seems a fairly reliable way to identify code under our control.

The "proper" way of doing this would probably involve adding a custom `Formatter`, but it doesn't seem particularly straightforward to send custom output to a specific formatter.