### PR TITLE
add Admin acknowledging service edits feature 

### DIFF
--- a/features/admin/access_a_service.feature
+++ b/features/admin/access_a_service.feature
@@ -22,7 +22,7 @@ Scenario: Admin with Service Manager role can edit, remove and publish a service
   Then I see a destructive banner message containing 'Are you sure you want to remove ‘Plant-based cloud hosting’?'
   When I click 'Remove'
   Then I see a temporary-message banner message containing 'Removed by '
-  And I see a temporary-message banner message containing 'that user.emailAddress'
+  And I see a temporary-message banner message containing that user.emailAddress
   When I click 'Publish service'
   Then I see a destructive banner message containing 'Are you sure you want to publish ‘Plant-based cloud hosting’?'
   When I click 'Publish'

--- a/features/admin/acknowledge_service_edits.feature
+++ b/features/admin/acknowledge_service_edits.feature
@@ -1,0 +1,44 @@
+@admin
+Feature: Admin acknowledging service edits
+
+Background:
+  Given I have a published service on a live G-Cloud framework
+  And I ensure that all update audit events for that service are acknowledged
+
+Scenario: Admin approves service edits
+  Given I choose a random sentence
+  And user 'functional.test@example.com' sets the serviceDescription of that service to that random_sentence
+  And I am logged in as the existing admin-ccs-category user
+  And I am on the 'Admin' page
+  When I click 'Review service changes'
+  Then I am on the 'Check edits to services' page
+  And I don't see a banner message
+  And I see that service.supplierName in the 'Edited services' summary table
+  When I click the summary table 'View changes' link for that service.id
+  Then I am on that service.serviceName page
+  And I see 'functional.test@example.com made 1 edit' in the page's main
+  And I see that random_sentence in the page's ins
+
+  # Before we approve the edit we're going to test a race condition of the supplier re-editing the service
+  # before approval
+
+  When I choose a random sentence
+  And user 'functional.test@example.com' sets the serviceDescription of that service to that random_sentence
+  And I click the 'Approve edit' button
+  Then I am on the 'Check edits to services' page
+  And I see a success banner message containing that service.id
+
+  # However we still haven't approved the second edit
+
+  And I see that service.supplierName in the 'Edited services' summary table
+  When I click the summary table 'View changes' link for that service.id
+  Then I am on that service.serviceName page
+  And I see 'functional.test@example.com made 1 edit' in the page's main
+  # This is the second random_sentence now of course
+  And I see that random_sentence in the page's ins
+
+  When I click the 'Approve edit' button
+  Then I am on the 'Check edits to services' page
+  And I see a success banner message containing that service.id
+  And I don't see that service.id in the 'Edited services' summary table
+  And that service has no unacknowledged update audit events

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -23,6 +23,8 @@ end
 
 Given /^I have a (not-submitted|submitted|enabled|disabled|published|failed) service on a live G-Cloud framework$/ do |status|
   @service = get_a_service(status)
+  puts "Service id: #{@service['id']}"
+  puts "Service name: #{@service['serviceName']}"
 end
 
 When /^I enter that service id in the '(.*)' field( and click its associated '(.*)' button)?$/ do |field_name, maybe_click_statement, click_button_name|

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -237,6 +237,12 @@ When(/^I choose a random uppercase letter$/) do
   puts "letter: #{@letter}"
 end
 
+When(/^I choose a random sentence$/) do
+  lexicon = %w[apple banana cherry date fig gooseberry juniper]
+  @random_sentence = ((0..8).map { |n| lexicon.sample }).join(" ").capitalize + "."
+  puts "sentence: #{@random_sentence}"
+end
+
 # the rescue is used because if a banner cannot be found the function throws an exception and does not look for the other option
 Then /^I see a (success|warning|destructive|temporary-message) banner message containing #{MAYBE_VAR}$/ do |status, message|
   begin

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -238,7 +238,7 @@ When(/^I choose a random uppercase letter$/) do
 end
 
 # the rescue is used because if a banner cannot be found the function throws an exception and does not look for the other option
