### PR TITLE
Pagination tests handle old and new pagination

### DIFF
--- a/features/step_definitions/catalogue_steps.rb
+++ b/features/step_definitions/catalogue_steps.rb
@@ -121,8 +121,7 @@ Then(/^I am taken to page (\d+) of results$/) do |page_number|
   if page.has_css?('.dm-pagination') # @TODO: New pagination - remove else clause when search page released
     expect(page).to have_selector(:xpath, "//nav//ul//li//a//span[contains(text(), 'Next page')]")
     expect(page).to have_selector(:xpath, "//nav//ul//li//a//span[contains(text(), '#{page_number + 1} of')]")
-    if page_number == 1
-      expect(page).to have_selector(:xpath, "//nav//ul//li//a//span[contains(text(), 'Next page')]")
+    if page_number == 1)
       expect(page).not_to have_selector(:xpath, "//nav//ul//li//a//span[contains(text(), 'Previous page')]")
     else
       expect(page).to have_selector(:xpath, "//nav//ul//li//a//span[contains(text(), 'Previous page')]")
@@ -132,7 +131,6 @@ Then(/^I am taken to page (\d+) of results$/) do |page_number|
     expect(page).to have_selector(:xpath, "//a[contains(text(), 'Next')]//following-sibling::span[contains(text(),'page')]")
     expect(page).to have_selector(:xpath, "//a[contains(text(), 'Next')]//following-sibling::span[contains(text(),'page')]/..//following-sibling::span[@class='page-numbers'][contains(text(), '#{page_number + 1} of')]")
     if page_number == 1
-      expect(page).to have_selector(:xpath, "//a[contains(text(), 'Next')]//following-sibling::span[contains(text(),'page')]")
       expect(page).not_to have_selector(:xpath, "//a[contains(text(), 'Previous')]//following-sibling::span[contains(text(),'page')]")
     else
       expect(page).to have_selector(:xpath, "//a[contains(text(), 'Previous')]//following-sibling::span[contains(text(),'page')]")

--- a/features/step_definitions/catalogue_steps.rb
+++ b/features/step_definitions/catalogue_steps.rb
@@ -117,14 +117,27 @@ end
 Then(/^I am taken to page (\d+) of results$/) do |page_number|
   page_number = page_number.to_i
   expect(current_url).to include("page=#{page_number}")
-  expect(page).to have_selector(:xpath, "//a[contains(text(), 'Next')]//following-sibling::span[contains(text(),'page')]")
-  expect(page).to have_selector(:xpath, "//a[contains(text(), 'Next')]//following-sibling::span[contains(text(),'page')]/..//following-sibling::span[@class='page-numbers'][contains(text(), '#{page_number + 1} of')]")
-  if page_number == 1
-    expect(page).to have_selector(:xpath, "//a[contains(text(), 'Next')]//following-sibling::span[contains(text(),'page')]")
-    expect(page).not_to have_selector(:xpath, "//a[contains(text(), 'Previous')]//following-sibling::span[contains(text(),'page')]")
+
+  if page.has_css?('.dm-pagination') # @TODO: New pagination - remove else clause when search page released
+    expect(page).to have_selector(:xpath, "//nav//ul//li//a//span[contains(text(), 'Next page')]")
+    expect(page).to have_selector(:xpath, "//nav//ul//li//a//span[contains(text(), '#{page_number + 1} of')]")
+    if page_number == 1
+      expect(page).to have_selector(:xpath, "//nav//ul//li//a//span[contains(text(), 'Next page')]")
+      expect(page).not_to have_selector(:xpath, "//nav//ul//li//a//span[contains(text(), 'Previous page')]")
+    else
+      expect(page).to have_selector(:xpath, "//nav//ul//li//a//span[contains(text(), 'Previous page')]")
+      expect(page).to have_selector(:xpath, "//nav//ul//li//a//span[contains(text(), '#{page_number - 1} of')]")
+    end
   else
