### PR TITLE
Fix functional tests for GOV.UK Design System flash messages in user frontend

### DIFF
--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -243,6 +243,11 @@ When(/^I choose a random sentence$/) do
   puts "sentence: #{@random_sentence}"
 end
 
+Then /^I see a (success|error|notice) flash message containing #{MAYBE_VAR}$/ do |type, message|
+  flash_message = page.find(:css, ".dm-alert.dm-alert--#{type}", wait: false)
+  expect(flash_message).to have_content(message)
+end
+
 # the rescue is used because if a banner cannot be found the function throws an exception and does not look for the other option
 Then /^I see a (success|warning|destructive|temporary-message) banner message containing #{MAYBE_VAR}$/ do |status, message|
   begin

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -90,7 +90,7 @@ Then /^that user can not log in using their correct password$/ do
     When I enter that user.emailAddress in the 'Email address' field
     And I enter that user.emailAddress in the 'Password' field
     And I click the 'Log in' button
-    Then I see a destructive banner message containing 'Accounts are locked'
+    Then I see a error flash message containing 'Accounts are locked'
     And I don't see the 'Log out' button
   }
 end
@@ -113,7 +113,7 @@ Then /^that user is able to reset their password$/ do
 
     When I enter that user.emailAddress in the 'Email address' field
     And I click 'Send reset email' button
-    Then I see a success banner message containing 'send a link to reset the password'
+    Then I see a success flash message containing 'send a link to reset the password'
     And I receive a 'reset-password' email for that user.emailAddress
     And I click the link in that email
     Then I am on the 'Reset password' page
@@ -121,6 +121,6 @@ Then /^that user is able to reset their password$/ do
     And I enter that user.password in the 'Confirm new password' field
     And I click 'Reset password' button
     Then I am on the 'Log in to the Digital Marketplace' page
-    And I see a success banner message containing 'You have successfully changed your password.'
+    And I see a success flash message containing 'You have successfully changed your password.'
   }
 end

--- a/features/supplier/supplier_account.feature
+++ b/features/supplier/supplier_account.feature
@@ -167,6 +167,7 @@ Scenario: Supplier user can provide and change supplier details before confirmin
   And I see 'that supplier.dunsNumber' text on the page
 
 @requires-credentials @notify
+@skip-staging
 Scenario: Supplier user can add and remove contributors
   When I click 'Contributors'
   Then I am on the 'Invite or remove contributors' page

--- a/features/user/lock_account.feature
+++ b/features/user/lock_account.feature
@@ -1,6 +1,7 @@
 @user @lock-account
 Feature: Users are locked if they enter the wrong password too many times
 
+@skip-staging
 Scenario: User has 5 failed login attempts and is locked out of their account
   Given I have a supplier user
   When the wrong password is entered 5 times for that user

--- a/features/user/reset_password.feature
+++ b/features/user/reset_password.feature
@@ -1,6 +1,7 @@
 @user @reset-password @requires-credentials @notify
 Feature: Reset user password
 
+@skip-staging
 Scenario: User has forgotten their password and requests a password reset
   Given I have a buyer user
   When I visit the homepage
@@ -9,6 +10,7 @@ Scenario: User has forgotten their password and requests a password reset
 
   And that user is able to reset their password
 
+@skip-staging
 Scenario: Inactive user trying to reset password instead receives an informational message
   Given I have a buyer user with:
     | active | false |

--- a/features/user/reset_password.feature
+++ b/features/user/reset_password.feature
@@ -21,5 +21,5 @@ Scenario: Inactive user trying to reset password instead receives an information
 
   When I enter that user.emailAddress in the 'Email address' field
   And I click 'Send reset email' button
-  Then I see a success banner message containing 'send a link to reset the password'
+  Then I see a success flash message containing 'send a link to reset the password'
   And I receive a 'reset-password-inactive' email for that user.emailAddress


### PR DESCRIPTION
Ticket: https://trello.com/c/sxhsW20p/88-replace-flash-messages-with-alert-component-in-briefs-frontend

Needed for alphagov/digitalmarketplace-user-frontend#265.

---

I've run these locally against local and staging.