-Then /^I see a (success|warning|destructive|temporary-message) banner message containing '(.*)'$/ do |status, message|
+Then /^I see a (success|warning|destructive|temporary-message) banner message containing #{MAYBE_VAR}$/ do |status, message|
   begin
     banner_message = page.find(:css, ".banner-#{status}-without-action", wait: false)
   rescue Capybara::ElementNotFound => e
@@ -324,7 +324,7 @@ When /^I click the top\-level summary table '(.*)' link for the section '(.*)'$/
   edit_link.click
 end
 
-When /I click the summary table '(.*)' (link|button) for '(.*)'$/ do |link_name, elem_type, field_to_edit|
+When /I click the summary table #{MAYBE_VAR} (link|button) for #{MAYBE_VAR}$/ do |link_name, elem_type, field_to_edit|
   case elem_type
     when 'link'
       edit_link = page.find(:xpath, "//tr/*/span[normalize-space(text()) = '#{field_to_edit}']/../..//a[contains(normalize-space(text()), '#{link_name}')]")
@@ -334,7 +334,7 @@ When /I click the summary table '(.*)' (link|button) for '(.*)'$/ do |link_name,
   edit_link.click
 end
 
-When /I click the summary table '(.*)' (link|button) for the '(.*)' link$/ do |link_name, elem_type, field_to_edit|
+When /I click the summary table #{MAYBE_VAR} (link|button) for #{MAYBE_VAR} link$/ do |link_name, elem_type, field_to_edit|
   case elem_type
     when 'link'
       edit_link = page.find(:xpath, "//tr/td/*/a[normalize-space(text()) = '#{field_to_edit}']/../../..//a[contains(normalize-space(text()), '#{link_name}')]")
@@ -344,7 +344,7 @@ When /I click the summary table '(.*)' (link|button) for the '(.*)' link$/ do |l
   edit_link.click
 end
 
-When /I click a summary table '(.*)' (link|button) for '(.*)'$/ do |link_name, elem_type, field_to_edit|
+When /I click a summary table #{MAYBE_VAR} (link|button) for #{MAYBE_VAR}$/ do |link_name, elem_type, field_to_edit|
   case elem_type
     when 'link'
       edit_link = page.all(:xpath, "//tr/*/span[normalize-space(text()) = '#{field_to_edit}']/../..//a[contains(normalize-space(text()), '#{link_name}')]")
@@ -383,9 +383,9 @@ Then /^I see the '(.*)' summary table filled with:$/ do |table_heading, table|
   end
 end
 