-    expect(page).to have_selector(:xpath, "//a[contains(text(), 'Previous')]//following-sibling::span[contains(text(),'page')]")
-    expect(page).to have_selector(:xpath, "//a[contains(text(), 'Previous')]//following-sibling::span[contains(text(),'page')]/..//following-sibling::span[@class='page-numbers'][contains(text(), '#{page_number - 1} of')]")
+    expect(page).to have_selector(:xpath, "//a[contains(text(), 'Next')]//following-sibling::span[contains(text(),'page')]")
+    expect(page).to have_selector(:xpath, "//a[contains(text(), 'Next')]//following-sibling::span[contains(text(),'page')]/..//following-sibling::span[@class='page-numbers'][contains(text(), '#{page_number + 1} of')]")
+    if page_number == 1
+      expect(page).to have_selector(:xpath, "//a[contains(text(), 'Next')]//following-sibling::span[contains(text(),'page')]")
+      expect(page).not_to have_selector(:xpath, "//a[contains(text(), 'Previous')]//following-sibling::span[contains(text(),'page')]")
+    else
+      expect(page).to have_selector(:xpath, "//a[contains(text(), 'Previous')]//following-sibling::span[contains(text(),'page')]")
+      expect(page).to have_selector(:xpath, "//a[contains(text(), 'Previous')]//following-sibling::span[contains(text(),'page')]/..//following-sibling::span[@class='page-numbers'][contains(text(), '#{page_number - 1} of')]")
+    end
   end
 end
 

--- a/features/step_definitions/catalogue_steps.rb
+++ b/features/step_definitions/catalogue_steps.rb
@@ -121,7 +121,7 @@ Then(/^I am taken to page (\d+) of results$/) do |page_number|
   if page.has_css?('.dm-pagination') # @TODO: New pagination - remove else clause when search page released
     expect(page).to have_selector(:xpath, "//nav//ul//li//a//span[contains(text(), 'Next page')]")
     expect(page).to have_selector(:xpath, "//nav//ul//li//a//span[contains(text(), '#{page_number + 1} of')]")
-    if page_number == 1)
+    if page_number == 1
       expect(page).not_to have_selector(:xpath, "//nav//ul//li//a//span[contains(text(), 'Previous page')]")
     else
       expect(page).to have_selector(:xpath, "//nav//ul//li//a//span[contains(text(), 'Previous page')]")

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -156,11 +156,20 @@ end
 
 When /I click the (Next|Previous) Page link$/ do |next_or_previous|
   # can't use above as we have services with the word 'next' in the name :(
+  # @TODO: Remove old classes when DM-GOVUK Search Page is released.
   klass = ''
   if next_or_previous == 'Next'
-    klass = '.next'
+    if page.has_css?('.dm-pagination')
+      klass = '.dm-pagination__item--next'
+    else
+      klass = '.next'
+    end
   elsif next_or_previous == 'Previous'
-    klass = '.previous'
+    if page.has_css?('.dm-pagination')
+      klass = '.dm-pagination__item--previous'
+    else
+      klass = '.previous'
+    end
   end
   page.find(:css, "#{klass} :link").click
 end

--- a/features/step_definitions/supplieraz_steps.rb
+++ b/features/step_definitions/supplieraz_steps.rb
@@ -7,9 +7,15 @@ end
 
 When(/^I click that specific supplier$/) do
   # This step is hardcoded as we want to make sure we don't somehow click a similarly-named supplier
+  # @TODO: Remove else clause when DM-GOVUK search pages are released
+  if page.has_css?('.app-search-result')
+    result_class = 'app-search-result'
+  else
+    result_class = 'search-result'
+  end
 
   # we do a broad match using xpath first
