### PR TITLE
Remove skip-staging tags for DOS4

### DIFF
--- a/features/supplier/supplier_applies_for_an_opportunity.feature
+++ b/features/supplier/supplier_applies_for_an_opportunity.feature
@@ -8,15 +8,6 @@ Background:
   And I have a supplier user
   And that supplier is logged in
 
-@skip-preview
-Scenario: Supplier is not eligible as they are not on the framework
-  Given I go to that brief page
-  And I click 'Apply for this opportunity'
-  Then I am on the 'You can’t apply for this opportunity' page
-  And I see 'You can’t apply for this opportunity because you’re not a Digital Outcomes and Specialists 3 supplier.' text on the page
-  And I see a 'data-reason' attribute with the value 'supplier-not-on-digital-outcomes-and-specialists-3'
-
-@skip-staging
 Scenario: Supplier is not eligible as they are not on the framework
   Given I go to that brief page
   And I click 'Apply for this opportunity'
@@ -24,19 +15,6 @@ Scenario: Supplier is not eligible as they are not on the framework
   And I see 'You can’t apply for this opportunity because you’re not a Digital Outcomes and Specialists 4 supplier.' text on the page
   And I see a 'data-reason' attribute with the value 'supplier-not-on-digital-outcomes-and-specialists-4'
 
-@skip-preview
-Scenario: Supplier is not eligible as they are not on the digital-specialists lot
-  Given that supplier has applied to be on that framework
-  And we accepted that suppliers application to the framework
-  And that supplier has returned a signed framework agreement for the framework
-  And that supplier has a service on the digital-outcomes lot
-  And I go to that brief page
-  And I click 'Apply for this opportunity'
-  Then I am on the 'You can’t apply for this opportunity' page
-  And I see 'You can’t apply for this opportunity because you didn’t say you could provide services in this category when you applied to the Digital Outcomes and Specialists 3 framework.' text on the page
-  And I see a 'data-reason' attribute with the value 'supplier-not-on-lot'
-
-@skip-staging
 Scenario: Supplier is not eligible as they are not on the digital-specialists lot
   Given that supplier has applied to be on that framework
   And we accepted that suppliers application to the framework
@@ -48,19 +26,6 @@ Scenario: Supplier is not eligible as they are not on the digital-specialists lo
   And I see 'You can’t apply for this opportunity because you didn’t say you could provide services in this category when you applied to the Digital Outcomes and Specialists 4 framework.' text on the page
   And I see a 'data-reason' attribute with the value 'supplier-not-on-lot'
 
-@skip-preview
-Scenario: Supplier is not eligible as they can not provide the developer role
-  Given that supplier has applied to be on that framework
-  And we accepted that suppliers application to the framework
-  And that supplier has returned a signed framework agreement for the framework
-  And that supplier has a service on the digital-specialists lot for the designer role
-  And I go to that brief page
-  And I click 'Apply for this opportunity'
-  Then I am on the 'You can’t apply for this opportunity' page
-  And I see 'You can’t apply for this opportunity because you didn’t say you could provide this specialist role when you applied to the Digital Outcomes and Specialists 3 framework.' text on the page
-  And I see a 'data-reason' attribute with the value 'supplier-not-on-role'
-
-@skip-staging
 Scenario: Supplier is not eligible as they can not provide the developer role
   Given that supplier has applied to be on that framework
   And we accepted that suppliers application to the framework


### PR DESCRIPTION
https://trello.com/c/sMuf2MLA/1156-fix-dos3-opportunities-on-supplier-fe

DOS4 is now live on staging, so we can remove the `@skip-staging` tags on the 'Apply for an opportunity' scenarios.