### PR TITLE
Disable tests that are failing on production

### DIFF
--- a/features/smoulder-tests/supplier/opportunities.feature
+++ b/features/smoulder-tests/supplier/opportunities.feature
@@ -50,6 +50,7 @@ Scenario: Specialist roles are selectable for Digital specialists
   When I note the result_count
   Then a filter checkbox's associated aria-live region contains that result_count
 
+@skip-production
 Scenario Outline: Specialist roles are not selectable for non-Digital specialists lots
   Given I visit the /digital-outcomes-and-specialists/opportunities page
   Then I don't see a 'Designer' checkbox
@@ -63,6 +64,7 @@ Scenario Outline: Specialist roles are not selectable for non-Digital specialist
     | Digital outcomes           |
     | User research participants |
 
+@skip-production
 Scenario Outline: User gets no results for impossible combinations of location and lot
   Given I visit the /digital-outcomes-and-specialists/opportunities page
   And I click '<lot>'
@@ -85,6 +87,7 @@ Scenario Outline: User gets no results for impossible combinations of location a
 
 
 
+@skip-production
 Scenario Outline: User can filter by status, lot, location and keyword together
   Given I visit the /digital-outcomes-and-specialists/opportunities page
   When I note the result_count


### PR DESCRIPTION
We are getting false positives from these tests. We need to fix these
tests but we don't want to keep getting false alarms.