### PR TITLE
Fix steps that were looking for a h2 on a page

### DIFF
--- a/features/admin/acknowledge_service_edits.feature
+++ b/features/admin/acknowledge_service_edits.feature
@@ -16,7 +16,7 @@ Scenario: Admin approves service edits
   And I see that service.supplierName in the 'Edited services' summary table
   When I click the summary table 'View changes' link for that service.id
   Then I am on that service.serviceName page
-  And I see 'functional.test@example.com made 1 edit' in the page's main
+  And I see 'functional.test@example.com made 1 edit' text on the page
   And I see that random_sentence in the page's ins
 
   # Before we approve the edit we're going to test a race condition of the supplier re-editing the service
@@ -33,7 +33,7 @@ Scenario: Admin approves service edits
   And I see that service.supplierName in the 'Edited services' summary table
   When I click the summary table 'View changes' link for that service.id
   Then I am on that service.serviceName page
-  And I see 'functional.test@example.com made 1 edit' in the page's main
+  And I see 'functional.test@example.com made 1 edit' text on the page
   # This is the second random_sentence now of course
   And I see that random_sentence in the page's ins
 

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -280,7 +280,7 @@ Then /^I am at the (\/.*) url$/ do |page_url|
 end
 
 Then /^I see #{MAYBE_VAR} in the page's (.*)$/ do |page_name_fragment, selector|
-  expect(find(selector).text).to include(normalize_whitespace(page_name_fragment))
+  expect(page.find('main').find(selector).text).to include(normalize_whitespace(page_name_fragment))
 end
 
 Then(/^I see the page's h1 ends in #{MAYBE_VAR}$/) do |term|


### PR DESCRIPTION
We had an issue where the presence of the cookie banner was causing an ambiguous match for scenarios looking for a h2 on the page, because the cookie banner includes a h2.

This commit changes the step that looks for things on the page to look within the main element only, which excludes the cookie banner.

---

I'm currently testing this change locally, running against preview.