### PR TITLE
Use Bash as Makefile shell

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "gemset.nix",
     "lines": null
   },
-  "generated_at": "2020-08-28T12:26:19Z",
+  "generated_at": "2020-09-04T16:35:30Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -90,7 +90,7 @@
         "hashed_secret": "03a508edc89113f88428c661928e17c1473194cc",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 38,
+        "line_number": 36,
         "type": "Secret Keyword"
       }
     ],
@@ -99,7 +99,7 @@
         "hashed_secret": "6422dc66ecc59b9bd8afcf9d7912708f0fcf6d09",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 8,
+        "line_number": 6,
         "type": "Secret Keyword"
       }
     ],

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+SHELL := /bin/bash
 DM_ENVIRONMENT ?= local
 
 CONFIG := config/${DM_ENVIRONMENT}.sh

--- a/config/common.sh
+++ b/config/common.sh
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 export DM_ENVIRONMENT=${DM_ENVIRONMENT:="development"}
 
 export DM_API_DOMAIN=${DM_API_DOMAIN:=https://api.${DM_ENVIRONMENT}.marketplace.team}

--- a/config/local.example.sh
+++ b/config/local.example.sh
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 export DM_ENVIRONMENT=${DM_ENVIRONMENT:="local"}
 
 export DM_API_PORT=${DM_API_PORT:=5000}

--- a/config/preview.example.sh
+++ b/config/preview.example.sh
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 export DM_ENVIRONMENT=${DM_ENVIRONMENT:="preview"}
 
 export DM_API_ACCESS_TOKEN=${DM_API_ACCESS_TOKEN:=myToken}


### PR DESCRIPTION
Currently we seem to use the default - sh. This causes problems with the default `local.sh` since `BASH_SOURCE` is not valid sh.

Switch to force the use of bash to ensure that `BASH_SOURCE` works.

Note that `local.sh` does have a bash shebang. However, this is useless because the shebang is not evaluated when the script is sourced.