### PR TITLE
Add step for filtering search results by category

### DIFF
--- a/features/smoke-tests/buyer/catalogue.feature
+++ b/features/smoke-tests/buyer/catalogue.feature
@@ -27,7 +27,6 @@ Scenario: User is able to search by keywords field on the search results page to
   And I click a link with text that service.serviceName in that search_result
   Then I am on that service.serviceName page
 
-@skip-production
 Scenario: User is able to click on several random filters
   Given I visit the /buyers/direct-award/g-cloud/choose-lot page
   And I have a random g-cloud lot from the API

--- a/features/smoke-tests/supplier/opportunities.feature
+++ b/features/smoke-tests/supplier/opportunities.feature
@@ -12,7 +12,6 @@ Scenario: User is able to navigate to opportunity detail page via selecting the 
   When I click a random result in the list of opportunity results returned
   Then I am on that result.title page
 
-@skip-production
 Scenario Outline: User can filter by individual lot and keyword search
   Given I visit the /digital-outcomes-and-specialists/opportunities page
   When I note the result_count

--- a/features/smoke-tests/supplier/opportunities.feature
+++ b/features/smoke-tests/supplier/opportunities.feature
@@ -15,7 +15,7 @@ Scenario: User is able to navigate to opportunity detail page via selecting the 
 Scenario Outline: User can filter by individual lot and keyword search
   Given I visit the /digital-outcomes-and-specialists/opportunities page
   When I note the result_count
-  And I click '<lot>'
+  And I click the '<lot>' category link
   Then I see that the stated number of results does not exceed that result_count
   And I see all the opportunities on the page are on the '<lot>' lot
   And I note the result_count

--- a/features/smoulder-tests/supplier/opportunities.feature
+++ b/features/smoulder-tests/supplier/opportunities.feature
@@ -50,7 +50,6 @@ Scenario: Specialist roles are selectable for Digital specialists
   When I note the result_count
   Then a filter checkbox's associated aria-live region contains that result_count
 
-@skip-production
 Scenario Outline: Specialist roles are not selectable for non-Digital specialists lots
   Given I visit the /digital-outcomes-and-specialists/opportunities page
   Then I don't see a 'Designer' checkbox
@@ -64,7 +63,6 @@ Scenario Outline: Specialist roles are not selectable for non-Digital specialist
     | Digital outcomes           |
     | User research participants |
 
-@skip-production
 Scenario Outline: User gets no results for impossible combinations of location and lot
   Given I visit the /digital-outcomes-and-specialists/opportunities page
   And I click '<lot>'
@@ -87,7 +85,6 @@ Scenario Outline: User gets no results for impossible combinations of location a
 
 
 
-@skip-production
 Scenario Outline: User can filter by status, lot, location and keyword together
   Given I visit the /digital-outcomes-and-specialists/opportunities page
   When I note the result_count

--- a/features/smoulder-tests/supplier/opportunities.feature
+++ b/features/smoulder-tests/supplier/opportunities.feature
@@ -54,7 +54,7 @@ Scenario Outline: Specialist roles are not selectable for non-Digital specialist
   Given I visit the /digital-outcomes-and-specialists/opportunities page
   Then I don't see a 'Designer' checkbox
   And I don't see any 'specialistRole' checkboxes
-  When I click '<lot>'
+  When I click the '<lot>' category link
   Then I don't see a 'Designer' checkbox
   And I don't see any 'specialistRole' checkboxes
 
@@ -65,7 +65,7 @@ Scenario Outline: Specialist roles are not selectable for non-Digital specialist
 
 Scenario Outline: User gets no results for impossible combinations of location and lot
   Given I visit the /digital-outcomes-and-specialists/opportunities page
-  And I click '<lot>'
+  And I click the '<lot>' category link
   And I check '<location>' checkbox
   And I wait for the page to reload
   Then I see no results
@@ -88,7 +88,7 @@ Scenario Outline: User gets no results for impossible combinations of location a
 Scenario Outline: User can filter by status, lot, location and keyword together
   Given I visit the /digital-outcomes-and-specialists/opportunities page
   When I note the result_count
-  And I click '<lot>'
+  And I click the '<lot>' category link
   Then I see that the stated number of results does not exceed that result_count
   And I note the result_count
   When I check '<status>' checkbox

--- a/features/step_definitions/catalogue_steps.rb
+++ b/features/step_definitions/catalogue_steps.rb
@@ -64,6 +64,12 @@ Then (/^I note the total number of pages of results$/) do
   puts "Noted page_count: #{@page_count}"
 end
 
+Then(/^I click the (.*) category link$/) do |category|
+  # Look for links only in the lot-filters div so we don't click any
+  # search results which happen to include the name of a lot/category.
+  page.find(:css, ".lot-filters a", text: category).click
+end
+
 Then /^I click a random category link$/ do
   links = CatalogueHelpers.get_category_links(page)
   link_el = links.sample


### PR DESCRIPTION
https://trello.com/c/HYk2HSCJ/896-smoke-test-failures-on-production

Our catalogue tests can be tripped up if there happens to be a search result that contains the text of a filter or category in its name.

This PR adds a more specific step for filtering by category that uses a CSS selector to limit where we look for the specific category name.

This should fix the problems we were seeing yesterday, so I've reverted the commits that added skip-production tags.