### PR TITLE
Update functional tests for Briefs FE flash messages update

### DIFF
--- a/features/buyer/award_flow_requirements.feature
+++ b/features/buyer/award_flow_requirements.feature
@@ -13,7 +13,6 @@ Background:
   When I click the 'Let suppliers know the outcome' link for that brief
   Then I am on the 'Have you awarded a contract for %s?' page with brief 'title'
 
-
 Scenario: Award flow - Award a requirement to a winning supplier
 
   Given I choose 'Yes' radio button
@@ -29,7 +28,7 @@ Scenario: Award flow - Award a requirement to a winning supplier
   And I enter '2020' in the 'input-awardedContractStartDate-year' field
   And I enter '20000.00' in the 'input-awardedContractValue' field
   And I click the 'submit' button
-  Then I see a success banner message containing 'updated'
+  Then I see a success flash message containing 'updated'
 
   When I go to that brief overview page
   Then I see the 'View suppliers who applied' link
@@ -49,7 +48,7 @@ Scenario: Award Flow - Cancel requirements
   When I choose 'Your requirements have been cancelled' radio button
   And I click the 'Update requirements' button
   Then I am on the '%s' page with brief 'title'
-  And I see a success banner message containing 'updated'
+  And I see a success flash message containing 'updated'
 
   When I go to that brief page
   Then I see a temporary-message banner message containing 'This opportunity was cancelled'
@@ -65,17 +64,16 @@ Scenario: Award flow - Mark requirements as unsuccessful
   When I choose 'There were no suitable suppliers' radio button
   And I click the 'Update requirements' button
   Then I am on the '%s' page with brief 'title'
-  And I see a success banner message containing 'updated'
+  And I see a success flash message containing 'updated'
 
   When I go to that brief page
   Then I see a temporary-message banner message containing 'No suitable suppliers applied'
   And I see a temporary-message banner message containing 'The buyer didn't award this contract because no suppliers met their '
   And I see a temporary-message banner message containing 'requirements. They may publish an updated version later.'
 
-
 Scenario: Award flow - Abort flow as still evaluating
 
   Given I choose 'We are still evaluating suppliers' radio button
   And I click the 'Save and continue' button
   Then I am on the 'Your requirements' page
-  And I see a success banner message containing 'updated'
+  And I see a success flash message containing 'updated'

--- a/features/buyer/cancel_requirements.feature
+++ b/features/buyer/cancel_requirements.feature
@@ -4,7 +4,6 @@ Feature: Cancel a requirement outside the award flow
   As a buyer within government
   I want to cancel my requirements after applications have closed, because I didn't go ahead with the procurement
 
-
 Scenario: Cancel requirements
   Given I am logged in as the buyer of a closed brief
 
@@ -22,7 +21,7 @@ Scenario: Cancel requirements
   And I click the 'Update requirements' button
   Then I see 'The contract was not awarded' text on the page
   And I see 'the requirements were cancelled.' text on the page
-  And I see a success banner message containing 'updated'
+  And I see a success flash message containing 'updated'
   And I see the 'View suppliers who applied' link
 
   When I go to that brief page
@@ -30,7 +29,6 @@ Scenario: Cancel requirements
   And I see a temporary-message banner message containing 'The buyer cancelled this opportunity,'
   And I see a temporary-message banner message containing 'for example because they no longer have the budget.'
   And I see a temporary-message banner message containing 'They may publish an updated version later.'
-
 
 Scenario: Cancel requirements where no suitable suppliers applied
   Given I am logged in as the buyer of a closed brief
@@ -49,7 +47,7 @@ Scenario: Cancel requirements where no suitable suppliers applied
   And I click the 'Update requirements' button
   Then I see 'The contract was not awarded' text on the page
   And I see 'no suitable suppliers applied.' text on the page
-  And I see a success banner message containing 'updated'
+  And I see a success flash message containing 'updated'
   And I see the 'View suppliers who applied' link
 
   When I go to that brief page

