### PR TITLE
supplier creation: adapt to summary tables being converted to summary lists

### DIFF
--- a/features/supplier/supplier_creation.feature
+++ b/features/supplier/supplier_creation.feature
@@ -4,7 +4,111 @@ Feature: User steps through supplier account creation process
 Background:
   Given There is at least one framework that can be applied to
 
-Scenario: Create new supplier account (without duns flow)
+@skip-staging
+Scenario: Create new supplier account (without duns flow) - summary lists
+  Given I visit the homepage
+  When I click 'Become a supplier'
+  Then I am on the 'Become a supplier' page
+
+  When I click 'Create a supplier account'
+  Then I am on the 'Create a supplier account' page
+
+  When I click 'Start'
+  Then I am on the 'Enter your DUNS number' page
+
+  When I enter '999999999' in the 'duns_number' field
+  And I click 'Continue'
+  Then I am on the 'Your company details' page
+
+  When I enter 'This is a test company name' in the 'company_name' field
+  And I enter 'Company contact name' in the 'contact_name' field
+  And I enter 'murphy.and.company@example.com' in the 'email_address' field
+  And I enter '0123456789' in the 'phone_number' field
+  And I click 'Continue'
+  Then I am on the 'Create login' page
+
+  When I enter 'murphy@example.com' in the 'email_address' field
+  And I click 'Continue'
+  Then I am on the 'Check your information' page
+  And I see the 'Your company details' summary list filled with:
+    | field                  | value                          |
+    | DUNS number            | 999999999                      |
+    | Company name           | This is a test company name    |
+    | Contact name           | Company contact name           |
+    | Contact email          | murphy.and.company@example.com |
+    | Contact phone number   | 0123456789                  |
+  And I see the 'Your login details' summary list filled with:
+    | field                  | value              |
+    | Email address          | murphy@example.com |
+
+  When I update the value of 'DUNS number' to '999999998' using the summary list 'Change' link and the 'Continue' button
+  And I update the value of 'Company name' to 'Changed test company name' using the summary list 'Change' link and the 'Continue' button
+  And I update the value of 'Contact name' to 'Changed contact name' using the summary list 'Change' link and the 'Continue' button
+  And I update the value of 'Contact email' to 'murphy.solo.enterprises@example.com' using the summary list 'Change' link and the 'Continue' button
+  And I update the value of 'Contact phone number' to '9876543210' using the summary list 'Change' link and the 'Continue' button
+  Then I see the 'Your company details' summary list filled with:
+    | field                  | value                               |
+    | DUNS number            | 999999998                           |
+    | Company name           | Changed test company name           |
+    | Contact name           | Changed contact name                |
+    | Contact email          | murphy.solo.enterprises@example.com |
+    | Contact phone number   | 9876543210                          |
+
+  When I click the summary list 'Change' link for 'Email address'
+  And I enter 'd.b.murphy@example.com' in the 'Your email address' field and click its associated 'Continue' button
+  Then I see the 'Your login details' summary list filled with:
+    | field                  | value                   |
+    | Email address          | d.b.murphy@example.com  |
+
+  # We can't ever click the "Create account" button to check the final page because this will create a supplier entry
+  # with DUNS number 000000001 and the test will never pass again.
+
+@skip-staging
+Scenario: Create new supplier account (with duns flow) - summary lists
+  Given I visit the homepage
+  When I click 'Become a supplier'
+  And I click 'Create a supplier account'
+  And I click 'Start'
+  Then I am on the 'Enter your DUNS number' page
+
+  When I enter '288305220' in the 'duns_number' field
+  And I click 'Continue'
+  Then I am on the 'We found these details' page
+  And I see the 'We found these details' summary list filled with:
+    | field                  | value                          |
+    | DUNS number            | 288305220                      |
+    | Company name           | SAVE THE CHILDREN FUND         |
+
+  When I choose the 'Yes' radio button for the 'Is this the company you want to create an account for?' question
+  And I click 'Continue'
+  Then I am on the 'Your company details' page
+  And I see the 'Company name' field prefilled with 'SAVE THE CHILDREN FUND'
+
+  When I enter 'Company contact name' in the 'contact_name' field
+  And I enter 'murphy.and.company@example.com' in the 'email_address' field
+  And I enter '0123456789' in the 'phone_number' field
+  And I click 'Continue'
+  Then I am on the 'Create login' page
+
+  When I enter 'murphy@example.com' in the 'email_address' field
+  And I click 'Continue'
+  Then I am on the 'Check your information' page
+  And I see the 'Your company details' summary list filled with:
+    | field                  | value                          |
+    | DUNS number            | 288305220                      |
+    | Company name           | SAVE THE CHILDREN FUND         |
+    | Contact name           | Company contact name           |
+    | Contact email          | murphy.and.company@example.com |
+    | Contact phone number   | 0123456789                     |
+  And I see the 'Your login details' summary list filled with:
+    | field                  | value              |
+    | Email address          | murphy@example.com |
+
+  # We can't ever click the "Create account" button to check the final page because this will create a supplier entry
+  # with DUNS number 288305220 and the test will never pass again.
+
+@skip-preview
+Scenario: Create new supplier account (without duns flow) - summary tables
   Given I visit the homepage
   When I click 'Become a supplier'
   Then I am on the 'Become a supplier' page
