### PR TITLE
antivirus test: upload file with a weirder key name

### DIFF
--- a/features/smoulder-tests/antivirus/antivirus.feature
+++ b/features/smoulder-tests/antivirus/antivirus.feature
@@ -3,5 +3,5 @@ Feature: Antivirus scanning
 @smoulder-tests @antivirus @notify @file-upload @requires-aws-credentials @skip-local
 Scenario: Uploading an infected file to a bucket should generate a warning email
   Given I have a randomized file containing the eicar test signature
-  When I upload that file to the documents bucket under the key 'functional_tests/bad.pdf'
+  When I upload that file to the documents bucket under the key 'functional_tests/we?rd d%r+name❡/bad.pdf'
   Then I receive a notification regarding that file within 4 minutes


### PR DESCRIPTION
https://trello.com/c/l2On3zPU

To test https://github.com/alphagov/digitalmarketplace-antivirus-api/pull/47

Though I'm going to have to think of a way of checking this only on preview to begin with...