### PR TITLE
Update steps for changes to buyer frontend content

### DIFF
--- a/features/buyer/tell_us_about_contract.feature
+++ b/features/buyer/tell_us_about_contract.feature
@@ -78,7 +78,7 @@ Scenario: User exports results
   And I see the 'Save a search' instruction list item status showing as 'Completed'
   When I click the 'Export your results' link
   Then I am on the 'Before you export your results' page
-  When I check 'I understand that I cannot edit my search after I export my results' checkbox
+  When I check I understand that I cannot edit my search after I export my results checkbox
   And I click the 'Export results and continue' button
   Then I am on the 'Download your results' page
   And I see a success banner message containing 'Results exported. Your files are ready to download.'

--- a/features/buyer/tell_us_about_contract.feature
+++ b/features/buyer/tell_us_about_contract.feature
@@ -78,7 +78,7 @@ Scenario: User exports results
   And I see the 'Save a search' instruction list item status showing as 'Completed'
   When I click the 'Export your results' link
   Then I am on the 'Before you export your results' page
-  When I check 'I understand that I cannot edit my search again after I export my results' checkbox
+  When I check 'I understand that I cannot edit my search after I export my results' checkbox
   And I click the 'Export results and continue' button
   Then I am on the 'Download your results' page
   And I see a success banner message containing 'Results exported. Your files are ready to download.'

--- a/features/step_definitions/direct_award_steps.rb
+++ b/features/step_definitions/direct_award_steps.rb
@@ -28,7 +28,7 @@ When (/^I have exported my results for the '(.*)' saved search$/) do |search_nam
     Given I visit the /buyers/direct-award/g-cloud page
     And I click the '#{search_name}' link
     And I click the 'Export your results' link
-    And I check 'I understand that I cannot edit my search again after I export my results' checkbox
+    And I check 'I understand that I cannot edit my search after I export my results' checkbox
     And I click the 'Export results and continue' button
     Then I see a success banner message containing 'Results exported. Your files are ready to download.'
   }

--- a/features/step_definitions/direct_award_steps.rb
+++ b/features/step_definitions/direct_award_steps.rb
@@ -28,7 +28,7 @@ When (/^I have exported my results for the '(.*)' saved search$/) do |search_nam
     Given I visit the /buyers/direct-award/g-cloud page
     And I click the '#{search_name}' link
     And I click the 'Export your results' link
-    And I check 'I understand that I cannot edit my search after I export my results' checkbox
+    And I check I understand that I cannot edit my search after I export my results checkbox
     And I click the 'Export results and continue' button
     Then I see a success banner message containing 'Results exported. Your files are ready to download.'
   }
@@ -83,6 +83,12 @@ When (/^I have downloaded the search results as a file of type '(.*)'$/) do |fil
     puts "The file type '#{file_type}' is not recognised"
   end
   steps "And I should get a download file with filename ending '.#{file_type}'"
+end
+
+# Override to support different versions of content on preview and staging
+# TODO remove once alphagov/digitalmarketplace-buyer-frontend#1030 has been released
+And "I check I understand that I cannot edit my search after I export my results checkbox" do
+  check_checkbox('user_understands')
 end
 
 And (/^I see the '(.*)' instruction list item status showing as '(.*)'$/) do |list_item, status|


### PR DESCRIPTION
https://trello.com/c/v6elozgK/25-2-high-level-content-review-of-pages-in-search-for-g-cloud-services-journey

Fixes tests to pass against alphagov/digitalmarketplace-buyer-frontend#1030

To make releasing easier I've added a second commit that can be reverted once alphagov/digitalmarketplace-buyer-frontend#1030 has been released.

We want the tests to pass on both preview and staging with slightly different content for the checkbox 'I understand that I cannot edit my search results( again)? after I export my results'. Normally to do this we would have two versions of the test, one with the new content and one with the old content, and add appropriate tags for each stage.

Unfortunately this particular step is part of another multi-step step definition, which makes that process a bit harder. Instead I've added a new step that targets the specific checkbox using the form input name (which hasn't changed).

It's a bit of a hack, but hopefully it won't be in our code for long!