### PR TITLE
Update tests for changes to header and footer in apps

### DIFF
--- a/features/public/public_opportunity.feature
+++ b/features/public/public_opportunity.feature
@@ -6,7 +6,7 @@ Scenario: Public views the publish requirements. Details presented matches what 
   And I have a buyer user
   And that buyer is logged in
   And I have a live digital-specialists brief
-  And I click the 'Log out' button
+  And I click 'Log out'
 
   When I go to that brief page
   Then I see the details of the brief match what was published

--- a/features/smoke-tests/homepage.feature
+++ b/features/smoke-tests/homepage.feature
@@ -1,6 +1,8 @@
 @smoke-tests @homepage
 Feature: Check appropriate links on homepage
 
+@skip-local
+@skip-preview
 Scenario: User can see the main links on the homepage
   Given I visit the homepage
   Then I see the 'Find cloud hosting, software and support' link
@@ -12,3 +14,17 @@ Scenario: User can see the main links on the homepage
   And I see the 'View Digital Outcomes and Specialists opportunities' link
   And I see the 'Become a supplier' link
   And I see the 'G-Cloud supplier A–Z' link
+
+@skip-staging
+@skip-production
+Scenario: User can see the main links on the homepage
+  Given I visit the homepage
+  Then I see the 'Find cloud hosting, software and support' link
+  And I see the 'Buy physical datacentre space' link
+  And I see the 'Find an individual specialist' link
+  And I see the 'Find a team to provide an outcome' link
+  And I see the 'Find user research participants' link
+  And I see the 'Find a user research lab' link
+  And I see the 'View Digital Outcomes and Specialists opportunities' link
+  And I see the 'Become a supplier' link
+  And I see the 'G-Cloud supplier A to Z' link

--- a/features/smoulder-tests/public/supplieraz.feature
+++ b/features/smoulder-tests/public/supplieraz.feature
@@ -1,9 +1,18 @@
 @smoulder-tests
 Feature: Passive supplier a-z browsing journey
 
+@skip-local
+@skip-preview
 Scenario: User can click through to opportunities page
   Given I visit the homepage
   When I click 'G-Cloud supplier A–Z'
+  Then I am on the 'Suppliers starting with A' page
+
+@skip-staging
+@skip-production
+Scenario: User can click through to opportunities page
+  Given I visit the homepage
+  When I click 'G-Cloud supplier A to Z'
   Then I am on the 'Suppliers starting with A' page
 
 Scenario: User can click through to suppliers beginning with a specific letter


### PR DESCRIPTION
We've recently merged [changes that remov govuk_template from the buyer frontend and replaced the header and footer with new components](https://github.com/alphagov/digitalmarketplace-govuk-frontend#55).

This has broken a few tests, as the new header uses a link instead of a form for the 'Log out' button, and [the footer refers to 'G-Cloud supplier A to Z' instead of 'A-Z'](https://trello.com/c/i4eJBbNC/274-replace-content-supplier-a-z-with-supplier-a-to-z).