### PR TITLE
fix bundler deprecation warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,9 @@ setup: install config clean
 	mkdir -p reports/
 
 install:
-	bundle install --path .bundle --without development
+	bundle config set path '.bundle';\
+	bundle config set without 'development';\
+	bundle install
 
 .PHONY: config
 config:


### PR DESCRIPTION
https://trello.com/c/VvUcGjXh/124-deprecation-warnings-on-functional-test-runs
Fixes deprecation warning:
```
$ make run
bundle install --path .bundle --without development
[DEPRECATED] The `--path` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set path '.bundle'`, and stop using this flag
[DEPRECATED] The `--without` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set without 'development'`, and stop using this flag
```