### PR TITLE
Update tests for new requirements task list page on briefs frontend

### DIFF
--- a/features/buyer/requirements.feature
+++ b/features/buyer/requirements.feature
@@ -4,6 +4,66 @@ Feature: Create and publish a requirement
   As a buyer within government
   I want to be able to create and publish a requirement
 
+
+@skip-staging
+Scenario: Create individual specialist requirement
+  Given I am logged in as a buyer user
+    And I have created an individual specialist requirement
+   Then I complete the following tasks:
+      | task_name                                       |
+      | Specialist role                                 |
+      | Location                                        |
+      | Set how long your requirements will be open for |
+
+  Given 'Description of work' should not be completed
+   When I click 'Description of work'
+    And I answer all summary questions with:
+      | field                 | value       | expected_summary_table_value |
+      | startDate-day         | 08          | Tuesday 8                    |
+      | startDate-month       | 9           | September                    |
+      | startDate-year        | 2020        | 2020                         |
+
+    And I click 'Return to overview'
+   Then 'Description of work' should be completed
+
+  Given 'Shortlist and evaluation process' should not be completed
+   When I click 'Shortlist and evaluation process'
+    And I answer all summary questions with:
+      | field              | value |
+      | numberOfSuppliers  | 5     |
+      | technicalWeighting | 10    |
+      | culturalWeighting  | 5     |
+      | priceWeighting     | 85    |
+   When I click 'Return to overview'
+   Then 'Shortlist and evaluation process' should be completed
+
+  Given 'Describe question and answer session' should not be completed
+   When I click 'Describe question and answer session'
+   And I answer all summary questions
+   And I click 'Return to overview'
+   Then 'Describe question and answer session' should be completed
+
+   When I click 'Preview your requirements'
+   Then I am on the 'Preview your requirements' page
+    And I see the 'Return to overview' link
+    And I see 'Incomplete applications' text in the desktop preview panel
+    And I see 'Tuesday 8 September 2020' text in the desktop preview panel
+    And I see 'Technical competence 10%' text in the desktop preview panel
+    And I click 'Confirm your requirements and publish'
+   Then I am on the 'Publish your requirements and evaluation criteria' page
+    And I click 'Publish requirements'
+
+  Then I don't see the 'Title' link
+   And I don't see the 'Specialist role' link
+   And I don't see the 'Location' link
+   And I don't see the 'Description of work' link
+   And I don't see the 'Shortlist and evaluation process' link
+   And I don't see the 'Set how long your requirements will be open for' link
+   And I don't see the 'Describe question and answer session' link
+   And I don't see the 'Publish your requirements' link
+
+
+@skip-local @skip-preview
 Scenario: Create individual specialist requirement
   Given I am logged in as a buyer user
     And I have created an individual specialist requirement
@@ -60,6 +120,60 @@ Scenario: Create individual specialist requirement
    And I don't see the 'Describe question and answer session' link
    And I don't see the 'Publish your requirements' link
 
+
+@skip-staging
+Scenario: Create team to provide an outcome
+  Given I am logged in as a buyer user
+    And I have created a team to provide an outcome requirement
+   Then I complete the following tasks:
+      | task_name |
+      | Location |
+
+  Given 'Description of work' should not be completed
+   When I click 'Description of work'
+    And I answer all summary questions with:
+      | field                 | value       | expected_summary_table_value |
+      | startDate-day         | 9           | Wednesday 9                    |
+      | startDate-month       | 9           | September                    |
+      | startDate-year        | 2020        | 2020                         |
+    And I click 'Return to overview'
+   Then 'Description of work' should be completed
+
+  Given 'Shortlist and evaluation process' should not be completed
+   When I click 'Shortlist and evaluation process'
+    And I answer all summary questions with:
+      | field              | value |
+      | numberOfSuppliers  | 5     |
+      | technicalWeighting | 10    |
+      | culturalWeighting  | 5     |
+      | priceWeighting     | 85    |
+    And I click 'Return to overview'
+   Then 'Shortlist and evaluation process' should be completed
+
+  Given 'Describe question and answer session' should not be completed
+   When I click 'Describe question and answer session'
+    And I answer all summary questions
+    And I click 'Return to overview'
+   Then 'Describe question and answer session' should be completed
+
+   When I click 'Preview your requirements'
+   Then I am on the 'Preview your requirements' page
+    And I see the 'Return to overview' link
+    And I see '0 SME, 0 large' text in the desktop preview panel
+    And I see 'Wednesday 9 September 2020' text in the desktop preview panel
+    And I see 'Cultural fit 5%' text in the desktop preview panel
+    And I click 'Confirm your requirements and publish'
+   Then I am on the 'Publish your requirements and evaluation criteria' page
+    And I click 'Publish requirements'
+
+  Then I don't see the 'Title' link
+   And I don't see the 'Location' link
+   And I don't see the 'Description of work' link
+   And I don't see the 'Shortlist and evaluation process' link
+   And I don't see the 'Publish your requirements' link
+
+
+@skip-local @skip-preview
 Scenario: Create team to provide an outcome
   Given I am logged in as a buyer user
     And I have created a team to provide an outcome requirement
