### PR TITLE
Update password reset/change error messages

### DIFF
--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -106,6 +106,12 @@ Given /^that user is on the user research mailing list$/ do
 end
 
 Then /^that user is able to reset their password$/ do
+  if dm_environment == 'staging'
+    success_message = "You have successfully changed your password."
+  else
+    success_message = "Your password has been successfully changed."
+  end
+
   steps %{
     Given I visit the /user/login page
     When I click 'Forgotten password'
@@ -121,6 +127,6 @@ Then /^that user is able to reset their password$/ do
     And I enter that user.password in the 'Confirm new password' field
     And I click 'Reset password' button
     Then I am on the 'Log in to the Digital Marketplace' page
-    And I see a success flash message containing 'You have successfully changed your password.'
+    And I see a success flash message containing '#{success_message}'
   }
 end

--- a/features/user/change_password.feature
+++ b/features/user/change_password.feature
@@ -2,6 +2,29 @@
 Feature: Password change
 Background:
 
+@skip-staging
+Scenario Outline: Logged in user can change their password
+  Given I am logged in as a <role> user
+  And I visit the <dashboard_url> page
+  When I click 'Change your password'
+  Then I am on the 'Change your password' page
+  When I enter that user.password in the 'Old password' field
+  And I enter that user.password in the 'New password' field
+  And I enter that user.password in the 'Confirm new password' field
+  And I click 'Save changes' button
+  Then I see a success flash message containing 'Your password has been successfully changed.'
+  And I am at the <dashboard_url> url
+  And I receive a 'change-password-alert' email for that user.emailAddress
+  And I click the link in that email
+  Then I am on the 'Reset password' page
+
+  Examples:
+    | role     |  dashboard_url |
+    | buyer    |  /buyers       |
+    | supplier |  /suppliers    |
+
+
+@skip-preview @skip-local
 Scenario Outline: Logged in user can change their password
   Given I am logged in as a <role> user
   And I visit the <dashboard_url> page
@@ -33,6 +56,31 @@ Scenario Outline: Logged in admin user can change their password
   And I enter that user.password in the 'New password' field
   And I enter that user.password in the 'Confirm new password' field
   And I click 'Save changes' button
+  Then I see a success banner message containing 'Your password has been successfully changed.'
+  And I am at the /admin url
+  And I receive a 'change-password-alert' email for that user.emailAddress
+  And I click the link in that email
+  Then I am on the 'Reset password' page
+
+  Examples:
+    | role                    |
+    | admin                   |
+    | admin-framework-manager |
+    | admin-ccs-category      |
+    | admin-ccs-sourcing      |
+    | admin-manager           |
+
+
+@skip-preview
+Scenario Outline: Logged in admin user can change their password
+  Given I am logged in as the existing <role> user
+  And I visit the /admin page
+  When I click 'Change your password'
+  Then I am on the 'Change your password' page
+  When I enter that user.password in the 'Old password' field
+  And I enter that user.password in the 'New password' field
+  And I enter that user.password in the 'Confirm new password' field
+  And I click 'Save changes' button
   Then I see a success banner message containing 'You have successfully changed your password.'
   And I am at the /admin url
   And I receive a 'change-password-alert' email for that user.emailAddress
@@ -48,6 +96,20 @@ Scenario Outline: Logged in admin user can change their password
     | admin-manager           |
 
 
+@skip-staging
+Scenario: User sees validation if they input incorrect old password
+  Given I am logged in as a supplier user
+  And I visit the /suppliers page
+  When I click 'Change your password'
+  Then I am on the 'Change your password' page
+  When I enter 'WrongPassword' in the 'Old password' field
+  And I enter that user.password in the 'New password' field
+  And I enter that user.password in the 'Confirm new password' field
+  And I click 'Save changes' button
+  Then I am on the 'Change your password' page
+  And I see a validation message containing 'Enter your old password'
+
+@skip-preview
 Scenario: User sees validation if they input incorrect old password
   Given I am logged in as a supplier user
   And I visit the /suppliers page


### PR DESCRIPTION
https://trello.com/c/ITSfGrTU/126-1-review-error-message-content-in-user-frontend

This will need a separate PR to remove the duplicate scenarios for staging, once we're ready to deploy. One of the scenarios (logged in admin user) isn't run on staging anyway, because we don't want to send a 'real' password change email for those accounts. 