-Then /^I see #{MAYBE_VAR} in the '(.*)' summary table$/ do |content, table_heading|
+Then /^I (don't |)see #{MAYBE_VAR} in the '(.*)' summary table$/ do |negate, content, table_heading|
   result_table_rows = get_table_rows_by_caption(table_heading)
-  expect(result_table_rows.any? { |row| row.text.include?(content) }).to be true
+  expect(result_table_rows.any? { |row| row.text.include?(content) }).to be negate.empty?
 end
 
 Then /^I see that the '(.*)' summary table has (\d+)(?: or (more|fewer))? entr(?:y|ies)$/ do |table_heading, expected_number_of_rows, comparison|

--- a/features/step_definitions/supplier_steps.rb
+++ b/features/step_definitions/supplier_steps.rb
@@ -68,6 +68,20 @@ Given /^that supplier has a service on the (.*) lot(?: for the (.*) role)?$/ do 
   puts "service id: #{@service['id']}"
 end
 
+Given 'I ensure that all update audit events for that service are acknowledged' do
+  acknowledge_all_service_updates(@service['id'])
+end
+
+Given /^that service has( no)? unacknowledged update audit events$/ do |negate|
+  audit_events_json = get_unacknowledged_service_update_audit_events(@service['id'])
+  if negate
+    expect(audit_events_json['auditEvents'].length).to eq(0), "#{audit_events_json['auditEvents'].length} found"
+  else
+    expect(audit_events_json['auditEvents'].length).not_to eq(0), "None found"
+    puts "Found #{audit_events_json['auditEvents'].length}"
+  end
+end
+
 Given 'I have a supplier with a reusable declaration' do
   @supplier = get_supplier_with_reusable_declaration
   puts "supplier id: #{@supplier['id']}"

--- a/features/step_definitions/supplier_steps.rb
+++ b/features/step_definitions/supplier_steps.rb
@@ -82,6 +82,14 @@ Given /^that service has( no)? unacknowledged update audit events$/ do |negate|
   end
 end
 
+Given /^user #{MAYBE_VAR} sets the (\w+) of that service to #{MAYBE_VAR}$/ do |editor_email, field_name, new_text|
+  update_service(
+    @service['id'],
+    { field_name => new_text },
+    editor_email,
+  )
+end
+
 Given 'I have a supplier with a reusable declaration' do
   @supplier = get_supplier_with_reusable_declaration
   puts "supplier id: #{@supplier['id']}"

--- a/features/supplier/view_and_edit_g_cloud_services.feature
+++ b/features/supplier/view_and_edit_g_cloud_services.feature
@@ -9,6 +9,7 @@ Background:
   And we accepted that suppliers application to the framework
   And that supplier has returned a signed framework agreement for the framework
   And that supplier has a service on the cloud-support lot
+  And I ensure that all update audit events for that service are acknowledged
   When I visit the /suppliers page
   # The following step only works by virtue of there only being a single service for this supplier - multiple services on
   # multiple frameworks will cause multiple "View services" links to be present
@@ -26,6 +27,7 @@ Scenario: Supplier user can edit the name of a service
   And I click 'Save and return'
   Then I am on the 'Changed cloud support service' page
   And I see a success banner message containing 'You’ve edited your service. The changes are now live on the Digital Marketplace.'
+  And that service has unacknowledged update audit events
 
 Scenario: Supplier user can edit the description of a service
   Given I see the 'About your service' summary table filled with:
@@ -40,6 +42,7 @@ Scenario: Supplier user can edit the description of a service
   And I see the 'About your service' summary table filled with:
     | field                        | value                          |
     | Service description          | This is an updated description |
+  And that service has unacknowledged update audit events
 
 Scenario: Supplier user can edit the features and benefits of a service
   Given I see the 'Service features and benefits' summary table filled with:
@@ -55,6 +58,7 @@ Scenario: Supplier user can edit the features and benefits of a service
   And I see the 'Service features and benefits' summary table filled with:
     | field                         | value                                                                                  |
     | Service features and benefits | Service features Feature 1 New Feature 2 Service benefits Benefit 1 Updated Benefit 2  |
+  And that service has unacknowledged update audit events
 
 @requires-credentials @file-upload
 Scenario: Supplier user can replace the service definition document
@@ -64,6 +68,7 @@ Scenario: Supplier user can replace the service definition document
   And I click 'Save and return'
   Then I am on that service.serviceName page
   And I see a success banner message containing 'You’ve edited your service. The changes are now live on the Digital Marketplace.'
+  And that service has unacknowledged update audit events
 
 @requires-credentials @file-upload
 Scenario: Supplier user can not replace the service definition document with a non-pdf file
@@ -73,6 +78,7 @@ Scenario: Supplier user can not replace the service definition document with a n
   And I click 'Save and return'
   Then I am on the 'Documents' page
   And I see a validation message containing 'Your document is not in an open format. Please save as an Open Document Format (ODF) or PDF/A (eg .pdf, .odt).'
+  And that service has no unacknowledged update audit events
 
 @requires-credentials @file-upload
 Scenario: Supplier user can not replace the service definition document with a file over 5MB
@@ -82,6 +88,7 @@ Scenario: Supplier user can not replace the service definition document with a f
   And I click 'Save and return'
   Then I am on the 'Documents' page
   And I see a validation message containing 'Your document exceeds the 5MB limit. Please reduce file size.'
+  And that service has no unacknowledged update audit events
 
 Scenario: Supplier can remove their G-Cloud service from the marketplace
   When I click 'Remove service'
@@ -92,3 +99,4 @@ Scenario: Supplier can remove their G-Cloud service from the marketplace
 
   When I click that service.serviceName
   Then I see a temporary-message banner message containing 'This service was removed'
+  And that service has no unacknowledged update audit events

--- a/features/supplier/view_and_edit_g_cloud_services.feature
+++ b/features/supplier/view_and_edit_g_cloud_services.feature
@@ -16,8 +16,8 @@ Background:
   # Two steps below so we can assert the page title for either G9 or G10
   Then I am on the 'Your G-Cloud' page
   And I see the page's h1 ends in 'services'
-  When I click 'Test cloud support service'
-  Then I am on the 'Test cloud support service' page
+  When I click that service.serviceName
+  Then I am on that service.serviceName page
 
 Scenario: Supplier user can edit the name of a service
   When I click the top-level summary table 'Edit' link for the section 'Service name'
@@ -35,7 +35,7 @@ Scenario: Supplier user can edit the description of a service
   Then I am on the 'About your service' page
   And I enter 'This is an updated description' in the 'serviceDescription' field
   And I click 'Save and return'
-  Then I am on the 'Test cloud support service' page
+  Then I am on that service.serviceName page
   And I see a success banner message containing 'You’ve edited your service. The changes are now live on the Digital Marketplace.'
   And I see the 'About your service' summary table filled with:
     | field                        | value                          |
@@ -50,7 +50,7 @@ Scenario: Supplier user can edit the features and benefits of a service
   And I enter 'New Feature 2' in the 'input-serviceFeatures-2' field
   And I enter 'Updated Benefit 2' in the 'input-serviceBenefits-2' field
   And I click 'Save and return'
-  Then I am on the 'Test cloud support service' page
+  Then I am on that service.serviceName page
   And I see a success banner message containing 'You’ve edited your service. The changes are now live on the Digital Marketplace.'
   And I see the 'Service features and benefits' summary table filled with:
     | field                         | value                                                                                  |
@@ -62,7 +62,7 @@ Scenario: Supplier user can replace the service definition document
   Then I am on the 'Documents' page
   And I choose file 'test.pdf' for the field 'serviceDefinitionDocumentURL'
   And I click 'Save and return'
-  Then I am on the 'Test cloud support service' page
+  Then I am on that service.serviceName page
   And I see a success banner message containing 'You’ve edited your service. The changes are now live on the Digital Marketplace.'
 
 @requires-credentials @file-upload
@@ -90,5 +90,5 @@ Scenario: Supplier can remove their G-Cloud service from the marketplace
   When I click 'Remove service'
   Then I see a success banner message containing 'Test cloud support service has been removed.'
 
-  When I click 'Test cloud support service'
+  When I click that service.serviceName
   Then I see a temporary-message banner message containing 'This service was removed'

--- a/features/support/api_helpers.rb
+++ b/features/support/api_helpers.rb
@@ -527,6 +527,18 @@ def acknowledge_all_service_updates(service_id)
   end
 end
 
+def update_service(service_id, service_data, updated_by)
+  response = call_api(
+    :post,
+    "/services/#{service_id}",
+    payload: {
+      "services": service_data,
+      "updated_by": updated_by,
+    },
+  )
+  expect(response.code).to eq(200), response.body
+end
+
 def get_supplier_with_reusable_declaration
   reusable_frameworks = (get_frameworks.select do |framework|
     framework['allowDeclarationReuse']

--- a/features/support/transforms.rb
+++ b/features/support/transforms.rb
@@ -4,6 +4,12 @@
 MAYBE_VAR_RE = '((?:the )?(?:\'(?<value>.*)\')|(?:that (?<quoted>quoted )?(?<variable>\w+)(?<attributes>(?:\.[\w-]+)*)))'
 MAYBE_VAR = MAYBE_VAR_RE.gsub(/<[a-z]+>/, ':')
 
+# the following transform, used in conjunction with our habit of putting quotation marks
+# *outside* our steps' capture groups, is unfortunately overzealous - causing any captured
+# parameter to be possibly transformed if e.g. beginning with "that ".
+# TODO we should decide what to do about this, possibly by making _all_ our outer-quoted
+# capture groups use MAYBE_VAR somehow
+
 Transform /^#{MAYBE_VAR}$/ do |whole_match|
   # to access the inner regex groups we have to perform the regex again with the groups captured. from what i can tell
   # Transforms don't work very well with multiple arguments, so we implement the transform itself as a single-argument


### PR DESCRIPTION
https://trello.com/c/CnowkGc5

This was originally going to be at least two different scenarios, but I realized that the setup of the "race condition" test was the same as the contents of the first test, so decided not to waste anyone's time making it do it twice.

Can anyone think of any other scenarios I could test?