### PR TITLE
Include DOS preview page in requirements scenarios

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,8 @@ config/%.sh: config/%.example.sh
 clean:
 	rm -rf reports/
 
-lint:
-	bundle exec govuk-lint-ruby features --diff
+lint: install
+	bundle exec rubocop features
 
 docker-up:
 	$(eval export AWS_ACCESS_KEY_ID=$(shell aws configure get aws_access_key_id))

--- a/features/buyer/requirements-preview.feature
+++ b/features/buyer/requirements-preview.feature
@@ -42,6 +42,7 @@ Scenario: Create individual specialist requirement
    Then 'Describe question and answer session' should be ticked
 
     When I click 'Publish your requirements'
+     And I click 'Publish requirements'
 
   Then I don't see the 'Title' link
    And I don't see the 'Specialist role' link
@@ -87,6 +88,7 @@ Scenario: Create team to provide an outcome
    Then 'Describe question and answer session' should be ticked
 
     When I click 'Publish your requirements'
+     And I click 'Publish requirements'
 
   Then I don't see the 'Title' link
    And I don't see the 'Location' link
@@ -125,6 +127,7 @@ Scenario: Create user research participants
    Then 'Describe question and answer session' should be ticked
 
   Then I click 'Publish your requirements'
+   And I click 'Publish requirements'
 
   Then I don't see the 'Title' link
    And I don't see the 'Location' link

--- a/features/buyer/requirements-preview.feature
+++ b/features/buyer/requirements-preview.feature
@@ -41,8 +41,15 @@ Scenario: Create individual specialist requirement
    And I click 'Return to overview'
    Then 'Describe question and answer session' should be ticked
 
-    When I click 'Publish your requirements'
-     And I click 'Publish requirements'
+   When I click 'Preview your requirements'
+   Then I am on the 'Preview your requirements' page
+    And I see the 'Return to overview' link
+    And I see 'Incomplete applications' text in the desktop preview panel
+    And I see 'Tuesday 8 September 2020' text in the desktop preview panel
+    And I see 'Technical competence 10%' text in the desktop preview panel
+    And I click 'Confirm your requirements and publish'
+   Then I am on the 'Publish your requirements and evaluation criteria' page
+    And I click 'Publish requirements'
 
   Then I don't see the 'Title' link
    And I don't see the 'Specialist role' link
@@ -87,8 +94,15 @@ Scenario: Create team to provide an outcome
     And I click 'Return to overview'
    Then 'Describe question and answer session' should be ticked
 
-    When I click 'Publish your requirements'
-     And I click 'Publish requirements'
+   When I click 'Preview your requirements'
+   Then I am on the 'Preview your requirements' page
+    And I see the 'Return to overview' link
+    And I see '0 SME, 0 large' text in the desktop preview panel
+    And I see 'Wednesday 9 September 2020' text in the desktop preview panel
+    And I see 'Cultural fit 5%' text in the desktop preview panel
+    And I click 'Confirm your requirements and publish'
+   Then I am on the 'Publish your requirements and evaluation criteria' page
+    And I click 'Publish requirements'
 
   Then I don't see the 'Title' link
    And I don't see the 'Location' link
@@ -126,8 +140,15 @@ Scenario: Create user research participants
     And I click 'Return to overview'
    Then 'Describe question and answer session' should be ticked
 
-  Then I click 'Publish your requirements'
-   And I click 'Publish requirements'
+   When I click 'Preview your requirements'
+   Then I am on the 'Preview your requirements' page
+    And I see the 'Return to overview' link
+    And I see 'Deadline for asking questions' text in the desktop preview panel
+    And I see 'View question and answer session details' text in the desktop preview panel
+    And I see 'Price 80%' text in the desktop preview panel
+    And I click 'Confirm your requirements and publish'
+   Then I am on the 'Publish your requirements and evaluation criteria' page
+    And I click 'Publish requirements'
 
   Then I don't see the 'Title' link
    And I don't see the 'Location' link

--- a/features/step_definitions/requirements_steps.rb
+++ b/features/step_definitions/requirements_steps.rb
@@ -98,3 +98,9 @@ When "I answer all summary questions" do
        | field | value |
   }
 end
+
+Then "I see '$expected_text' text in the desktop preview panel" do |expected_text|
+  within_frame(0) do
+    expect(page).to have_content expected_text
+  end
+end


### PR DESCRIPTION
https://trello.com/c/LjBLJMHt/175-take-feature-flag-off-dos-preview-and-include-in-functional-test

We want to follow the expected user journey of 
- clicking the 'Preview your requirements' link on the overview
- landing on the Preview page
- checking some content
- clicking the confirm button
- landing on the Publish page

I've left the Mobile frame out of the journey for now - if people feel strongly I can add it in.

Also includes a fix for our `make lint` command, which should be using `rubocop` in line with our Travis checks, and installing the test packages beforehand.

In terms of deploying, we've already split the files into two, for local/preview and for staging. Merging this PR should still pass on all stages. Once https://github.com/alphagov/digitalmarketplace-briefs-frontend/pull/253 is reviewed and deployed, we'll need to combine the files back into one `requirements.feature`.