### PR TITLE
Change README to avoid specifying the Ruby version

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,11 @@ brew install rbenv
 echo 'eval "$(rbenv init -)"' >> ~/.bash_profile
 ```
 
-Once you have `rbenv` in your environment you can install Ruby 2.3.1, [bundler](http://bundler.io/),
+Once you have `rbenv` in your environment you can install Ruby 2.6, [bundler](http://bundler.io/),
 and then you're good to go :smile:.
 
 ```bash
-rbenv install 2.3.1
+rbenv install
 gem install bundler
 make install
 ```


### PR DESCRIPTION
Running `rbenv install` should install the version of Ruby specified in `.ruby-version`, so we don't need to specifiy the exact version in the example command line.

This should probably have been part of #694 :sweat_smile: