### PR TITLE
Disable tests that are failing on production

### DIFF
--- a/features/smoke-tests/buyer/catalogue.feature
+++ b/features/smoke-tests/buyer/catalogue.feature
@@ -27,6 +27,7 @@ Scenario: User is able to search by keywords field on the search results page to
   And I click a link with text that service.serviceName in that search_result
   Then I am on that service.serviceName page
 
+@skip-production
 Scenario: User is able to click on several random filters
   Given I visit the /buyers/direct-award/g-cloud/choose-lot page
   And I have a random g-cloud lot from the API

--- a/features/smoke-tests/supplier/opportunities.feature
+++ b/features/smoke-tests/supplier/opportunities.feature
@@ -12,6 +12,7 @@ Scenario: User is able to navigate to opportunity detail page via selecting the 
   When I click a random result in the list of opportunity results returned
   Then I am on that result.title page
 
+@skip-production
 Scenario Outline: User can filter by individual lot and keyword search
   Given I visit the /digital-outcomes-and-specialists/opportunities page
   When I note the result_count


### PR DESCRIPTION
We are getting false positives from these tests. We need to fix these
tests but we don't want to keep getting false alarms.