### PR TITLE
Cross domain tracking / PII redaction scenarios

### DIFF
--- a/features/step_definitions/cookies_steps.rb
+++ b/features/step_definitions/cookies_steps.rb
@@ -1,0 +1,47 @@
+Then(/^I (see|do not see) a '_ga' tracking ID query parameter on the URL$/) do |can_see_ga|
+  current_url_uri = URI(current_url)
+  query_hash = Hash[URI::decode_www_form(current_url_uri.query || "")]
+  if can_see_ga == 'see'
+    expect(query_hash).to have_key('_ga')
+  elsif can_see_ga == 'do not see'
+    expect(query_hash).not_to have_key('_ga')
+  end
+end
+
+# Based on http://jbusser.github.io/2014/11/01/integration-testing-google-analytics-with-capybara-and-rspec.html
+
+def inline_http_requests
+  page.driver.network_traffic.map do |traffic|
+    # Return all HTTP requests made by Poltergeist
+    URI.parse traffic.url
+  end
+end
+
+def google_analytics_requests
+  inline_http_requests.select do |request|
+    # Return all requests matching this host
+    request.host == 'www.google-analytics.com'
+  end
+end
+
+def google_analytics_request_with_param(param)
+  google_analytics_requests.detect do |request|
+    # We're only interested in analytics requests with `/collect/` in the path
+    if request.path.match 'collect'
+      request.query.match param unless request.query.nil?
+    end
+  end
+end
+
+And(/^a tracking pageview (has been|has not been) fired( with a redacted email)?$/) do |has_tracking, redacted|
+  if has_tracking == 'has been'
+    if redacted
+      expect(google_analytics_request_with_param('[email]')).not_to be_nil
+    else
+      expect(google_analytics_requests).not_to be_empty
+    end
+  else
+    # Should be no requests sent to the GA domain
+    expect(google_analytics_requests).to be_empty
+  end
+end

--- a/features/step_definitions/cookies_steps.rb
+++ b/features/step_definitions/cookies_steps.rb
@@ -33,11 +33,11 @@ def google_analytics_request_with_param(param)
   end
 end
 
-And(/^a tracking pageview (has been|has not been) fired( with a redacted email)?$/) do |has_tracking, redacted|
+And(/^a tracking pageview (has been|has not been) fired(?: with (.+@.+) redacted)?$/) do |has_tracking, email|
   if has_tracking == 'has been'
-    if redacted
+    if email
       expect(google_analytics_request_with_param('[email]')).not_to be_nil
-      expect(google_analytics_request_with_param('joe@example.com')).to be_nil
+      expect(google_analytics_request_with_param(email)).to be_nil
     else
       expect(google_analytics_requests).not_to be_empty
     end

--- a/features/step_definitions/cookies_steps.rb
+++ b/features/step_definitions/cookies_steps.rb
@@ -37,6 +37,7 @@ And(/^a tracking pageview (has been|has not been) fired( with a redacted email)?
   if has_tracking == 'has been'
     if redacted
       expect(google_analytics_request_with_param('[email]')).not_to be_nil
+      expect(google_analytics_request_with_param('joe@example.com')).to be_nil
     else
       expect(google_analytics_requests).not_to be_empty
     end

--- a/features/user/change_cookie_settings.feature
+++ b/features/user/change_cookie_settings.feature
@@ -52,7 +52,7 @@ Scenario: User does a search and PII is redacted from analytics
   Then I see 'Can we store analytics cookies on your device?' text on the page
   And I click 'Yes' button
   When I visit the /g-cloud/search?q=joe@example.com page
-  Then a tracking pageview has been fired with a redacted email
+  Then a tracking pageview has been fired with joe@example.com redacted
 
 Scenario: User rejects analytics and navigates between DMP and Gov.uk
   Given I visit the homepage

--- a/features/user/change_cookie_settings.feature
+++ b/features/user/change_cookie_settings.feature
@@ -38,3 +38,33 @@ Scenario: User sees an error message if they submit an empty form
   And I click the 'Save cookie settings' button
   Then I see 'There was a problem saving your settings' text on the page
   And I don't see 'Your cookie settings were saved' text on the page
+
+Scenario: User accepts analytics and navigates between DMP and Gov.uk
+  Given I visit the homepage
+  Then I see 'Can we store analytics cookies on your device?' text on the page
+  And I click 'Yes' button
+  When I click the 'About Government Digital Services' link
+  Then I see a '_ga' tracking ID query parameter on the URL
+  And a tracking pageview has been fired
+
+Scenario: User does a search and PII is redacted from analytics
+  Given I visit the homepage
+  Then I see 'Can we store analytics cookies on your device?' text on the page
+  And I click 'Yes' button
+  When I visit the /g-cloud/search?q=joe@example.com page
+  Then a tracking pageview has been fired with a redacted email
+
+Scenario: User rejects analytics and navigates between DMP and Gov.uk
+  Given I visit the homepage
+  Then I see 'Can we store analytics cookies on your device?' text on the page
+  And I click 'No' button
+  When I visit the homepage
+  And I click the 'About Government Digital Services' link
+  Then I do not see a '_ga' tracking ID query parameter on the URL
+  And a tracking pageview has not been fired
+
+Scenario: User does not set analytics and navigates between DMP and Gov.uk
+  Given I visit the homepage
+  When I click the 'About Government Digital Services' link
+  Then I do not see a '_ga' tracking ID query parameter on the URL
+  And a tracking pageview has not been fired


### PR DESCRIPTION
https://trello.com/c/hRRSka2u/5-re-enable-cross-domain-tracking-3

Two main things happening here:
- inspecting the URL query parameter when travelling from Digital Marketplace to GOV.UK (if analytics is enabled, a `?_ga=...` parameter will be appended)
- inspecting the requests sent to www.google-analytics.com (if analytics is enabled, any PII data such as emails should be redacted; if analytics is disabled or not set, nothing should be sent at all).

Co-authored with @phantas 🏆 