### PR TITLE
Update framework application helpers with new submit buttons

### DIFF
--- a/features/step_definitions/framework_application_steps.rb
+++ b/features/step_definitions/framework_application_steps.rb
@@ -25,7 +25,7 @@ Then(/^I follow the first 'Edit' link and answer all questions on that page and 
       answer = fill_form
     end
     merge_fields_and_print_answers(answer)
-    find_elements_by_xpath("//button[contains(normalize-space(text()), 'Save and continue')] | //button[contains(normalize-space(text()), 'Save and return to declaration overview')]")[0].click
+    first(:button, text: /(Save and continue)|(Save and return to declaration overview)/).click
   end
 end
 
@@ -39,14 +39,14 @@ Then(/^I submit a service for each lot$/) do
     rescue Capybara::ElementNotFound => e
       answer_all_dos_lot_questions "Edit"
       answer_all_service_questions "Add"
-      find_elements_by_xpath("//button[contains(normalize-space(text()), 'Mark as complete')]")[0].click
+      first(:button, "Mark as complete").click
     else
       answer = fill_form
       merge_fields_and_print_answers(answer)
       click_on 'Save and continue', wait: false
       answer_all_dos_lot_questions "Edit"
       answer_all_service_questions "Answer question"
-      find_elements_by_xpath("//button[contains(normalize-space(text()), 'Mark as complete')]")[0].click
+      first(:button, "Mark as complete").click
       click_on "Back to application", wait: false
     end
 

--- a/features/step_definitions/framework_application_steps.rb
+++ b/features/step_definitions/framework_application_steps.rb
@@ -25,7 +25,7 @@ Then(/^I follow the first 'Edit' link and answer all questions on that page and 
       answer = fill_form
     end
     merge_fields_and_print_answers(answer)
-    find_and_click_submit_button
+    find_elements_by_xpath("//button[contains(normalize-space(text()), 'Save and continue')] | //button[contains(normalize-space(text()), 'Save and return to declaration overview')]")[0].click
   end
 end
 
@@ -39,14 +39,14 @@ Then(/^I submit a service for each lot$/) do
     rescue Capybara::ElementNotFound => e
       answer_all_dos_lot_questions "Edit"
       answer_all_service_questions "Add"
-      find_elements_by_xpath("//input[@value='Mark as complete']")[0].click
+      find_elements_by_xpath("//button[contains(normalize-space(text()), 'Mark as complete')]")[0].click
     else
       answer = fill_form
       merge_fields_and_print_answers(answer)
       click_on 'Save and continue', wait: false
       answer_all_dos_lot_questions "Edit"
       answer_all_service_questions "Answer question"
-      find_elements_by_xpath("//input[@value='Mark as complete']")[0].click
+      find_elements_by_xpath("//button[contains(normalize-space(text()), 'Mark as complete')]")[0].click
       click_on "Back to application", wait: false
     end
 

--- a/features/support/form_helpers.rb
+++ b/features/support/form_helpers.rb
@@ -361,18 +361,23 @@ module FormHelper
   end
 
   def find_and_click_submit_button
-    submit_button = find_elements_by_xpath("//input[@class='button-save']")[0].value
-    if submit_button == 'Save and continue'
-      click_on 'Save and continue', wait: false
-      false
-    else
-      click_on submit_button, wait: false
+    # Get the submit buttons on the page, and categorise by whether we expect to redirect to the summary or not
+    save_and_return_button = find_elements_by_xpath("//button[contains(normalize-space(text()), 'Save and return')] | //button[contains(normalize-space(text()), 'Save and return to service summary')]")[0]
+    save_and_continue_button = find_elements_by_xpath("//button[contains(normalize-space(text()), 'Save and continue')]")[0]
+
+    if save_and_return_button
+      save_and_return_button.click
+      # Section finished - return to summary
       true
+    elsif save_and_continue_button
+      save_and_continue_button.click
+      # Go to next page in the section
+      false
     end
   end
 
   def is_service_complete
-    find_elements_by_xpath("//input[@value='Mark as complete']").length > 0
+    find_elements_by_xpath("//button[contains(normalize-space(text()), 'Mark as complete')]").length > 0
   end
 
   def answer_all_service_questions(prompt_text)


### PR DESCRIPTION
Two scenarios in our functional tests have been failing for a while, but we didn't notice because those scenarios require the framework to be in an `open` state.

The failures are due to the changes in the submit buttons (from `input` to `button`). It's not trivial to fix, because:

- our supplier application scenario sometimes expects the user to continue through each section sequentially, and sometimes expects the user to jump back to the summary page before starting the next section. The `find_and_click_submit_button` method returns `true` or `false` depending on where we're expected to go. The trouble is, we don't know where we're expected to go before we start looking for the buttons 😿  
- the wording on the buttons is also different for declaration pages and for service pages, and imply different destination pages 

I'm confident however that these functions aren't used outside the application journey.

The changes below are full of ugly xpath statements but they do at least pass. Suggestions for improvement welcome.

