### PR TITLE
Remove user research banner tests from preview

### DIFF
--- a/features/user/user_research.feature
+++ b/features/user/user_research.feature
@@ -1,4 +1,4 @@
-@user @user-research
+@user @user-research @skip-preview
 Feature: User Research
 Background:
 


### PR DESCRIPTION
We are starting to replace the user research banner with a permanent
phase banner that includes information about user research; see
https://trello.com/c/KvRAxFQ9.

This means we no longer need the functional tests to run on preview.