### PR TITLE
Find briefs without regard to framework

### DIFF
--- a/features/step_definitions/brief_response_steps.rb
+++ b/features/step_definitions/brief_response_steps.rb
@@ -7,8 +7,7 @@ Given /^I have a (draft|live|withdrawn) (.*) brief$/ do |status, lot_slug|
 end
 
 Given /^I am logged in as the buyer of a (closed|live) brief$/ do |status|
-  framework = 'digital-outcomes-and-specialists-4'
-  @brief = get_briefs(framework, status).sample
+  @brief = get_briefs(status).sample
   if @brief
     puts "brief id: #{@brief['id']}"
   else
@@ -29,8 +28,7 @@ Given /^I am logged in as the buyer of a (closed|live) brief$/ do |status|
 end
 
 Given /^I am logged in as the buyer of a closed brief with responses$/ do
-  framework = 'digital-outcomes-and-specialists-3'  # TODO: change to DOS4 when there are more closed DOS4 briefs
-  submitted_brief_responses = iter_brief_responses(framework, 'submitted', 'closed')
+  submitted_brief_responses = iter_brief_responses('submitted', 'closed')
   submitted_brief_responses.each do |brief_response|
     @brief = get_brief(brief_response['brief']['id'])
     @buyer_user = (@brief['users'].select { |u| u["active"] && !u["locked"] })[0]

--- a/features/step_definitions/brief_response_steps.rb
+++ b/features/step_definitions/brief_response_steps.rb
@@ -8,16 +8,22 @@ end
 
 Given /^I am logged in as the buyer of a (closed|live) brief$/ do |status|
   framework = 'digital-outcomes-and-specialists-4'
-  matched_brief = get_briefs(framework, status).sample
-  raise "could not find a #{status} #{framework} brief" if not matched_brief
+  @brief = get_briefs(framework, status).sample
+  if @brief
+    puts "brief id: #{@brief['id']}"
+  else
+    raise "could not find a #{status} brief"
+  end
 
-  @brief = matched_brief
-  puts "brief id: #{@brief['id']}"
+  @buyer_user = (@brief['users'].select { |u| u["active"] && !u["locked"] })[0]
+  if @buyer_user
+    puts "user id: #{@buyer_user['id']}"
+  else
+    raise "could not find active user for #{status} brief #{brief['id']}"
+  end
 
-  @buyer_user = (matched_brief['users'].select { |u| u["active"] && !u["locked"] })[0]
-  puts "user id: #{@buyer_user['id']}"
-  @lot_slug = matched_brief['lotSlug']
-  @framework_slug = matched_brief['frameworkSlug']
+  @lot_slug = @brief['lotSlug']
+  @framework_slug = @brief['frameworkSlug']
   @buyer_user.update('password' => ENV["DM_BUYER_USER_PASSWORD"])
   steps "Given that buyer is logged in"
 end

--- a/features/support/api_helpers.rb
+++ b/features/support/api_helpers.rb
@@ -178,7 +178,12 @@ def get_brief(brief_id)
 end
 
 def get_briefs(framework_slug, status)
-  params = { status: status, framework: framework_slug, with_users: 'True' }
+  params = {
+    framework: framework_slug,
+    human: 'True',  # sort by latest first
+    status: status,
+    with_users: 'True',
+  }
   response = call_api(:get, '/briefs', params: params)
   JSON.parse(response.body)['briefs']
 end
@@ -203,7 +208,11 @@ def get_brief_responses(framework_slug, brief_response_status, brief_status)
 end
 
 def iter_brief_responses(framework_slug, brief_response_status, brief_status)
-  params = { status: brief_response_status, framework: framework_slug }
+  params = {
+    framework: framework_slug,
+    human: 'True',  # sort by latest first
+    status: brief_response_status,
+  }
   Enumerator.new do |enum|
     brief_responses = iter_api(:get, '/brief-responses', 'briefResponses', params: params)
     brief_responses = brief_responses.select { |x| x['brief']['status'] == brief_status }

--- a/features/support/api_helpers.rb
+++ b/features/support/api_helpers.rb
@@ -177,9 +177,8 @@ def get_brief(brief_id)
   JSON.parse(response.body)['briefs']
 end
 
-def get_briefs(framework_slug, status)
+def get_briefs(status)
   params = {
-    framework: framework_slug,
     human: 'True',  # sort by latest first
     status: status,
     with_users: 'True',
@@ -207,9 +206,8 @@ def get_brief_responses(framework_slug, brief_response_status, brief_status)
   brief_response_list
 end
 
-def iter_brief_responses(framework_slug, brief_response_status, brief_status)
+def iter_brief_responses(brief_response_status, brief_status)
   params = {
-    framework: framework_slug,
     human: 'True',  # sort by latest first
     status: brief_response_status,
   }


### PR DESCRIPTION
I think that specifying which framework to search when finding briefs is more trouble than its worth; if we are looking for live briefs then we should only ever find briefs for the current live framework(s), and if we're looking for closed briefs if we use the "human" search order then we'll always start looking at the most recent briefs in the most recent framework anyway.

This should make the period when we change DOS frameworks much less painful, and as a side effect might mean fewer failures due to lack of briefs in the future.

As a side note, I've split these changes into small but complete parts, so if we need to in future it should be straightforward to revert them.