### PR TITLE
Don't run antivirus status test locally

### DIFF
--- a/features/smoke-tests/apps_status.feature
+++ b/features/smoke-tests/apps_status.feature
@@ -13,7 +13,7 @@ Feature: Apps /_status is ok
     Then I see 'ok' as the value of the 'status' JSON field
     And Display the value of the 'version' JSON field as 'Release version'
 
-  @status @antivirus-api
+  @status @antivirus-api @skip-local
   Scenario: Check the antivirus API /_status
     Given I visit the antivirus-api /_status page
     Then I see 'ok' as the value of the 'status' JSON field


### PR DESCRIPTION
The antivirus-api app can't meaningfully be run locally, since it relies on SNS stuff from AWS.

After this commit, the entire (un-skipped) test suite passes on my machine.