### PR TITLE
Supplier can copy a service from a previous framework (and delete it)

### DIFF
--- a/features/step_definitions/framework_application_steps.rb
+++ b/features/step_definitions/framework_application_steps.rb
@@ -119,12 +119,13 @@ Then /^I am on #{MAYBE_VAR} page for that lot$/ do |page_title|
 end
 
 Then /^I( don't)? see the existing service in the copyable services table$/ do |negate|
-  service_name = @existing_service['serviceName']
-  previous_framework_name = @existing_service['frameworkName']
+  previous_framework_slug = @existing_service['frameworkSlug']
+  expected_link = "/suppliers/frameworks/#{previous_framework_slug}/services/#{@existing_service['id']}"
+
   if negate
-    step "I don't see '#{service_name}' in the 'Previous framework services' summary table"
+    expect(page).not_to have_link(href: expected_link)
   else
-    step "I see '#{service_name}' in the 'Previous framework services' summary table"
+    expect(page).to have_link(href: expected_link)
   end
 end
 
@@ -137,25 +138,25 @@ Then "I click the 'Add' button for the existing service" do
 end
 
 Then /^I( don't)? see that service in the Draft services section$/ do |negate|
-  service_name = @existing_service['serviceName']
+  service_name = normalize_whitespace(@existing_service['serviceName'])
   if negate
-    step "I don't see '#{service_name}' in the 'Draft services' summary table"
+    expect(page).not_to have_link(service_name)
   else
-    step "I see '#{service_name}' in the 'Draft services' summary table"
+    expect(page).to have_link(service_name)
   end
 end
 
 Then "I click the link to edit the newly copied service" do
-  service_name = @existing_service['serviceName']
+  service_name = normalize_whitespace(@existing_service['serviceName'])
   step "I click the '#{service_name}' link"
 end
 
 Then "I am on the draft service page" do
-  service_name = @existing_service['serviceName']
+  service_name = normalize_whitespace(@existing_service['serviceName'])
   step "I am on the '#{service_name}' page"
 end
 
 Then "I see confirmation that I have removed that draft service" do
-  service_name = @existing_service['serviceName']
+  service_name = normalize_whitespace(@existing_service['serviceName'])
   step "I see a success banner message containing '#{service_name} was removed'"
 end

--- a/features/step_definitions/framework_application_steps.rb
+++ b/features/step_definitions/framework_application_steps.rb
@@ -96,3 +96,66 @@ Then /^I( don't)? receive a (follow-up|clarification) question( confirmation)? e
     puts "Notify id: #{@email.id}"
   end
 end
+
+
+Then 'I click on the lot link for the existing service' do
+  lot_name = @existing_service['lotName']
+  lot_link = page.all(:xpath, "//div[@class='govuk-grid-column-two-thirds framework-lots-table']//a[text()='#{lot_name}']")
+  lot_link[0].click
+end
+
+
+Then /^I click the link to view and add services from the previous framework/ do
+  # The previous framework name includes a &nbsp, so use the link here instead
+  framework_slug = @framework['slug']
+  lot_slug = @existing_service['lotSlug']
+  step "I visit the /suppliers/frameworks/#{framework_slug}/submissions/#{lot_slug}/previous-services page"
+end
+
+
+Then /^I am on #{MAYBE_VAR} page for that lot$/ do |page_title|
+  page_title.sub! "lot", @existing_service['lotName'].downcase
+  step "I am on the '#{page_title}' page"
+end
+
+Then /^I( don't)? see the existing service in the copyable services table$/ do |negate|
+  service_name = @existing_service['serviceName']
+  previous_framework_name = @existing_service['frameworkName']
+  if negate
+    step "I don't see '#{service_name}' in the 'Previous framework services' summary table"
+  else
+    step "I see '#{service_name}' in the 'Previous framework services' summary table"
+  end
+end
+
+Then "I click the 'Add' button for the existing service" do
+  # We want to pick our specific service, as there could be multiple ones on the page.
+  # TODO: replace use of data analytics label with a proper unique identifier
+  button_analytics_label = "ID: #{@existing_service['id']}"
+  button = page.all(:xpath, "//form//button[@data-analytics-label='#{button_analytics_label}']")[0]
+  button.click
+end
+
+Then /^I( don't)? see that service in the Draft services section$/ do |negate|
+  service_name = @existing_service['serviceName']
+  if negate
+    step "I don't see '#{service_name}' in the 'Draft services' summary table"
+  else
+    step "I see '#{service_name}' in the 'Draft services' summary table"
+  end
+end
+
+Then "I click the link to edit the newly copied service" do
+  service_name = @existing_service['serviceName']
+  step "I click the '#{service_name}' link"
+end
+
+Then "I am on the draft service page" do
+  service_name = @existing_service['serviceName']
+  step "I am on the '#{service_name}' page"
+end
+
+Then "I see confirmation that I have removed that draft service" do
+  service_name = @existing_service['serviceName']
+  step "I see a success banner message containing '#{service_name} was removed'"
+end

--- a/features/step_definitions/supplier_steps.rb
+++ b/features/step_definitions/supplier_steps.rb
@@ -95,3 +95,8 @@ Given 'I have a supplier with a reusable declaration' do
   puts "supplier id: #{@supplier['id']}"
 end
 
+
+Given 'I have a supplier with a copyable service' do
+  @supplier = get_supplier_with_copyable_service(@framework)
+  puts "supplier id: #{@supplier['id']}"
+end

--- a/features/supplier/supplier_applies_to_a_framework.feature
+++ b/features/supplier/supplier_applies_to_a_framework.feature
@@ -64,3 +64,42 @@ Scenario: Supplier re-uses a declaration
   # TODO this is where we could continue onwards to make some assertions about the reused declaration data, however
   # at time of writing we redact so much data from the test datasets as to make this infeasible. revisit this.
 
+Scenario: Supplier copies a service from a previous framework
+  Given I have a supplier with a copyable service
+  And that supplier has a user with:
+    |active|true|
+  And that supplier has begun the application process for that framework
+  And that supplier has confirmed their company details for that application
+  And that supplier is logged in
+  When I visit the /suppliers page
+  And I click 'Continue your application'
+  Then I am on the 'Apply to framework' page for that framework application
+
+  When I click 'Add, edit and complete services'
+  Then I am on the 'Your framework services' page for that framework application
+  Then I click on the lot link for the existing service
+  And I click the link to view and add services from the previous framework
+  Then I am on the 'Previous lot services' page for that lot
+  And I see the existing service in the copyable services table
+
+  When I click the 'Add' button for the existing service
+  Then I see 'You'll need to review it before it can be completed.' text on the page
+
+  When I click 'Back to services'
+  Then I see that service in the Draft services section
+  When I click the link to view and add services from the previous framework
+  Then I don't see the existing service in the copyable services table
+
+  When I click 'Back to services'
+  And I click the link to edit the newly copied service
+  Then I am on the draft service page
+
+  When I click the 'Remove draft service' button
+  Then I see 'Are you sure you want to remove this service?' text on the page
+  When I click the 'Yes, remove' button
+  Then I see confirmation that I have removed that draft service
+  Then I don't see that service in the Draft services section
+
+  When I click the link to view and add services from the previous framework
+  Then I am on the 'Previous lot services' page for that lot
+  And I see the existing service in the copyable services table

--- a/features/support/api_helpers.rb
+++ b/features/support/api_helpers.rb
@@ -597,6 +597,13 @@ def get_supplier_with_reusable_declaration
   JSON.parse(call_api(:get, "/suppliers/#{supplier_framework['supplierId']}").body)['suppliers']
 end
 
+def get_supplier_with_copyable_service(framework)
+  @existing_service = get_a_service("published", framework['family'])
+  puts "Service name: #{@existing_service['serviceName']}"
+  puts "Service ID: #{@existing_service['id']}"
+  JSON.parse(call_api(:get, "/suppliers/#{@existing_service['supplierId']}").body)['suppliers']
+end
+
 def remove_supplier_declaration(supplier_id, framework_slug)
   response = call_api(
     :post,

--- a/features/support/api_helpers.rb
+++ b/features/support/api_helpers.rb
@@ -601,6 +601,7 @@ def get_supplier_with_copyable_service(framework)
   @existing_service = get_a_service("published", framework['family'])
   puts "Service name: #{@existing_service['serviceName']}"
   puts "Service ID: #{@existing_service['id']}"
+  puts "Lot name: #{@existing_service['lotName']}"
   JSON.parse(call_api(:get, "/suppliers/#{@existing_service['supplierId']}").body)['suppliers']
 end
 

--- a/features/support/api_helpers.rb
+++ b/features/support/api_helpers.rb
@@ -404,7 +404,7 @@ def get_frameworks
   all_frameworks = JSON.parse(frameworks_from_api.body)['frameworks']
 end
 
-def get_a_service(status, framework_type = "g-cloud")
+def get_a_service(status, framework_type = "g-cloud", must_be_copyable = false)
   all_frameworks = get_frameworks
   suitable_framework_slugs = []
   all_frameworks.each do |framework|
@@ -414,7 +414,14 @@ def get_a_service(status, framework_type = "g-cloud")
   end
   params = { status: status, framework: suitable_framework_slugs[0] }
   services_from_api = call_api(:get, '/services', params: params)
-  JSON.parse(services_from_api.body)['services'].sample
+  service_list = JSON.parse(services_from_api.body)['services']
+
+  if must_be_copyable
+    # Check if the service has already been used to create a draft service
+    service_list = service_list.select { |x| x['copiedToFollowingFramework'] == false }
+  end
+
+  service_list.sample
 end
 
 def create_user(user_role, custom_user_data = {})
@@ -598,7 +605,7 @@ def get_supplier_with_reusable_declaration
 end
 
 def get_supplier_with_copyable_service(framework)
-  @existing_service = get_a_service("published", framework['family'])
+  @existing_service = get_a_service("published", framework['family'], must_be_copyable = true)
   puts "Service name: #{@existing_service['serviceName']}"
   puts "Service ID: #{@existing_service['id']}"
   puts "Lot name: #{@existing_service['lotName']}"


### PR DESCRIPTION
https://trello.com/c/WBjRZd14/80-2-frameworks-repo-copyservices-list-exclude-rather-than-include-fields

We were lacking coverage of a complex part of the framework application journey, which I plan to touch on in https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/1231. I thought it would be good to have some confidence that I'm not breaking anything 😸 

What we're testing:
- Supplier can see existing services from a previous framework, and copy one of them to create a new draft
- Once the draft is created, the source service 'disappears' from the list of copyable services
- Supplier can delete the draft they just created (cleaning things up nicely for our test environment!)
- Once the draft is deleted, the source service reappears in the list of copyable services

Not covered (yet...?):
- bulk copying all services from a previous framework's lot
- copying a draft service from the same framework (i.e. creating a draft from a draft)

Notes for reviewers:
- My Ruby is rusty so please feel free to suggest syntax/efficiency improvements
- Includes steps using summary tables and flash messages which we will be changing at some point, I guess/hope?
- I've tried to keep the step definitions/helpers consistent with existing methods where possible.
- `copiable`/`copyable` - both still look weird to me, not sure which one to go for 😿 
- We shouldn't need any skip tags for deploying, the following should work against existing code