### PR TITLE
Update validation message step to support GOV.UK Design System

### DIFF
--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -258,7 +258,7 @@ Then /^I don't see a banner message$/ do
 end
 
 Then /^I see a validation message containing '(.*)'$/ do |message|
-  validation_message = page.find(:css, ".validation-message")
+  validation_message = page.find(:css, ".validation-message, .govuk-error-message")
   expect(validation_message).to have_content(message)
 end
 


### PR DESCRIPTION
As part of migrating our frontends to use GOV.UK Design System styles
and components we are replacing instances of our validation components
with the error message component.

We want to be able to have the test working on either version, so this
commit updates the step that looks for validation messages to also look
for error messages.