### PR TITLE
Change service edits feature test to acknowledge all service edits

### DIFF
--- a/features/admin/acknowledge_service_edits.feature
+++ b/features/admin/acknowledge_service_edits.feature
@@ -3,7 +3,7 @@ Feature: Admin acknowledging service edits
 
 Background:
   Given I have a published service on a live G-Cloud framework
-  And I ensure that all update audit events for that service are acknowledged
+  And I ensure that all update audit events are acknowledged
 
 Scenario: Admin approves service edits
   Given I choose a random sentence

--- a/features/step_definitions/supplier_steps.rb
+++ b/features/step_definitions/supplier_steps.rb
@@ -68,6 +68,10 @@ Given /^that supplier has a service on the (.*) lot(?: for the (.*) role)?$/ do 
   puts "service id: #{@service['id']}"
 end
 
+Given 'I ensure that all update audit events are acknowledged' do
+  acknowledge_all_service_updates
+end
+
 Given 'I ensure that all update audit events for that service are acknowledged' do
   acknowledge_all_service_updates(@service['id'])
 end

--- a/features/support/api_helpers.rb
+++ b/features/support/api_helpers.rb
@@ -494,23 +494,28 @@ def get_or_create_user(custom_user_data)
   @user = create_user(role, custom_user_data)
 end
 
-def get_unacknowledged_service_update_audit_events(service_id)
+def get_unacknowledged_service_update_audit_events(service_id = nil)
+  params = {
+    "latest-first": "true",
+    "audit-type": "update_service",
+    "acknowledged": "false",
+  }
+  if service_id
+    params.update({ # rubocop:disable Style/BracesAroundHashParameters
+      "object-type": "services",
+      "object-id": service_id,
+    })
+  end
   response = call_api(
     :get,
     "/audit-events",
-    params: {
-      "object-type": "services",
-      "object-id": service_id,
-      "latest-first": "true",
-      "audit-type": "update_service",
-      "acknowledged": "false",
-    },
+    params: params,
   )
   expect(response.code).to eq(200), response.body
   JSON.parse(response.body)
 end
 
-def acknowledge_all_service_updates(service_id)
+def acknowledge_all_service_updates(service_id = nil)
   listing_response_json = get_unacknowledged_service_update_audit_events(service_id)
 
   if listing_response_json["auditEvents"].length != 0


### PR DESCRIPTION
We had an issue where functional tests were failing because the number
of unacknowledge service edits on the admin page was larger than 100, so
the most recent were being pushed on to a second page and not visible.

This PR changes the service edit feature's background to make sure
that all unacknowledged service edits are acknowledged, so we can be
sure the page is clear before beginning the tests.