### PR TITLE
Clarify environments to run functional tests against

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ To run only the smoulder test suite
 
 To run tests for a specific environment file
 
-Create a `config/<environment>.sh` file and run `DM_ENVIRONMENT=preview make smoke-tests`
+Create a `config/<environment>.sh` file and run `DM_ENVIRONMENT=<environment> make smoke-tests`
 
 To run a specific feature run with
 


### PR DESCRIPTION
While I was trying to run the tests against my local environment I missed to see the link between the name of the configuration file and the environment I was trying to run the tests against.
Hopefully this change makes it a bit clearer for the next person.