### PR TITLE
Support new dmBanner component styles

### DIFF
--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -251,7 +251,7 @@ end
 # the rescue is used because if a banner cannot be found the function throws an exception and does not look for the other option
 Then /^I see a (success|warning|destructive|temporary-message) banner message containing #{MAYBE_VAR}$/ do |status, message|
   begin
-    banner_message = page.find(:css, ".banner-#{status}-without-action", wait: false)
+    banner_message = page.find(:css, ".dm-banner, .banner-#{status}-without-action", wait: false)
   rescue Capybara::ElementNotFound => e
     banner_message = page.find(:css, ".banner-#{status}-with-action", wait: false)
   end


### PR DESCRIPTION
https://trello.com/c/7UUGcFmw/92-2-replace-notification-banners-with-digitalmarketplace-govuk-frontend-banner-component-in-g-cloud-service-page-and-dos-opportuni

Adds support for the functional tests to look for the new `dm-banner` class as well as the old `banner-temporary-message-without-action` class. I've tested this against the [Buyer FE branch](https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/1056) and against master.

Removing the actual 'temporary message' wording from the step (e.g. 'I see a temporary-message banner message') will not be backwards compatible, so I've left that for now - will create a tech debt card to clean up once we've released.