### PR TITLE
Fix typo in clarification question submit button

### DIFF
--- a/features/supplier/supplier_asks_a_framework_question.feature
+++ b/features/supplier/supplier_asks_a_framework_question.feature
@@ -18,7 +18,7 @@ Scenario: Supplier asks a clarification question
   And I see 'You can ask clarification questions until' text on the page
   And I see 'Answers are published to this page around twice a week' text on the page
   When I enter a random value in the 'clarification_question' field
-  And I click the 'Ask question' button
+  And I click the 'Ask a question' button
   Then I receive a clarification question email regarding that question for 'clarification-questions@example.gov.uk'
   And I receive a clarification question confirmation email regarding that question for that supplier_user.emailAddress
   And I don't receive a follow-up question email regarding that question for 'follow-up@example.gov.uk'


### PR DESCRIPTION
https://trello.com/c/6i2MB9zG/1482-fix-g12-functional-test

The scenario for asking a clarification question failed, as the wording on the submit button was slightly mismatched.

This doesn't need a skip-staging tag yet, as framework applications are only open on Preview. 