@@ -110,6 +224,56 @@ Scenario: Create team to provide an outcome
    And I don't see the 'Shortlist and evaluation process' link
    And I don't see the 'Publish your requirements' link
 
+
+@skip-staging
+Scenario: Create user research participants
+  Given I am logged in as a buyer user
+    And I have created user research participants requirement
+   Then I complete the following tasks:
+      | task_name |
+      | Location |
+
+  Given 'Description of work' should not be completed
+   When I click 'Description of work'
+    And I answer all summary questions
+    And I click 'Return to overview'
+   Then 'Description of work' should be completed
+
+  Given 'Shortlist and evaluation process' should not be completed
+   When I click 'Shortlist and evaluation process'
+    And I answer all summary questions with:
+      | field              | value |
+      | numberOfSuppliers  | 5     |
+      | technicalWeighting | 10    |
+      | culturalWeighting  | 10    |
+      | priceWeighting     | 80    |
+    And I click 'Return to overview'
+   Then 'Shortlist and evaluation process' should be completed
+
+  Given 'Describe question and answer session' should not be completed
+   When I click 'Describe question and answer session'
+    And I answer all summary questions
+    And I click 'Return to overview'
+   Then 'Describe question and answer session' should be completed
+
+   When I click 'Preview your requirements'
+   Then I am on the 'Preview your requirements' page
+    And I see the 'Return to overview' link
+    And I see 'Deadline for asking questions' text in the desktop preview panel
+    And I see 'View question and answer session details' text in the desktop preview panel
+    And I see 'Price 80%' text in the desktop preview panel
+    And I click 'Confirm your requirements and publish'
+   Then I am on the 'Publish your requirements and evaluation criteria' page
+    And I click 'Publish requirements'
+
+  Then I don't see the 'Title' link
+   And I don't see the 'Location' link
+   And I don't see the 'Description of work' link
+   And I don't see the 'Shortlist and evaluation process' link
+   And I don't see the 'Publish your requirements' link
+
+
+@skip-local @skip-preview
 Scenario: Create user research participants
   Given I am logged in as a buyer user
     And I have created user research participants requirement
@@ -246,7 +410,7 @@ Scenario: Cancel a withdraw draft requirement request
   Then I see the 'Cancel' link
   And I click 'Cancel'
   Then I am on that brief overview page
-  
+
 
 Scenario: Edit a draft requirement
   Given I am logged in as a buyer user
@@ -257,6 +421,14 @@ Scenario: Edit a draft requirement
   Then I am on the 'Green Tea Drinker' page
 
 
+@skip-staging
+Scenario: There is no 'Publish requirements' link for an incomplete requirement draft
+  Given I am logged in as a buyer user
+  And I have created an individual specialist requirement
+  Then I don't see the 'Publish requirements' link
+
+
+@skip-local @skip-preview
 Scenario: There is no 'Publish requirements' button for an incomplete requirement draft
   Given I am logged in as a buyer user
   And I have created an individual specialist requirement

--- a/features/step_definitions/requirements_steps.rb
+++ b/features/step_definitions/requirements_steps.rb
@@ -28,6 +28,21 @@ Then(/^'(.*)' should (not |)be ticked$/) do |label, negative|
   expect(page).to have_selector(:xpath, expr, count: count)
 end
 
+Then(/^'(.*)' should (not |)be completed$/) do |task_name, completed|
+  task_list_item_selector = "li.dm-task-list__item"
+  task_list_tag_selector = "strong.govuk-tag.dm-task-list__tag"
+
+  task_list_item = page.find(task_list_item_selector, text: task_name)
+
+  if completed.include? "not"
+    # tag should be "To do" or "Optional"
+    expect(task_list_item.find(task_list_tag_selector)).to have_text(/(To do|Optional)/)
+  else
+    # tag should be "Done"
+    expect(task_list_item.find(task_list_tag_selector)).to have_text("Done")
+  end
+end
+
 When "I answer the following questions:" do |table|
 
   table.rows.flatten.each { |question|
@@ -44,6 +59,29 @@ When "I answer the following questions:" do |table|
     click_on 'Save and continue', wait: false
 
     expect(page).to have_selector(:xpath, expr, count: 1)
+  }
+end
+
+When "I complete the following tasks:" do |table|
+
+  table.rows.flatten.each { |task_name|
+    task_list_item_selector = "li.dm-task-list__item"
+    task_list_tag_selector = "strong.govuk-tag.dm-task-list__tag"
+
+    task_list_item = page.find(task_list_item_selector, text: task_name)
+
+    # tag should be "To do" or "Optional"
+    expect(task_list_item.find(task_list_tag_selector)).to have_text(/(To do|Optional)/)
+
+    # click the question name on the overview page (eg, "Location")
+    click_on task_name, wait: false
+
+    @fields.merge! fill_form
+
+    click_on 'Save and continue', wait: false
+
+    task_list_item = page.find(task_list_item_selector, text: task_name)
+    expect(task_list_item.find(task_list_tag_selector)).to have_text("Done")
   }
 end
 


### PR DESCRIPTION
Ticket: https://trello.com/c/SPGKu5rX/95-3-replace-instruction-list-with-govuk-design-system-task-list-pages-pattern-in-create-a-dos-opportunity-journey