### PR TITLE
Remove skip-staging tags

### DIFF
--- a/features/supplier/supplier_asks_a_framework_question.feature
+++ b/features/supplier/supplier_asks_a_framework_question.feature
@@ -1,7 +1,7 @@
 @supplier @supplier-framework-question
 Feature: Supplier asks a framework question
 
-@skip-staging
+@notify
 Scenario: Supplier asks a clarification question
   Given there is a framework that is open for applications with clarification questions open
   And I have a supplier user
@@ -24,8 +24,7 @@ Scenario: Supplier asks a clarification question
   And I don't receive a follow-up question email regarding that question for 'follow-up@example.gov.uk'
   And I see a success banner message containing 'Your clarification question has been sent.'
 
-@skip-staging
-Scenario: Supplier asks a question about their application
+Scenario: Supplier cannot ask a question after the clarification deadline
   Given there is a framework that is open for applications with clarification questions closed
   And I have a supplier user
   And that supplier has applied to be on that framework


### PR DESCRIPTION
Forgot to remove these as part of https://trello.com/c/2oq3Py0C/586-include-supplier-name-in-framework-clarification-question-email-to-ccs

Also rename scenario to reflect that suppliers can no longer ask questions after the deadline.