### PR TITLE
Update search result item tests

### DIFF
--- a/features/step_definitions/catalogue_steps.rb
+++ b/features/step_definitions/catalogue_steps.rb
@@ -8,16 +8,16 @@ When /^I see #{MAYBE_VAR} as the search query in the search box$/ do |query|
 end
 
 When(/^I click a random result in the list of service results returned$/) do
-  search_results = all(:xpath, "//*[@class='search-result']")
+  search_results = all(:xpath, "//*[@class='app-search-result']")
   selected_result = search_results[rand(search_results.length)]
 
   @result = @result || Hash.new
 
-  a_elem = selected_result.first(:xpath, ".//h2[@class='search-result-title']/a")
+  a_elem = selected_result.first(:css, "h2.govuk-heading-s a")
   @result['title'] = a_elem.text
   puts "Result name: #{ERB::Util.h @result['title']}"
 
-  @result['supplier_name'] = selected_result.first(:xpath, ".//*[@class='search-result-supplier']").text
+  @result['supplier_name'] = selected_result.first(:css, "p:nth-of-type(1)").text
   puts "Result supplier_name: #{ERB::Util.h @result['supplier_name']}"
 
   a_elem.click
@@ -25,9 +25,9 @@ end
 
 Then (/^I (don't )?see a search result$/) do |negate|
   if negate
-    expect(page).not_to have_selector(:css, "div.search-result")
+    expect(page).not_to have_selector(:css, "li.app-search-result")
   else
-    expect(page).to have_selector(:css, "div.search-result")
+    expect(page).to have_selector(:css, "li.app-search-result")
   end
 end
 

--- a/features/step_definitions/opportunities_steps.rb
+++ b/features/step_definitions/opportunities_steps.rb
@@ -1,10 +1,10 @@
 When(/^I click a random result in the list of opportunity results returned$/) do
-  search_results = all(:xpath, "//*[@class='search-result']")
+  search_results = all(:xpath, "//*[@class='app-search-result']")
   selected_result = search_results[rand(search_results.length)]
 
   @result ||= Hash.new
 
-  a_elem = selected_result.first(:xpath, ".//h2[@class='search-result-title']/a")
+  a_elem = selected_result.first(:css, "h2.govuk-heading-s a")
   @result['title'] = a_elem.text
   puts "Result name: #{@result['title']}"
 
@@ -17,7 +17,7 @@ When(/^I note the result_count$/) do
 end
 
 Then (/^I see an opportunity in the search results$/) do
-  expect(page).to have_selector(:css, ".search-result")
+  expect(page).to have_selector(:css, ".app-search-result")
 end
 
 Then (/^I see that the stated number of results (does not exceed|equals|is no fewer than) that (\w+)$/) do |comparison_string, variable_name|

--- a/features/support/catalogue_helpers.rb
+++ b/features/support/catalogue_helpers.rb
@@ -20,7 +20,7 @@ module CatalogueHelpers
   end
 
   def self.get_service_search_results(page, service)
-    page.all(:xpath, "//*[@class='search-result'][.//h2//a[contains(@href, '#{service['id']}')]]").find_all { |sr_element|
+    page.all(:xpath, "//*[@class='app-search-result'][.//h2//a[contains(@href, '#{service['id']}')]]").find_all { |sr_element|
       # now refine with a much more precise test
       sr_element.all(:css, "h2 a").any? { |a_element|
         (
@@ -28,11 +28,11 @@ module CatalogueHelpers
         ) && (
           a_element.text == normalize_whitespace(service['serviceName'])
         )
-      } && sr_element.all(:css, "p.search-result-supplier").any? { |p_element|
+      } && sr_element.all(:css, "p:nth-of-type(1)").any? { |p_element|
         p_element.text == normalize_whitespace(service['supplierName'])
-      } && sr_element.all(:css, "li.search-result-metadata-item,li.search-result-metadata-item-inline").any? { |li_element|
+      } && sr_element.all(:css, "ul[aria-label='tags'] li").any? { |li_element|
         li_element.text == normalize_whitespace(service['lotName'])
-      } && sr_element.all(:css, "li.search-result-metadata-item,li.search-result-metadata-item-inline").any? { |li_element|
+      } && sr_element.all(:css, "ul[aria-label='tags'] li").any? { |li_element|
         li_element.text == normalize_whitespace(service['frameworkName'])
       }
     }


### PR DESCRIPTION
https://trello.com/c/ybGmz7dL/180-1-review-colour-size-of-text-on-search-result-items

We've removed toolkit classes from search results on the buyer frontend, so the tests need to reflect that. This PR edits some selectors so that tests continue to target the correct elements.