### PR TITLE
Get the framework tests working for DOS 5

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "gemset.nix",
     "lines": null
   },
-  "generated_at": "2020-09-04T16:35:30Z",
+  "generated_at": "2020-10-08T13:26:31Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -108,7 +108,7 @@
         "hashed_secret": "4b3f840cf98d51f9fb96b68466a5a1fe78a4ab5e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 430,
+        "line_number": 434,
         "type": "Secret Keyword"
       }
     ]

--- a/features/step_definitions/framework_application_steps.rb
+++ b/features/step_definitions/framework_application_steps.rb
@@ -160,3 +160,8 @@ Then "I see confirmation that I have removed that draft service" do
   service_name = normalize_whitespace(@existing_service['serviceName'])
   step "I see a success banner message containing '#{service_name} was removed'"
 end
+
+Then "I have submitted services for each lot" do
+  lot_count = @framework['lots'].length
+  step "I see '#{lot_count} services' text on the page"
+end

--- a/features/step_definitions/framework_application_steps.rb
+++ b/features/step_definitions/framework_application_steps.rb
@@ -112,6 +112,20 @@ Then /^I click the link to view and add services from the previous framework/ do
   step "I visit the /suppliers/frameworks/#{framework_slug}/submissions/#{lot_slug}/previous-services page"
 end
 
+# Some suppliers have multiple services with the same name. Delete all existing
+# drafts with the same name as the service we want to add to avoid later
+# trouble finding links.
+Then 'I remove existing drafts with the same name' do
+  loop do
+    draft_services_with_same_name = page.all(:xpath, "//a[contains(text(), \"#{normalize_whitespace(@existing_service['serviceName'])}\")]")
+    break if draft_services_with_same_name.empty?
+
+    draft_services_with_same_name.first.click
+    step "I click the 'Remove draft service' button"
+    step "I see 'Are you sure you want to remove this' text on the page"
+    step "I click the 'Yes, remove' button"
+  end
+end
 
 Then /^I am on #{MAYBE_VAR} page for that lot$/ do |page_title|
   page_title.sub! "lot", @existing_service['lotName'].downcase

--- a/features/step_definitions/framework_application_steps.rb
+++ b/features/step_definitions/framework_application_steps.rb
@@ -99,8 +99,8 @@ end
 
 
 Then 'I click on the lot link for the existing service' do
-  lot_name = @existing_service['lotName']
-  lot_link = page.all(:xpath, "//div[@class='govuk-grid-column-two-thirds framework-lots-table']//a[text()='#{lot_name}']")
+  lotSlug = @existing_service['lotSlug']
+  lot_link = page.all(:xpath, "//div[@class='govuk-grid-column-two-thirds framework-lots-table']//a[contains(@href, '#{lotSlug}')]")
   lot_link[0].click
 end
 

--- a/features/step_definitions/framework_application_steps.rb
+++ b/features/step_definitions/framework_application_steps.rb
@@ -127,6 +127,12 @@ Then 'I remove existing drafts with the same name' do
   end
 end
 
+When 'I ensure I am on the services page' do
+  if ! page.all(:xpath, "//a[contains(text(), 'Back to services')]").empty?
+    step "I click 'Back to services'"
+  end
+end
+
 Then /^I am on #{MAYBE_VAR} page for that lot$/ do |page_title|
   page_title.sub! "lot", @existing_service['lotName'].downcase
   step "I am on the '#{page_title}' page"

--- a/features/step_definitions/supplier_steps.rb
+++ b/features/step_definitions/supplier_steps.rb
@@ -98,7 +98,8 @@ end
 
 
 Given 'I have a supplier with a copyable service' do
-  @supplier = get_supplier_with_copyable_service(@framework)
+  lot_with_no_limit = @framework['lots'].select { |lot| lot["oneServiceLimit"] == false }.first
+  @supplier = get_supplier_with_copyable_service(@framework, lot = lot_with_no_limit['slug'])
   puts "supplier id: #{@supplier['id']}"
 end
 

--- a/features/supplier/supplier_applies_to_a_framework.feature
+++ b/features/supplier/supplier_applies_to_a_framework.feature
@@ -32,7 +32,7 @@ Scenario: Supplier submits a framework application
   When I click 'Add, edit and complete services'
   Then I am on the 'Your framework services' page for that framework application
   Then I submit a service for each lot
-  And I see '1 service will be submitted' or '1 lab will be submitted' text on the page
+  And I see '1 service will be submitted' or '1 research studio will be submitted' text on the page
   And I click 'Back to framework application' link for that framework application
 
   Then I am on the 'Apply to framework' page for that framework application

