### PR TITLE
Upgrade dependencies to address activesupport vulnerability

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.0.3)
+    activesupport (6.0.3.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -11,8 +11,8 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.0)
     aws-eventstream (1.1.0)
-    aws-partitions (1.314.0)
-    aws-sdk-core (3.95.0)
+    aws-partitions (1.319.0)
+    aws-sdk-core (3.96.1)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
       aws-sigv4 (~> 1.1)
@@ -78,7 +78,7 @@ GEM
     mime-types-data (3.2020.0512)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)
-    minitest (5.14.0)
+    minitest (5.14.1)
     multi_json (1.14.1)
     multi_test (0.1.2)
     netrc (0.11.0)


### PR DESCRIPTION
https://snyk.io/vuln/SNYK-RUBY-ACTIVESUPPORT-569598

Snyk alerted us to a vulnerability in `activesupport` via https://github.com/alphagov/digitalmarketplace-functional-tests/pull/762. 

As per README instructions, run `bundle update` to fetch the new version into `Gemfile.lock`. 