### PR TITLE
synchronize_with_navigation_wait: add xhr_semaphore support

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -167,21 +167,40 @@ module Capybara
       # Note this is done *after* the possible patching via synchronize_with_timeout_error, so that it wraps
       # *outside* that.
 
-      def synchronize_with_unload_wait(*args, &block)
+      def is_page_loading
+        browser_params = driver.evaluate_script(%q({
+          "navigationStart": window.performance.timing.navigationStart,
+          "loadEventEnd": window.performance.timing.loadEventEnd,
+          "xhr_semaphore": (window.GOVUK && window.GOVUK.xhr_semaphore) || 0
+        }))
+
+        if browser_params['navigationStart'] > browser_params['loadEventEnd']
+          # navigationStart has been updated more recently than loadEventEnd, loadEventEnd presumably still
+          # carrying the value set when the *old* page got loaded - that means the dom is probably in the
+          # process of loading (or at least requesting) a new page. any following page queries will
+          # presumably be targeted at the upcoming page, which isn't ready.
+          reason = "navigationStart (#{browser_params['navigationStart']}) > loadEventEnd (#{browser_params['loadEventEnd']})"
+        elsif browser_params['xhr_semaphore'] > 0
+          # window.GOVUK.xhr_semaphore's non-zero value indicates that the page still has an ajax request in flight
+          reason = "xhr_semaphore = #{browser_params['xhr_semaphore']}"
+        else
+          return false
+        end
+
+        DEBUG_FILE.write "#{Time.now.utc.round(10).iso8601(6)}: #{reason} @ #{caller.to_a.select { |pth| pth.include? '/features/' }}\n"
+        true
+      end
+
+      def synchronize_with_navigation_wait(*args, &block)
         Timeout.timeout(dm_pre_load_wait_time) do
-          until driver.evaluate_script('window.performance.timing.navigationStart < window.performance.timing.loadEventEnd')
-            DEBUG_FILE.write "#{Time.now.utc.round(10).iso8601(6)}: #{caller.to_a.select { |pth| pth.include? '/features/' }}\n"
-            # navigationStart has been updated more recently than loadEventEnd, loadEventEnd presumably still
-            # carrying the value set when the *old* page got loaded - that means the dom is probably in the
-            # process of loading (or at least requesting) a new page. any following page queries will
-            # presumably be targeted at the upcoming page, which isn't ready.
+          until !is_page_loading
             sleep(0.01)
           end
         end
-        synchronize_without_unload_wait(*args, &block)
+        synchronize_without_navigation_wait(*args, &block)
       end
-      alias_method :synchronize_without_unload_wait, :synchronize
-      alias_method :synchronize, :synchronize_with_unload_wait
+      alias_method :synchronize_without_navigation_wait, :synchronize
+      alias_method :synchronize, :synchronize_with_navigation_wait # rubocop:disable Lint/DuplicateMethods
     end
   end
 end


### PR DESCRIPTION
https://trello.com/c/6htyRkFX

Renamed from `synchronize_with_unload_wait`, this wrapper now also looks for a `window.GOVUK.xhr_semaphore` property in the page's DOM, which, when present and non-zero, is taken to mean that the page has an ajax request in flight and the test should delay element testing.