### PR TITLE
g-cloud search tests: incorporate testing of multi-valued filter selections being preserved across pages

### DIFF
--- a/features/smoulder-tests/buyer/catalogue.feature
+++ b/features/smoulder-tests/buyer/catalogue.feature
@@ -51,13 +51,20 @@ Scenario: User is able to paginate through search results and all of the navigat
   And I choose that lot.name radio button
   And I click 'Search for services'
   Then I am on the 'Search results' page
+  When I check the 'Developed Vetting (DV)' checkbox
+  And I check the 'Security Clearance (SC)' checkbox
+  And I wait for the page to reload
   And I note the number of category links
   And I click the Next Page link
   Then I am taken to page 2 of results
   And I see the same number of category links as noted
+  And I see the 'Developed Vetting (DV)' checkbox is checked
+  And I see the 'Security Clearance (SC)' checkbox is checked
   When I click the Previous Page link
   Then I am taken to page 1 of results
   And I see the same number of category links as noted
+  And I see the 'Developed Vetting (DV)' checkbox is checked
+  And I see the 'Security Clearance (SC)' checkbox is checked
 
 Scenario: User gets no results for an unfindable term
   Given I visit the /g-cloud/search page


### PR DESCRIPTION
https://trello.com/c/KaL0fCtR

Use security clearance filter as values are quite stable across frameworks and selecting only two of them should still give us a reliably large number of results.