### PR TITLE
antivirus: upload file as csv instead of pdf

### DIFF
--- a/features/smoulder-tests/antivirus/antivirus.feature
+++ b/features/smoulder-tests/antivirus/antivirus.feature
@@ -3,5 +3,5 @@ Feature: Antivirus scanning
 @smoulder-tests @antivirus @notify @file-upload @requires-aws-credentials @skip-local
 Scenario: Uploading an infected file to a bucket should generate a warning email
   Given I have a randomized file containing the eicar test signature
-  When I upload that file to the documents bucket under the key 'functional_tests/we?rd d%r+name❡/bad.pdf'
+  When I upload that file to the documents bucket under the key 'functional_tests/we?rd d%r+name❡/bad.csv'
   Then I receive a notification regarding that file within 4 minutes


### PR DESCRIPTION
https://trello.com/c/zrbllE6t/

To prove that csvs can't bypass antivirus