### PR TITLE
Update header of help page

### DIFF
--- a/features/smoulder-tests/public/urls.feature
+++ b/features/smoulder-tests/public/urls.feature
@@ -11,4 +11,4 @@ Scenario: Use of trailing slashes in URL path
 
 Scenario: Use of relative URL path components
   Given I visit the /user/../help page
-  Then I am on the 'What do you need help with?' page
+  Then I am on the 'Help and feedback' page


### PR DESCRIPTION
The h1 on the help page has been changed (see
alphagov/digitalmarketplace-buyer-frontend#909). This commit updates the
text that the functional tests are looking for to match.