### PR TITLE
Wait for page load on non-AJAX search result pages

### DIFF
--- a/features/smoke-tests/buyer/catalogue.feature
+++ b/features/smoke-tests/buyer/catalogue.feature
@@ -12,14 +12,6 @@ Scenario: User can click through to g-cloud page
 Scenario: User is able to navigate to service detail page via selecting the service from the search results
   Given I visit the /g-cloud/search page
   Then I am on the 'Search results' page
-  When I click a random result in the list of service results returned
-  Then I am on that result.title page
-  And I see that result.supplier_name as the page header context
-
-@skip-staging @skip-production
-Scenario: User is able to navigate to service detail page via selecting the service from the search results
-  Given I visit the /g-cloud/search page
-  Then I am on the 'Search results' page
   And I wait for the page to load
   When I click a random result in the list of service results returned
   Then I am on that result.title page

--- a/features/smoke-tests/supplier/opportunities.feature
+++ b/features/smoke-tests/supplier/opportunities.feature
@@ -9,12 +9,6 @@ Scenario: User can click through to opportunities page
 
 Scenario: User is able to navigate to opportunity detail page via selecting the opportunity from the search results
   Given I visit the /digital-outcomes-and-specialists/opportunities page
-  When I click a random result in the list of opportunity results returned
-  Then I am on that result.title page
-
-@skip-staging @skip-production
-Scenario: User is able to navigate to opportunity detail page via selecting the opportunity from the search results
-  Given I visit the /digital-outcomes-and-specialists/opportunities page
   And I wait for the page to load
   When I click a random result in the list of opportunity results returned
   Then I am on that result.title page

--- a/features/smoulder-tests/supplier/opportunities.feature
+++ b/features/smoulder-tests/supplier/opportunities.feature
@@ -73,6 +73,7 @@ Scenario Outline: User gets no results for impossible combinations of location a
   When I click 'Clear filters'
   And I wait for the page to reload
   And I click 'All categories'
+  And I wait for the page to load
   And I check '<location>' checkbox
   And I wait for the page to reload
   Then I don't see the '<lot>' link
@@ -121,6 +122,7 @@ Scenario Outline: User can filter by status, lot, location and keyword together
   And I see all the opportunities on the page are on the '<lot>' lot
   And I see all the opportunities on the page are in the '<location>' location
   When I click 'All categories'
+  And I wait for the page to load
   Then I see '<phrase>' in the search summary text
   And I see that the stated number of results is no fewer than that result_count
   And I note the result_count


### PR DESCRIPTION
https://trello.com/c/xD6lS5Io/376-stop-smoke-tests-going-off-for-obsoletenode-error

- Removes the `skip-staging` and `skip-production` tags for the additional step (that we've already run on Preview)
- Adds in the page load step on two additional smoulder test scenarios, that have also had recent ObsoleteNode errors, which are also relying on search result pages to have finished loading.