@@ -62,7 +166,8 @@ Scenario: Create new supplier account (without duns flow)
   # We can't ever click the "Create account" button to check the final page because this will create a supplier entry
   # with DUNS number 000000001 and the test will never pass again.
 
-Scenario: Create new supplier account (with duns flow)
+@skip-preview
+Scenario: Create new supplier account (with duns flow) - summary tables
   Given I visit the homepage
   When I click 'Become a supplier'
   And I click 'Create a supplier account'

--- a/features/support/helpers.rb
+++ b/features/support/helpers.rb
@@ -223,7 +223,7 @@ def escape_xpath(string)
 end
 
 def get_table_rows_by_caption(caption)
-  result_table_xpath = "//caption[@class='visually-hidden'][normalize-space(text())=\"#{caption}\"]/parent::table"
+  result_table_xpath = "//caption[@class='visually-hidden'][normalize-space(string())=#{escape_xpath(caption)}]/parent::table"
   rows_xpath = "/tbody/tr[@class='summary-item-row']"
   result_table_rows_xpath = result_table_xpath + rows_xpath
   page.all(:xpath, result_table_rows_xpath)

--- a/features/support/helpers.rb
+++ b/features/support/helpers.rb
@@ -228,3 +228,11 @@ def get_table_rows_by_caption(caption)
   result_table_rows_xpath = result_table_xpath + rows_xpath
   page.all(:xpath, result_table_rows_xpath)
 end
+
+def get_summary_list_rows_by_preceding_heading(heading)
+  # do we even h5?
+  heading_xpath = "//*[self::h1 or self::h2 or self::h3 or self::h4][normalize-space(string())=normalize-space(#{escape_xpath(heading)})]"
+  dl_rows_xpath = "/following-sibling::*[position()=1][self::dl]/*"
+
+  page.all(:xpath, heading_xpath + dl_rows_xpath)
+end

--- a/gemset.nix
+++ b/gemset.nix
@@ -448,14 +448,14 @@
     version = "4.0.1";
   };
   rack = {
-    groups = ["default"];
+    groups = ["default" "test"];
     platforms = [];
     source = {
       remotes = ["https://rubygems.org"];
-      sha256 = "0z90vflxbgjy2n84r7mbyax3i2vyvvrxxrf86ljzn5rw65jgnn2i";
+      sha256 = "1id0jsslx1ipv0pbqjfn7mjbb2vx2xybk7qypq59a17163xp30gr";
       type = "gem";
     };
-    version = "2.0.7";
+    version = "2.0.8";
   };
   rack-test = {
     dependencies = ["rack"];


### PR DESCRIPTION
For the breakage introduced by https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/1186

The approach I took here is to make all of the necessary steps targeting "summary tables" able to target "summary lists" too. Managed to avoid having to rely on any class names, even though the equivalent of a `<tr>` is now a `<div>`.

~TODO before merge: appropriate `@skip-` tags.~