### PR TITLE
nasty debug log: fix to handle parallel cucumbers

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -170,7 +170,7 @@ module Capybara
       def synchronize_with_unload_wait(*args, &block)
         Timeout.timeout(dm_pre_load_wait_time) do
           until driver.evaluate_script('window.performance.timing.navigationStart < window.performance.timing.loadEventEnd')
-            DEBUG_FILE.write "#{Time.now.getutc}: #{caller.to_a.select { |pth| pth.include? '/features/' }}\n"
+            DEBUG_FILE.write "#{Time.now.utc.round(10).iso8601(6)}: #{caller.to_a.select { |pth| pth.include? '/features/' }}\n"
             # navigationStart has been updated more recently than loadEventEnd, loadEventEnd presumably still
             # carrying the value set when the *old* page got loaded - that means the dom is probably in the
             # process of loading (or at least requesting) a new page. any following page queries will

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -15,6 +15,6 @@ FileUtils.mkdir_p "reports"
 DEBUG_FILE = File.open("reports/debug.out", "w+")
 
 AfterStep do |result, test_step|
-  DEBUG_FILE.write "#{Time.now.getutc}: #{test_step.location}\n"
+  DEBUG_FILE.write "#{Time.now.utc.round(10).iso8601(6)}: #{test_step.location}\n"
 end
 

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -12,7 +12,7 @@ end
 
 require 'fileutils'
 FileUtils.mkdir_p "reports"
-DEBUG_FILE = File.open("reports/debug.out", "w+")
+DEBUG_FILE = File.open("reports/debug.#{Process.pid}.out", "a")
 
 AfterStep do |result, test_step|
   DEBUG_FILE.write "#{Time.now.utc.round(10).iso8601(6)}: #{test_step.location}\n"


### PR DESCRIPTION
I didn't previously consider that we have parallel cucumbers and with the present code we get interleaved log results in that case. Fix that.