### PR TITLE
Allow search page tests to handle new option select

### DIFF
--- a/features/smoulder-tests/buyer/catalogue.feature
+++ b/features/smoulder-tests/buyer/catalogue.feature
@@ -51,8 +51,8 @@ Scenario: User is able to paginate through search results and all of the navigat
   And I choose that lot.name radio button
   And I click 'Search for services'
   Then I am on the 'Search results' page
-  When I check the 'Developed Vetting (DV)' checkbox
-  And I check the 'Security Clearance (SC)' checkbox
+  And I check the 'Developed Vetting (DV)' checkbox in the 'Minimum government security clearance' group
+  And I check the 'Security Clearance (SC)' checkbox in the 'Minimum government security clearance' group
   And I wait for the page to reload
   And I note the number of category links
   And I click the Next Page link

--- a/features/smoulder-tests/supplier/opportunities.feature
+++ b/features/smoulder-tests/supplier/opportunities.feature
@@ -4,7 +4,7 @@ Feature: Supplier viewing and filtering DOS opportunities - extension of smoke t
 Scenario Outline: User can filter by individual status
   Given I visit the /digital-outcomes-and-specialists/opportunities page
   When I note the result_count
-  And I check '<status>' checkbox
+  And I check the '<status>' checkbox in the 'Status' group
   And I wait for the page to reload
   Then I see that the stated number of results does not exceed that result_count
   And I see all the opportunities on the page are of the '<status>' status
@@ -24,7 +24,7 @@ Scenario: Checking all statuses returns all results
 Scenario Outline: User can filter by individual location
   Given I visit the /digital-outcomes-and-specialists/opportunities page
   When I note the result_count
-  And I check '<location>' checkbox
+  And I check the '<location>' checkbox in the 'Location' group
   And I wait for the page to reload
   Then I see that the stated number of results does not exceed that result_count
   And I see all the opportunities on the page are in the '<location>' location
@@ -37,12 +37,13 @@ Scenario Outline: User can filter by individual location
 
 Scenario: Specialist roles are selectable for Digital specialists
   Given I visit the /digital-outcomes-and-specialists/opportunities page
-  Then I don't see a 'Designer' checkbox
+  Then I don't see a 'Specialist role' button
+  And I don't see a 'Designer' checkbox
   And I don't see any 'specialistRole' checkboxes
   When I click 'Digital specialists'
   And I note the result_count
   Then a filter checkbox's associated aria-live region contains that result_count
-  When I check 'Designer' checkbox
+  And I check the 'Designer' checkbox in the 'Specialist role' group
   And I wait for the page to reload
   Then I see that the stated number of results does not exceed that result_count
   And I see all the opportunities on the page are on the 'Digital specialists' lot
@@ -52,10 +53,12 @@ Scenario: Specialist roles are selectable for Digital specialists
 
 Scenario Outline: Specialist roles are not selectable for non-Digital specialists lots
   Given I visit the /digital-outcomes-and-specialists/opportunities page
-  Then I don't see a 'Designer' checkbox
+  Then I don't see a 'Specialist role' button
+  And I don't see a 'Designer' checkbox
   And I don't see any 'specialistRole' checkboxes
   When I click the '<lot>' category link
-  Then I don't see a 'Designer' checkbox
+  Then I don't see a 'Specialist role' button
+  And I don't see a 'Designer' checkbox
   And I don't see any 'specialistRole' checkboxes
 
   Examples:
@@ -66,7 +69,7 @@ Scenario Outline: Specialist roles are not selectable for non-Digital specialist
 Scenario Outline: User gets no results for impossible combinations of location and lot
   Given I visit the /digital-outcomes-and-specialists/opportunities page
   And I click the '<lot>' category link
-  And I check '<location>' checkbox
+  And I check the '<location>' checkbox in the 'Location' group
   And I wait for the page to reload
   Then I see no results
   # now we backtrack a bit to check the lot "link" has been made unclickable when showing it has no results
