### PR TITLE
Wait for document.readyState on search-related smoke tests on Preview

### DIFF
--- a/features/smoke-tests/buyer/catalogue.feature
+++ b/features/smoke-tests/buyer/catalogue.feature
@@ -9,7 +9,6 @@ Scenario: User can click through to g-cloud page
   When I click 'Start a new search'
   Then I am on the 'Choose a category' page
 
-@skip-preview
 Scenario: User is able to navigate to service detail page via selecting the service from the search results
   Given I visit the /g-cloud/search page
   Then I am on the 'Search results' page

--- a/features/smoke-tests/buyer/catalogue.feature
+++ b/features/smoke-tests/buyer/catalogue.feature
@@ -9,9 +9,19 @@ Scenario: User can click through to g-cloud page
   When I click 'Start a new search'
   Then I am on the 'Choose a category' page
 
+@skip-preview
 Scenario: User is able to navigate to service detail page via selecting the service from the search results
   Given I visit the /g-cloud/search page
   Then I am on the 'Search results' page
+  When I click a random result in the list of service results returned
+  Then I am on that result.title page
+  And I see that result.supplier_name as the page header context
+
+@skip-staging @skip-production
+Scenario: User is able to navigate to service detail page via selecting the service from the search results
+  Given I visit the /g-cloud/search page
+  Then I am on the 'Search results' page
+  And I wait for the page to load
   When I click a random result in the list of service results returned
   Then I am on that result.title page
   And I see that result.supplier_name as the page header context

--- a/features/smoke-tests/supplier/opportunities.feature
+++ b/features/smoke-tests/supplier/opportunities.feature
@@ -7,7 +7,6 @@ Scenario: User can click through to opportunities page
   Then I am on the 'Digital Outcomes and Specialists opportunities' page
   And I see an opportunity in the search results
 
-@skip-preview
 Scenario: User is able to navigate to opportunity detail page via selecting the opportunity from the search results
   Given I visit the /digital-outcomes-and-specialists/opportunities page
   When I click a random result in the list of opportunity results returned

--- a/features/smoke-tests/supplier/opportunities.feature
+++ b/features/smoke-tests/supplier/opportunities.feature
@@ -7,8 +7,16 @@ Scenario: User can click through to opportunities page
   Then I am on the 'Digital Outcomes and Specialists opportunities' page
   And I see an opportunity in the search results
 
+@skip-preview
 Scenario: User is able to navigate to opportunity detail page via selecting the opportunity from the search results
   Given I visit the /digital-outcomes-and-specialists/opportunities page
+  When I click a random result in the list of opportunity results returned
+  Then I am on that result.title page
+
+@skip-staging @skip-production
+Scenario: User is able to navigate to opportunity detail page via selecting the opportunity from the search results
+  Given I visit the /digital-outcomes-and-specialists/opportunities page
+  And I wait for the page to load
   When I click a random result in the list of opportunity results returned
   Then I am on that result.title page
 

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -484,6 +484,12 @@ And /^I wait for the page to reload/ do
   end
 end
 
+And /^I wait for the page to load/ do
+  Timeout.timeout(dm_custom_wait_time) do
+    loop until page.evaluate_script('document.readyState') === 'complete'
+  end
+end
+
 Then(/^I should get an? (download|inline) file(?: with file.?name ending(?: in)? '(.*?)')?(?: (?:and|with) content.?type(?: of)? '(.*?)')?( in a new window)?$/) do |download_inline, ending, content_type, maybe_new_window|
   if maybe_new_window
     # beware - not all drivers *necessarily* keep the windows list in a defined order


### PR DESCRIPTION
https://trello.com/c/xD6lS5Io/376-stop-smoke-tests-going-off-for-obsoletenode-error

**Observation**: search result pages for G-Cloud and DOS seem more susceptible to ObsoleteNode errors than other pages (looking at recent smoke, smoulder and functional test failures). 

**Hypothesis**: explicitly checking whether a search result page has finished loading before attempting to click will reduce the likelihood of Capybara being unable to find a link element. 

What I've tried:
- Insert a new step 'wait for the page to load' on scenarios where we're clicking directly on search results (i.e. not after using filters/live search - we already have a separate async handler for waiting for Ajax requests to finish)
- The page checks for the `document.readyState` property to be 'complete' (see https://developer.mozilla.org/en-US/docs/Web/API/Document/readyState). Even though we're not waiting for Ajax requests, these pages are slow to load (see analytics info on the ticket). 
- The step will wait until the maximum `dm_custom_wait_time` (currently 5s) before giving up
- Only applied to the two Preview smoke test scenarios at present - we can experiment by merging several apps at once (a known trigger for ObsoleteNode errors) and see we have fewer failures.