-  a_elements = page.all(:xpath, "//*[@class='search-result']//h2//a[contains(@href, '#{@supplier['id']}')]").find_all { |a_element|
+  a_elements = page.all(:xpath, "//*[@class='#{result_class}']//h2//a[contains(@href, '#{@supplier['id']}')]").find_all { |a_element|
     # now refine with a much more precise test
     (
       a_element[:href] =~ Regexp.new('^(.*\D)?' + "#{@supplier['id']}" + '(\D.*)?$')
@@ -33,7 +39,15 @@ end
 
 Then (/^I see that supplier in one of the pages that follow from clicking #{MAYBE_VAR}$/) do |next_link_label|
   i = 1
-  until search_result = page.first(:xpath, "//*[@class='search-result'][.//h2//a[contains(@href, '#{@supplier['id']}')]]")
+  # @TODO: Remove else clause when DM-GOVUK search pages are released
+  if page.has_css?('.app-search-result')
+    result_class = 'app-search-result'
+    result_heading_class = 'govuk-heading-s govuk-!-margin-bottom-1'
+  else
+    result_class = 'search-result'
+    result_heading_class = 'search-result-title'
+  end
+  until search_result = page.first(:xpath, "//*[@class='#{result_class}'][.//h2//a[contains(@href, '#{@supplier['id']}')]]")
     # ^^^ note assignment, not comparison here ^^^
     i += 1
     page.click_link(next_link_label)
@@ -41,7 +55,7 @@ Then (/^I see that supplier in one of the pages that follow from clicking #{MAYB
   end
 
   expect(
-    search_result.first(:xpath, ".//h2[@class='search-result-title']/a").text
+    search_result.first(:xpath, ".//h2[@class='#{result_heading_class}']/a").text
   ).to eq(normalize_whitespace(@supplier['name']))
 
   puts "Found supplier on page #{i}"

--- a/features/step_definitions/supplieraz_steps.rb
+++ b/features/step_definitions/supplieraz_steps.rb
@@ -54,22 +54,45 @@ Given(/I navigate to the list of '(.*)' page$/) do |value|
 end
 
 Then(/I am taken to page '(.*)' of results$/) do |page_number|
+  # @TODO: Remove old pagination styles once DM-GOVUK search page is released
   if current_url.include?('suppliers?')
     expect(current_url).to include("#{dm_frontend_domain}/g-cloud/suppliers?")
     expect(current_url).to include("prefix=#{@data_store['supplier_alphabet']}")
     expect(current_url).to include("page=#{page_number}")
     expect(current_url).to include("framework=g-cloud")
     if page_number >= '2'
-      expect(page).to have_selector(:xpath, "//a[contains(text(), 'Previous')]//following-sibling::span[contains(text(),'page')]")
+      expect(page).to have_selector(
+        :xpath,
+        (
+          "//a[contains(text(), 'Previous')]//following-sibling::span[contains(text(),'page')]"
+          "|"
+          "//nav//ul//li//a//span[contains(text(), 'Previous page')]"
+        )
+      )
     elsif page_number < '2'
-      expect(page).to have_selector(:xpath, "//a[contains(text(), 'Next')]//following-sibling::span[contains(text(),'page')]")
-      expect(page).not_to have_selector(:xpath, "//a[contains(text(), 'Previous')]//following-sibling::span[contains(text(),'page')]")
+      expect(page).to have_selector(
+        :xpath,
+        (
+          "//a[contains(text(), 'Next')]//following-sibling::span[contains(text(),'page')]"
+          "|"
+          "//nav//ul//li//a//span[contains(text(), 'Next page')]"
+        )
+      )
+      expect(page).not_to have_selector(
+        :xpath,
+        (
+          "//a[contains(text(), 'Previous')]//following-sibling::span[contains(text(),'page')]"
+          "|"
+          "//nav//ul//li//a//span[contains(text(), 'Previous page')]"
+        )
+      )
     end
   end
 end
 
 
 Then(/pagination is '(.*)'$/) do |availability|
+  # @TODO: Remove old pagination styles once DM-GOVUK search page is released
   if current_url.include?('suppliers?')
     pagination_available = "#{availability}"
   else
@@ -77,10 +100,38 @@ Then(/pagination is '(.*)'$/) do |availability|
   end
 
   if pagination_available == 'available'
-    expect(page).to have_selector(:xpath, "//a[contains(text(), 'Next')]//following-sibling::span[contains(text(),'page')]")
-    expect(page).not_to have_selector(:xpath, "//a[contains(text(), 'Previous')]//following-sibling::span[contains(text(),'page')]")
+    expect(page).to have_selector(
+      :xpath,
+      (
+        "//a[contains(text(), 'Next')]//following-sibling::span[contains(text(),'page')]"
+        "|"
+        "//nav//ul//li//a//span[contains(text(), 'Next page')]"
+      )
+    )
+    expect(page).not_to have_selector(
+      :xpath,
+      (
+        "//a[contains(text(), 'Previous')]//following-sibling::span[contains(text(),'page')]"
+        "|"
+        "//nav//ul//li//a//span[contains(text(), 'Previous page')]"
+      )
+    )
   elsif pagination_available == 'not available'
-    expect(page).not_to have_selector(:xpath, "//a[contains(text(), 'Next')]//following-sibling::span[contains(text(),'page')]")
-    expect(page).not_to have_selector(:xpath, "//a[contains(text(), 'Previous')]//following-sibling::span[contains(text(),'page')]")
+    expect(page).not_to have_selector(
+      :xpath,
+      (
+        "//a[contains(text(), 'Next')]//following-sibling::span[contains(text(),'page')]"
+        "|"
+        "//nav//ul//li//a//span[contains(text(), 'Next page')]"
+      )
+    )
+    expect(page).not_to have_selector(
+      :xpath,
+      (
+        "//a[contains(text(), 'Previous')]//following-sibling::span[contains(text(),'page')]"
+        "|"
+        "//nav//ul//li//a//span[contains(text(), 'Previous page')]"
+      )
+    )
   end
 end

--- a/features/step_definitions/supplieraz_steps.rb
+++ b/features/step_definitions/supplieraz_steps.rb
@@ -78,8 +78,8 @@ Then(/I am taken to page '(.*)' of results$/) do |page_number|
       expect(page).to have_selector(
         :xpath,
         (
-          "//a[contains(text(), 'Previous')]//following-sibling::span[contains(text(),'page')]"
-          "|"
+          "//a[contains(text(), 'Previous')]//following-sibling::span[contains(text(),'page')]" \
+          "|" \
           "//nav//ul//li//a//span[contains(text(), 'Previous page')]"
         )
       )
@@ -87,16 +87,16 @@ Then(/I am taken to page '(.*)' of results$/) do |page_number|
       expect(page).to have_selector(
         :xpath,
         (
-          "//a[contains(text(), 'Next')]//following-sibling::span[contains(text(),'page')]"
-          "|"
+          "//a[contains(text(), 'Next')]//following-sibling::span[contains(text(),'page')]" \
+          "|" \
           "//nav//ul//li//a//span[contains(text(), 'Next page')]"
         )
       )
       expect(page).not_to have_selector(
         :xpath,
         (
-          "//a[contains(text(), 'Previous')]//following-sibling::span[contains(text(),'page')]"
-          "|"
+          "//a[contains(text(), 'Previous')]//following-sibling::span[contains(text(),'page')]" \
+          "|" \
           "//nav//ul//li//a//span[contains(text(), 'Previous page')]"
         )
       )
@@ -117,16 +117,16 @@ Then(/pagination is '(.*)'$/) do |availability|
     expect(page).to have_selector(
       :xpath,
       (
-        "//a[contains(text(), 'Next')]//following-sibling::span[contains(text(),'page')]"
-        "|"
+        "//a[contains(text(), 'Next')]//following-sibling::span[contains(text(),'page')]" \
+        "|" \
         "//nav//ul//li//a//span[contains(text(), 'Next page')]"
       )
     )
     expect(page).not_to have_selector(
       :xpath,
       (
-        "//a[contains(text(), 'Previous')]//following-sibling::span[contains(text(),'page')]"
-        "|"
+        "//a[contains(text(), 'Previous')]//following-sibling::span[contains(text(),'page')]" \
+        "|" \
         "//nav//ul//li//a//span[contains(text(), 'Previous page')]"
       )
     )
@@ -134,16 +134,16 @@ Then(/pagination is '(.*)'$/) do |availability|
     expect(page).not_to have_selector(
       :xpath,
       (
-        "//a[contains(text(), 'Next')]//following-sibling::span[contains(text(),'page')]"
-        "|"
+        "//a[contains(text(), 'Next')]//following-sibling::span[contains(text(),'page')]" \
+        "|" \
         "//nav//ul//li//a//span[contains(text(), 'Next page')]"
       )
     )
     expect(page).not_to have_selector(
       :xpath,
       (
-        "//a[contains(text(), 'Previous')]//following-sibling::span[contains(text(),'page')]"
-        "|"
+        "//a[contains(text(), 'Previous')]//following-sibling::span[contains(text(),'page')]" \
+        "|" \
         "//nav//ul//li//a//span[contains(text(), 'Previous page')]"
       )
     )

--- a/features/step_definitions/supplieraz_steps.rb
+++ b/features/step_definitions/supplieraz_steps.rb
@@ -77,28 +77,22 @@ Then(/I am taken to page '(.*)' of results$/) do |page_number|
     if page_number >= '2'
       expect(page).to have_selector(
         :xpath,
-        (
-          "//a[contains(text(), 'Previous')]//following-sibling::span[contains(text(),'page')]" \
-          "|" \
-          "//nav//ul//li//a//span[contains(text(), 'Previous page')]"
-        )
+        "//a[contains(text(), 'Previous')]//following-sibling::span[contains(text(),'page')]" \
+        "|" \
+        "//nav//ul//li//a//span[contains(text(), 'Previous page')]"
       )
     elsif page_number < '2'
       expect(page).to have_selector(
         :xpath,
-        (
-          "//a[contains(text(), 'Next')]//following-sibling::span[contains(text(),'page')]" \
-          "|" \
-          "//nav//ul//li//a//span[contains(text(), 'Next page')]"
-        )
+        "//a[contains(text(), 'Next')]//following-sibling::span[contains(text(),'page')]" \
+        "|" \
+        "//nav//ul//li//a//span[contains(text(), 'Next page')]"
       )
       expect(page).not_to have_selector(
         :xpath,
-        (
-          "//a[contains(text(), 'Previous')]//following-sibling::span[contains(text(),'page')]" \
-          "|" \
-          "//nav//ul//li//a//span[contains(text(), 'Previous page')]"
-        )
+        "//a[contains(text(), 'Previous')]//following-sibling::span[contains(text(),'page')]" \
+        "|" \
+        "//nav//ul//li//a//span[contains(text(), 'Previous page')]"
       )
     end
   end
@@ -116,36 +110,28 @@ Then(/pagination is '(.*)'$/) do |availability|
   if pagination_available == 'available'
     expect(page).to have_selector(
       :xpath,
-      (
-        "//a[contains(text(), 'Next')]//following-sibling::span[contains(text(),'page')]" \
-        "|" \
-        "//nav//ul//li//a//span[contains(text(), 'Next page')]"
-      )
+      "//a[contains(text(), 'Next')]//following-sibling::span[contains(text(),'page')]" \
+      "|" \
+      "//nav//ul//li//a//span[contains(text(), 'Next page')]"
     )
     expect(page).not_to have_selector(
       :xpath,
-      (
-        "//a[contains(text(), 'Previous')]//following-sibling::span[contains(text(),'page')]" \
-        "|" \
-        "//nav//ul//li//a//span[contains(text(), 'Previous page')]"
-      )
+      "//a[contains(text(), 'Previous')]//following-sibling::span[contains(text(),'page')]" \
+      "|" \
+      "//nav//ul//li//a//span[contains(text(), 'Previous page')]"
     )
   elsif pagination_available == 'not available'
     expect(page).not_to have_selector(
       :xpath,
-      (
-        "//a[contains(text(), 'Next')]//following-sibling::span[contains(text(),'page')]" \
-        "|" \
-        "//nav//ul//li//a//span[contains(text(), 'Next page')]"
-      )
+      "//a[contains(text(), 'Next')]//following-sibling::span[contains(text(),'page')]" \
+      "|" \
+      "//nav//ul//li//a//span[contains(text(), 'Next page')]"
     )
     expect(page).not_to have_selector(
       :xpath,
-      (
-        "//a[contains(text(), 'Previous')]//following-sibling::span[contains(text(),'page')]" \
-        "|" \
-        "//nav//ul//li//a//span[contains(text(), 'Previous page')]"
-      )
+      "//a[contains(text(), 'Previous')]//following-sibling::span[contains(text(),'page')]" \
+      "|" \
+      "//nav//ul//li//a//span[contains(text(), 'Previous page')]"
     )
   end
 end


### PR DESCRIPTION
https://trello.com/c/d1wSRrnT/179-2-use-govuk-style-for-previous-and-next-links-on-search-results-page

Once the search pages changes are all released, we can get rid of these extra cases.