--- a/features/buyer/requirements.feature
+++ b/features/buyer/requirements.feature
@@ -193,7 +193,6 @@ Scenario Outline: View requirement in a dashboard
     | withdrawn | Closed requirements      |
     | draft     | Unpublished requirements |
 
-
 Scenario: Delete a draft requirement
   Given I am logged in as a buyer user
   And I have created an individual specialist requirement
@@ -201,8 +200,7 @@ Scenario: Delete a draft requirement
   When I click 'Delete'
   Then I see a destructive banner message containing 'Are you sure you want to delete these requirements?'
   When I click 'Yes, delete'
-  Then I see a success banner message containing 'were deleted'
-
+  Then I see a success flash message containing 'were deleted'
 
 Scenario: Withdraw live requirements
   Given I am logged in as the buyer of a live brief
@@ -216,7 +214,7 @@ Scenario: Withdraw live requirements
   And I click 'Withdraw requirements'
   Then I see a destructive banner message containing 'Are you sure you want to withdraw these requirements?'
   When I click 'Withdraw requirements'
-  Then I see a success banner message containing 'withdrawn your requirements'
+  Then I see a success flash message containing 'withdrawn your requirements'
 
 
 Scenario: Edit a draft requirement

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -244,7 +244,7 @@ When(/^I choose a random sentence$/) do
 end
 
 Then /^I see a (success|error|notice) flash message containing #{MAYBE_VAR}$/ do |type, message|
-  flash_message = page.find(:css, ".dm-alert.dm-alert--#{type}", wait: false)
+  flash_message = page.find(:css, ".dm-alert.dm-alert--#{type}, div.flash-message-container", wait: false)
   expect(flash_message).to have_content(message)
 end
 

--- a/features/supplier/supplier_account.feature
+++ b/features/supplier/supplier_account.feature
@@ -167,7 +167,6 @@ Scenario: Supplier user can provide and change supplier details before confirmin
   And I see 'that supplier.dunsNumber' text on the page
 
 @requires-credentials @notify
-@skip-staging
 Scenario: Supplier user can add and remove contributors
   When I click 'Contributors'
   Then I am on the 'Invite or remove contributors' page

--- a/features/user/change_password.feature
+++ b/features/user/change_password.feature
@@ -11,7 +11,7 @@ Scenario Outline: Logged in user can change their password
   And I enter that user.password in the 'New password' field
   And I enter that user.password in the 'Confirm new password' field
   And I click 'Save changes' button
-  Then I see a success banner message containing 'You have successfully changed your password.'
+  Then I see a success flash message containing 'You have successfully changed your password.'
   And I am at the <dashboard_url> url
   And I receive a 'change-password-alert' email for that user.emailAddress
   And I click the link in that email

--- a/features/user/lock_account.feature
+++ b/features/user/lock_account.feature
@@ -1,7 +1,6 @@
 @user @lock-account
 Feature: Users are locked if they enter the wrong password too many times
 
-@skip-staging
 Scenario: User has 5 failed login attempts and is locked out of their account
   Given I have a supplier user
   When the wrong password is entered 5 times for that user

--- a/features/user/reset_password.feature
+++ b/features/user/reset_password.feature
@@ -1,7 +1,6 @@
 @user @reset-password @requires-credentials @notify
 Feature: Reset user password
 
-@skip-staging
 Scenario: User has forgotten their password and requests a password reset
   Given I have a buyer user
   When I visit the homepage
@@ -10,7 +9,6 @@ Scenario: User has forgotten their password and requests a password reset
 
   And that user is able to reset their password
 
-@skip-staging
 Scenario: Inactive user trying to reset password instead receives an informational message
   Given I have a buyer user with:
     | active | false |


### PR DESCRIPTION
https://trello.com/c/sxhsW20p/88-replace-flash-messages-with-alert-component-in-briefs-frontend

Changes to the Briefs FE flash messages necessitate functional test changes.

https://github.com/alphagov/digitalmarketplace-briefs-frontend/pull/320