### PR TITLE
Add a sleep to our reload when the failure is ObsoleteNode

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -156,6 +156,7 @@ module Capybara
             raise Capybara::FrozenInTime, "time appears to be frozen, Capybara does not work with libraries which freeze time, consider using time travelling instead" if Capybara::Helpers.monotonic_time == start_time
 
             reload if session_options.automatic_reload
+            sleep(0.05) if e.class == Capybara::Poltergeist::ObsoleteNode
             retry
           ensure
             session.synchronized = false


### PR DESCRIPTION
To test the theory:

If we reload the page and immediately retry looking for our node we are _more_ likely to trigger an ObsoleteNode error.
This fits with the previous observation that upping the timeout made the tests longer.