### PR TITLE
177-3-update-breadcrumbs-to-use-govuk-frontend-component-in-buyer-frontend

### DIFF
--- a/features/smoulder-tests/buyer/catalogue.feature
+++ b/features/smoulder-tests/buyer/catalogue.feature
@@ -7,7 +7,6 @@ Scenario: User can select a lot from the g-cloud page and see search results.
   When I choose that lot.name radio button
   And I click 'Search for services'
   Then I am on the 'Search results' page
-  And I see that lot.name breadcrumb
   And I see a search result
 
 Scenario: User is able to search by service id and have result returned.

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -262,11 +262,6 @@ Then /^I see a validation message containing '(.*)'$/ do |message|
   expect(validation_message).to have_content(message)
 end
 
-Then /^I see #{MAYBE_VAR} breadcrumb$/ do |breadcrumb_text|
-  breadcrumb = page.all(:xpath, "//div[@id='global-breadcrumb']/nav//li").last
-  expect(breadcrumb.text).to eq(breadcrumb_text)
-end
-
 Then /^I (don't |)see (?:the|a) '(.*)' (button|link)$/ do |negative, selector_text, selector_type|
   expect(page).to have_selector(:link_or_button, selector_text) if negative.empty?
   expect(page).not_to have_selector(:link_or_button, selector_text) unless negative.empty?


### PR DESCRIPTION
* Remove breadcrumb check from functional tests
  * These should be done in unit tests


See https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/965