### PR TITLE
Update 'edit company details' tests for G-Cloud 12

### DIFF
--- a/features/admin/company_details.feature
+++ b/features/admin/company_details.feature
@@ -35,7 +35,7 @@ Scenario Outline: Correct admin roles can view a supplier's details
     | Address                      | 14 Duke Street Dublin H3 LY5 Ireland |
   And I see an entry in the 'Frameworks' table with:
     | field       | link1         | link2           |
-    | G-Cloud 11  | View services | View agreements |
+    | G-Cloud 12  | View services | View agreements |
   When I click the 'Users' link
   Then I am on the 'DM Functional Test Supplier - Company details feature' page
   And I see an entry in the 'Users' table with:


### PR DESCRIPTION
With G12 now live and G11 expired, our cleaned database dumps for staging and preview will have G12 as the latest live framework. The 'company details page' feature finds a supplier who is on the latest live framework, but the test still has a hardcoded reference to the name of that framework, so we need to update that whenever the latest live framework changes.