### PR TITLE
Fix issue with briefs

### DIFF
--- a/features/step_definitions/brief_response_steps.rb
+++ b/features/step_definitions/brief_response_steps.rb
@@ -7,7 +7,7 @@ Given /^I have a (draft|live|withdrawn) (.*) brief$/ do |status, lot_slug|
 end
 
 Given /^I am logged in as the buyer of a (closed|live) brief$/ do |status|
-  framework = 'digital-outcomes-and-specialists-3'
+  framework = 'digital-outcomes-and-specialists-4'
   matched_brief = get_briefs(framework, status).sample
   raise "could not find a #{status} #{framework} brief" if not matched_brief
 

--- a/features/step_definitions/brief_response_steps.rb
+++ b/features/step_definitions/brief_response_steps.rb
@@ -7,9 +7,13 @@ Given /^I have a (draft|live|withdrawn) (.*) brief$/ do |status, lot_slug|
 end
 
 Given /^I am logged in as the buyer of a (closed|live) brief$/ do |status|
-  matched_brief = get_briefs('digital-outcomes-and-specialists-3', status).sample
+  framework = 'digital-outcomes-and-specialists-3'
+  matched_brief = get_briefs(framework, status).sample
+  raise "could not find a #{status} #{framework} brief" if not matched_brief
+
   @brief = matched_brief
   puts "brief id: #{@brief['id']}"
+
   @buyer_user = (matched_brief['users'].select { |u| u["active"] && !u["locked"] })[0]
   puts "user id: #{@buyer_user['id']}"
   @lot_slug = matched_brief['lotSlug']

--- a/features/step_definitions/brief_response_steps.rb
+++ b/features/step_definitions/brief_response_steps.rb
@@ -23,13 +23,14 @@ Given /^I am logged in as the buyer of a (closed|live) brief$/ do |status|
 end
 
 Given /^I am logged in as the buyer of a closed brief with responses$/ do
-  submitted_brief_responses = iter_brief_responses('digital-outcomes-and-specialists-3', 'submitted', 'closed')
+  framework = 'digital-outcomes-and-specialists-3'  # TODO: change to DOS4 when there are more closed DOS4 briefs
+  submitted_brief_responses = iter_brief_responses(framework, 'submitted', 'closed')
   submitted_brief_responses.each do |brief_response|
     @brief = get_brief(brief_response['brief']['id'])
     @buyer_user = (@brief['users'].select { |u| u["active"] && !u["locked"] })[0]
     break if @buyer_user
   end
-  raise 'could not find an active user for a closed brief with responses' if not @buyer_user
+  raise "could not find an active user for a closed #{framework} brief with responses" if not @buyer_user
 
   @lot_slug = @brief['lotSlug']
   @framework_slug = @brief['frameworkSlug']

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -105,7 +105,7 @@ end
 
 # TODO merge with above step
 Given /^I have a random dos brief from the API$/ do
-  params = { status: "live,closed", framework: "digital-outcomes-and-specialists-3" }
+  params = { status: "live,closed", framework: "digital-outcomes-and-specialists-4" }
   page_one = call_api(:get, "/briefs", params: params)
   last_page_url = JSON.parse(page_one.body)['links']['last']
   params[:page] = if last_page_url


### PR DESCRIPTION
It seems that we have been unable to run our functional tests recently because they have been looking for DOS3 briefs, but all live briefs on preview are now DOS4.