--- a/features/supplier/supplier_applies_to_a_framework.feature
+++ b/features/supplier/supplier_applies_to_a_framework.feature
@@ -96,7 +96,7 @@ Scenario: Supplier copies a service from a previous framework
   Then I am on the draft service page
 
   When I click the 'Remove draft service' button
-  Then I see 'Are you sure you want to remove this service?' text on the page
+  Then I see 'Are you sure you want to remove this' text on the page
   When I click the 'Yes, remove' button
   Then I see confirmation that I have removed that draft service
   Then I don't see that service in the Draft services section

--- a/features/supplier/supplier_applies_to_a_framework.feature
+++ b/features/supplier/supplier_applies_to_a_framework.feature
@@ -37,7 +37,7 @@ Scenario: Supplier submits a framework application
 
   Then I am on the 'Apply to framework' page for that framework application
   And I see 'Your application is complete and will be submitted automatically' text on the page
-  And I see '3 services' text on the page
+  And I have submitted services for each lot
 
 Scenario: Supplier re-uses a declaration
   Given I have a supplier with a reusable declaration

--- a/features/supplier/supplier_applies_to_a_framework.feature
+++ b/features/supplier/supplier_applies_to_a_framework.feature
@@ -78,6 +78,7 @@ Scenario: Supplier copies a service from a previous framework
   When I click 'Add, edit and complete services'
   Then I am on the 'Your framework services' page for that framework application
   Then I click on the lot link for the existing service
+  And I remove existing drafts with the same name
   And I click the link to view and add services from the previous framework
   Then I am on the 'Previous lot services' page for that lot
   And I see the existing service in the copyable services table

--- a/features/supplier/supplier_applies_to_a_framework.feature
+++ b/features/supplier/supplier_applies_to_a_framework.feature
@@ -1,4 +1,4 @@
-@skip @supplier @supplier-framework-application
+@supplier @supplier-framework-application
 Feature: Apply to an open framework
 
 Background:

--- a/features/supplier/supplier_applies_to_a_framework.feature
+++ b/features/supplier/supplier_applies_to_a_framework.feature
@@ -86,12 +86,12 @@ Scenario: Supplier copies a service from a previous framework
   When I click the 'Add' button for the existing service
   Then I see 'You'll need to review it before it can be completed.' text on the page
 
-  When I click 'Back to services'
+  When I ensure I am on the services page
   Then I see that service in the Draft services section
   When I click the link to view and add services from the previous framework
   Then I don't see the existing service in the copyable services table
 
-  When I click 'Back to services'
+  When I ensure I am on the services page
   And I click the link to edit the newly copied service
   Then I am on the draft service page
 

--- a/features/support/api_helpers.rb
+++ b/features/support/api_helpers.rb
@@ -404,7 +404,7 @@ def get_frameworks
   all_frameworks = JSON.parse(frameworks_from_api.body)['frameworks']
 end
 
-def get_a_service(status, framework_type = "g-cloud", must_be_copyable = false)
+def get_a_service(status, framework_type = "g-cloud", must_be_copyable = false, lot_slug = nil)
   all_frameworks = get_frameworks
   suitable_framework_slugs = []
   all_frameworks.each do |framework|
@@ -413,6 +413,10 @@ def get_a_service(status, framework_type = "g-cloud", must_be_copyable = false)
     end
   end
   params = { status: status, framework: suitable_framework_slugs[0] }
+  if !lot_slug.nil?
+    params['lot'] = lot_slug
+  end
+
   services_from_api = call_api(:get, '/services', params: params)
   service_list = JSON.parse(services_from_api.body)['services']
 
@@ -604,8 +608,8 @@ def get_supplier_with_reusable_declaration
   JSON.parse(call_api(:get, "/suppliers/#{supplier_framework['supplierId']}").body)['suppliers']
 end
 
-def get_supplier_with_copyable_service(framework)
-  @existing_service = get_a_service("published", framework['family'], must_be_copyable = true)
+def get_supplier_with_copyable_service(framework, lot_slug = nil)
+  @existing_service = get_a_service("published", framework['family'], must_be_copyable = true, lot_slug = lot_slug)
   puts "Service name: #{@existing_service['serviceName']}"
   puts "Service ID: #{@existing_service['id']}"
   puts "Lot name: #{@existing_service['lotName']}"


### PR DESCRIPTION
Trello: https://trello.com/c/eLi7y2wX/423-update-functional-tests-if-necessary

We're soon going to be opening DOS 5, so it would be good to have automated tests to warn us if we inadvertently break the application journey.

These tests were last updated for G12, and did not work for DOS5. I've updated them so that they should now pass for DOS5 - see individual commits for details. I don't think I've made any changes that would break these tests for G12/3.

I've tested that these work locally. I re-ran the tests multiple times to test against a broad range of suppliers.