### PR TITLE
Revert "add skip annotations for updated tests"

### DIFF
--- a/features/buyer/buyer_clarification.feature
+++ b/features/buyer/buyer_clarification.feature
@@ -1,4 +1,4 @@
-@buyer @buyer-clarification @skip-staging @skip-production
+@buyer @buyer-clarification
 Feature: Buyer publishes question and answer
 
 Scenario: Buyer publishes answers to clarification questions on a brief which the public can see

--- a/features/public/public_opportunity.feature
+++ b/features/public/public_opportunity.feature
@@ -1,4 +1,4 @@
-@public-opportunity-view @skip-staging
+@public-opportunity-view
 Feature: Published requirements can be viewed by the public
 
 Scenario: Public views the publish requirements. Details presented matches what was published.


### PR DESCRIPTION
We can remove these now these changes have been deployed.
This reverts commit ceb0cd7aab616140c09ea89276f3ad9e5c69da06.