### PR TITLE
Allow using briefs where the user is not active

### DIFF
--- a/features/step_definitions/brief_response_steps.rb
+++ b/features/step_definitions/brief_response_steps.rb
@@ -24,7 +24,8 @@ Given /^I am logged in as the buyer of a closed brief with responses$/ do
   puts "brief id: #{@brief['id']}"
   @lot_slug = @brief['lotSlug']
   @framework_slug = @brief['frameworkSlug']
-  @buyer_user = (@brief['users'].select { |u| u["active"] && !u["locked"] })[0]
+  @buyer_user = @brief['users'].sample
+  ensure_user_can_log_in @buyer_user
   puts "user id: #{@buyer_user['id']}"
   @buyer_user.update('password' => ENV["DM_BUYER_USER_PASSWORD"])
   steps "Given that buyer is logged in"

--- a/features/support/api_helpers.rb
+++ b/features/support/api_helpers.rb
@@ -84,6 +84,15 @@ def ensure_user_exists(user_details)
   get_user_by_email(user_details['emailAddress'])
 end
 
+def ensure_user_can_log_in(user)
+  if user['active'] == 'false'
+    call_api(:post, "/users/#{user['id']}", payload: { users: { active: true } }, updated_by: "functional_tests")
+  end
+  if user['locked'] == 'true'
+    call_api(:post, "/users/#{user['id']}", payload: { users: { locked: false } }, updated_by: "functional_tests")
+  end
+end
+
 def ensure_no_framework_agreements_exist(framework_slug)
   response = call_api(:get, "/frameworks/#{framework_slug}/suppliers")
   expect(response.code).to eq(200), _error(response, "Failed to get framework #{framework_slug}")

--- a/features/support/api_helpers.rb
+++ b/features/support/api_helpers.rb
@@ -187,6 +187,10 @@ def get_brief_responses(framework_slug, brief_response_status, brief_status)
     next_page += 1
   end
 
+  if brief_reponse_list.empty?
+    raise "No #{brief_response_status} brief responses for #{brief_status} briefs"
+  end
+
   brief_response_list
 end
 


### PR DESCRIPTION
We have been running out of closed briefs with responses, partly because we limit ourselves to briefs where the user is active; this restriction is not necessary however. This commit adds a method `ensure_user_can_log_in` that activates deactivated users, and we use this in the "log in as user with brief with brief responses" step.