### PR TITLE
Remove old framework agreement flow from preview

### DIFF
--- a/features/supplier/supplier_uploads_signed_agreement.feature
+++ b/features/supplier/supplier_uploads_signed_agreement.feature
@@ -1,3 +1,4 @@
+@staging
 @supplier @file-upload @file-download @requires-credentials
 Feature: Supplier uploads a signed agreement for a framework
 


### PR DESCRIPTION
Now that G-Cloud 12 is live on preview we no longer want this test.