### PR TITLE
live service editing: tidy up unacknowledged service update audit events after scenarios

### DIFF
--- a/features/admin/access_a_service.feature
+++ b/features/admin/access_a_service.feature
@@ -5,7 +5,8 @@ Background:
   Given I have a published service on a live G-Cloud framework
 
 Scenario: Admin with Service Manager role can edit, remove and publish a service
-  Given I am logged in as the existing admin-ccs-category user
+  Given I ensure that all update audit events for that service are acknowledged
+  And I am logged in as the existing admin-ccs-category user
   And I am on the 'Admin' page
   When I click 'Edit suppliers and services'
   Then I am on the 'Edit suppliers and services' page
@@ -17,6 +18,8 @@ Scenario: Admin with Service Manager role can edit, remove and publish a service
   Then I am on the 'About your service' page
   When I enter 'Plant-based cloud hosting' in the 'serviceName' field and click its associated 'Save and return to summary' button
   Then I am on the 'Plant-based cloud hosting' page
+  # edits by admins shouldn't result in update audit events that need acknowledgement
+  And that service has no unacknowledged update audit events
 
   When I click the 'Remove service' link
   Then I see a destructive banner message containing 'Are you sure you want to remove ‘Plant-based cloud hosting’?'

--- a/features/supplier/view_and_edit_g_cloud_services.feature
+++ b/features/supplier/view_and_edit_g_cloud_services.feature
@@ -28,6 +28,8 @@ Scenario: Supplier user can edit the name of a service
   Then I am on the 'Changed cloud support service' page
   And I see a success banner message containing 'You’ve edited your service. The changes are now live on the Digital Marketplace.'
   And that service has unacknowledged update audit events
+  # tidy up
+  Then I ensure that all update audit events for that service are acknowledged
 
 Scenario: Supplier user can edit the description of a service
   Given I see the 'About your service' summary table filled with:
@@ -43,6 +45,8 @@ Scenario: Supplier user can edit the description of a service
     | field                        | value                          |
     | Service description          | This is an updated description |
   And that service has unacknowledged update audit events
+  # tidy up
+  Then I ensure that all update audit events for that service are acknowledged
 
 Scenario: Supplier user can edit the features and benefits of a service
   Given I see the 'Service features and benefits' summary table filled with:
@@ -59,6 +63,8 @@ Scenario: Supplier user can edit the features and benefits of a service
     | field                         | value                                                                                  |
     | Service features and benefits | Service features Feature 1 New Feature 2 Service benefits Benefit 1 Updated Benefit 2  |
   And that service has unacknowledged update audit events
+  # tidy up
+  Then I ensure that all update audit events for that service are acknowledged
 
 @requires-credentials @file-upload
 Scenario: Supplier user can replace the service definition document
@@ -69,6 +75,8 @@ Scenario: Supplier user can replace the service definition document
   Then I am on that service.serviceName page
   And I see a success banner message containing 'You’ve edited your service. The changes are now live on the Digital Marketplace.'
   And that service has unacknowledged update audit events
+  # tidy up
+  Then I ensure that all update audit events for that service are acknowledged
 
 @requires-credentials @file-upload
 Scenario: Supplier user can not replace the service definition document with a non-pdf file


### PR DESCRIPTION
https://trello.com/c/ObiHdZk2 - this is getting annoying.

This fix prevents the number of unacknowledged service updates accumulating to over ~100 and overflowing the admin's single page interface to them, in turn breaking its tests.