### PR TITLE
Be explicit about selecting radio by id

### DIFF
--- a/features/support/helpers.rb
+++ b/features/support/helpers.rb
@@ -118,9 +118,9 @@ end
 def choose_radio(locator_or_radio, options = { wait: false })
   begin
     radio = return_element('radio', locator_or_radio, options)
-    choose(radio[:id], options.merge(allow_label_click: true, wait: false))
+    choose(radio[:id], options.merge(allow_label_click: true, wait: false, id: radio[:id]))
   rescue Capybara::ElementNotFound
-    choose(radio[:id], allow_label_click: true, wait: false)
+    choose(radio[:id], allow_label_click: true, wait: false, id: radio[:id])
   end
   puts "Radio button value: #{radio.value}"
 end


### PR DESCRIPTION
https://trello.com/c/yHSxrqS9/173-3-replace-wtforms-toolkit-elements-with-govuk-frontend-components-in-award-a-dos-opportunity-journey

We select radios by ID, but with the new GOV.UK components, there's
ambiguity since the first radio's id is the same as the radios' name.

We can handle this by explicitly selecting the radio by ID, so the check
ignores the name attribute.