### PR TITLE
Update heading context step to support GOV.UK Design System

### DIFF
--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -317,7 +317,7 @@ Then /Display the value of the '(.*)' JSON field as '(.*)'$/ do |field, name|
 end
 
 Then(/^I see #{MAYBE_VAR} as the page header context$/) do |value|
-  expect(first(:xpath, "//header//*[@class='context']").text).to eq(normalize_whitespace(value))
+  expect(page.find(:css, "header .context, [class*='govuk-caption']")).to have_text(value)
 end
 
 When /^I choose file '(.*)' for the field '(.*)'$/ do |file, label|


### PR DESCRIPTION
As part of migrating our frontends to use GOV.UK Design System styles and components we are replacing instances of our heading context style with the GOV.UK Design System caption style.

We want to be able to have the test working on either version, so this commit updates the step that looks for heading contexts to also look for captions.

This is needed for https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/957.