### PR TITLE
Update create_supplier (properly, this time)

### DIFF
--- a/features/support/api_helpers.rb
+++ b/features/support/api_helpers.rb
@@ -259,7 +259,7 @@ def create_supplier(custom_supplier_data = {})
   random_string = SecureRandom.hex
   supplier_data = {
     name: 'functional test supplier ' + random_string,
-    dunsNumber: rand(999999999).to_s,
+    dunsNumber: 9.times.map { rand(10) }.join,
     contactInformation: [{
       contactName: random_string,
       email: random_string + "-supplier@example.com",


### PR DESCRIPTION
This will serve as a lesson for me to be more careful when changing Ruby code. The code I thought randomly generated a ten-digit number actually generated a number in the range 0-9999999999. Since we weren't validating DUNS number length, nobody noticed when a random supplier's DUNS number was, say, 3. I've replaced this with idiomatic ruby code that generates a 9-digit number. This runs the risk of a number, represented as a string, that has a leading zero. If that string is cast into an int at any point it'll lose that leading zero and only be 8 characters long, which will fail validation. However, there's nowhere (as far as we know) that does this so: onwards!