### PR TITLE
Skip antivirus-api tests

### DIFF
--- a/features/smoulder-tests/antivirus/antivirus.feature
+++ b/features/smoulder-tests/antivirus/antivirus.feature
@@ -1,3 +1,4 @@
+@skip-preview @skip-staging @skip-production
 Feature: Antivirus scanning
 
 @smoulder-tests @antivirus @notify @file-upload @requires-aws-credentials @skip-local


### PR DESCRIPTION
Ticket: https://trello.com/c/WnQGJGBi/1423-av-api-smoulder-tests-failing

Our antivirus-api has stopped reporting EICAR files as viruses (hopefully temporarily). Until this has been fixed lets skip this test.