@@ -74,7 +77,7 @@ Scenario Outline: User gets no results for impossible combinations of location a
   And I wait for the page to reload
   And I click 'All categories'
   And I wait for the page to load
-  And I check '<location>' checkbox
+  And I check the '<location>' checkbox in the 'Location' group
   And I wait for the page to reload
   Then I don't see the '<lot>' link
 
@@ -85,20 +88,19 @@ Scenario Outline: User gets no results for impossible combinations of location a
     | User research participants | Off-site                       |
 
 
-
 Scenario Outline: User can filter by status, lot, location and keyword together
   Given I visit the /digital-outcomes-and-specialists/opportunities page
   When I note the result_count
   And I click the '<lot>' category link
   Then I see that the stated number of results does not exceed that result_count
   And I note the result_count
-  When I check '<status>' checkbox
+  When I check the '<status>' checkbox in the 'Status' group
   And I wait for the page to reload
   Then I see that the stated number of results does not exceed that result_count
   And I note the result_count
   And I see all the opportunities on the page are on the '<lot>' lot
   And I see all the opportunities on the page are of the '<status>' status
-  When I check '<location>' checkbox
+  When I check the '<location>' checkbox in the 'Location' group
   And I wait for the page to reload
   Then I see that the stated number of results does not exceed that result_count
   And I note the result_count
@@ -127,7 +129,7 @@ Scenario Outline: User can filter by status, lot, location and keyword together
   And I see that the stated number of results is no fewer than that result_count
   And I note the result_count
   And I see all the opportunities on the page are in the '<location>' location
-  When I uncheck '<location>' checkbox
+  When I uncheck the '<location>' checkbox in the 'Location' group
   And I wait for the page to reload
   Then I see '<phrase>' in the search summary text
   And I see that the stated number of results is no fewer than that result_count

--- a/features/step_definitions/catalogue_steps.rb
+++ b/features/step_definitions/catalogue_steps.rb
@@ -82,8 +82,31 @@ Then(/^I see fewer search results than noted$/) do
   expect(CatalogueHelpers.get_service_count(page)).to be < @result_count
 end
 
+When(/^I (un)?check the (.*) checkbox in the (.*) group$/) do |maybe_un, checkbox_label, group_label|
+  if has_css?(".dm-option-select")
+    begin
+      is_checkbox_visible = page.find("label", text: checkbox_label)
+    rescue Capybara::ElementNotFound
+      page.find("button.dm-option-select__button", text: group_label).click
+    end
+  end
+
+  if not maybe_un
+    check_checkbox(checkbox_label)
+  else
+    uncheck_checkbox(checkbox_label)
+  end
+end
+
 Then(/^I select several random filters$/) do
-  page.all(:xpath, "//div[contains(@class, 'govuk-option-select')]//input[@type='checkbox']").sample.click
+  # We now hide options by default, so need to open them up first
+  if has_css?("button.dm-option-select__button")
+    button_el = page.all(:css, 'button.dm-option-select__button').sample
+    button_el.click
+    page.all(:css, ".js-opened .govuk-checkboxes__label").sample.click
+  else
+    page.all(:xpath, "//div[contains(@class, 'govuk-option-select')]//input[@type='checkbox']").sample.click
+  end
 end
 
 Then(/^I note the number of category links$/) do

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -530,9 +530,8 @@ Then(/^a filter checkbox's associated aria-live region contains #{MAYBE_VAR}$/) 
   expect(
     page.find_by_id(
       page.all(
-        :xpath,
-        "//div[contains(@class, 'govuk-option-select')]//input[@type='checkbox']").sample["aria-controls"],
-      visible: :all
+        :css,
+        "div .govuk-option-select input[type=checkbox], .dm-option-select input[type=checkbox]", visible: :all).sample["aria-controls"]
     ).text(:all)
   ).to include(value.to_s)
 end


### PR DESCRIPTION
https://trello.com/c/VCANsToa/233-3-replace-search-filters-with-govuk-checkbox-groups-option-select

We now default to collapsing our filters, so the functional tests need to account for this behaviour.