### PR TITLE
Pricing validation supports old and new CSS classes

### DIFF
--- a/features/support/form_helpers.rb
+++ b/features/support/form_helpers.rb
@@ -249,7 +249,9 @@ module FormHelper
 
   def pass_pricing_validation
     options = {}
-    pricing_questions = find_elements_by_xpath("//input[@class='text-box pricing-input-with-unit']")
+    pricing_questions = find_elements_by_xpath(
+      "//input[contains(@class, 'dmp-price-input__input') or contains(@class, 'pricing-input-with-unit')]"
+    )
     pricing_questions.each do |question|
       options[question["name"]] = "500"
     end


### PR DESCRIPTION
https://trello.com/c/yld9eBvJ/6-3-rebuild-pricing-form-template-using-govuk-design-system-components-in-supplier-frontend

We're about to replace the pricing form with new components (see https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/1222), so this PR changes the pricing validation `xpath` function to look for either the old class `pricing-input-with-unit`, or the new `dmp-price-input__input` class.

Tested locally against an open framework, and both `master` and the pricing form branch on Supplier FE.
