### PR TITLE
update phantomjs install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ gem install bundler
 make install
 ```
 
-You may have to install `phantomjs` separately:
+You will have to install `phantomjs` separately:
 
 ```bash
-brew install phantomjs
+brew cask install phantomjs
 ```
 
 ## Running tests


### PR DESCRIPTION
update phantomjs install command as per note from brew:
```
$ brew install phantomjs
Updating Homebrew...
Error: No available formula with the name "phantomjs" 
It was migrated from homebrew/core to homebrew/cask.
You can access it again by running:
  brew tap homebrew/cask
And then you can install it by running:
  brew cask install phantomjs
```