### PR TITLE
get_supplier_with_reusable_declaration: obey supplierFramework.allowDeclarationReuse

### DIFF
--- a/features/support/api_helpers.rb
+++ b/features/support/api_helpers.rb
@@ -503,7 +503,7 @@ def get_supplier_with_reusable_declaration
   reusable_frameworks.detect do |framework|
     body_json = JSON.parse(call_api(:get, "/frameworks/#{framework['slug']}/suppliers?with_declarations=false").body)
     supplier_framework = body_json['supplierFrameworks'].shuffle.detect do |sf|
-      sf['onFramework']
+      sf['onFramework'] && sf['allowDeclarationReuse']
     end
   end
 


### PR DESCRIPTION
https://trello.com/c/V7cUDIRW

To correspond to the new behaviour of https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/1074