### PR TITLE
BUGFIX-skip-supplier-creation-for-now

### DIFF
--- a/features/supplier/supplier_creation.feature
+++ b/features/supplier/supplier_creation.feature
@@ -1,4 +1,4 @@
-@supplier @supplier-creation
+@supplier @supplier-creation @skip-preview
 Feature: Create new supplier account
 
 Background:


### PR DESCRIPTION
Skip buyer creation tests on preview while a workaround for the duns flow is found