### PR TITLE
Add functional test for lot limited to one service

### DIFF
--- a/features/step_definitions/supplier_steps.rb
+++ b/features/step_definitions/supplier_steps.rb
@@ -96,10 +96,20 @@ Given 'I have a supplier with a reusable declaration' do
   puts "supplier id: #{@supplier['id']}"
 end
 
+Given 'I have a lot which accepts multiple services' do
+  @lot = @framework['lots'].find { |lot| lot["oneServiceLimit"] == false }
+end
+
+Given 'I have a lot limited to a single service' do
+  @lot = @framework['lots'].find { |lot| lot["oneServiceLimit"] }
+  # This sort of lot does not exist on g-cloud
+  unless @lot
+    skip_this_scenario
+  end
+end
 
 Given 'I have a supplier with a copyable service' do
-  lot_with_no_limit = @framework['lots'].select { |lot| lot["oneServiceLimit"] == false }.first
-  @supplier = get_supplier_with_copyable_service(@framework, lot = lot_with_no_limit['slug'])
+  @supplier = get_supplier_with_copyable_service(@framework, lot_slug = @lot['slug'])
   puts "supplier id: #{@supplier['id']}"
 end
 

--- a/features/supplier/supplier_applies_to_a_framework.feature
+++ b/features/supplier/supplier_applies_to_a_framework.feature
@@ -65,7 +65,8 @@ Scenario: Supplier re-uses a declaration
   # at time of writing we redact so much data from the test datasets as to make this infeasible. revisit this.
 
 Scenario: Supplier copies a service from a previous framework
-  Given I have a supplier with a copyable service
+  Given I have a lot which accepts multiple services
+  And I have a supplier with a copyable service
   And that supplier has a user with:
     |active|true|
   And that supplier has begun the application process for that framework
@@ -103,3 +104,32 @@ Scenario: Supplier copies a service from a previous framework
   When I click the link to view and add services from the previous framework
   Then I am on the 'Previous lot services' page for that lot
   And I see the existing service in the copyable services table
+
+Scenario: Supplier copies a service for a lot limited to one service from a previous framework
+  Given I have a lot limited to a single service
+  And I have a supplier with a copyable service
+  And that supplier has a user with:
+    |active|true|
+  And that supplier has begun the application process for that framework
+  And that supplier has confirmed their company details for that application
+  And that supplier is logged in
+  When I visit the /suppliers page
+  And I click 'Continue your application'
+  Then I am on the 'Apply to framework' page for that framework application
+
+  When I click 'Add, edit and complete services'
+  Then I am on the 'Your framework services' page for that framework application
+  
+  When I click on the lot link for the existing service
+  Then I see 'Do you want to reuse your previous' text on the page
+
+  When I choose the 'Yes' radio button
+  And I click the 'Save and continue' button
+  Then I am on the draft service page
+
+  When I click the 'Remove draft service' button
+  Then I see 'Are you sure you want to remove' text on the page
+
+  When I click the 'Yes, remove' button
+  Then I see confirmation that I have removed that draft service
+  And I am on the 'Your framework services' page for that framework application


### PR DESCRIPTION
Trello: https://trello.com/c/sF5d314l/475-2-improve-dos5-tests-for-framework-applications

In DOS, some services are limited to one service per lot (oneServiceLimit). These lots are not tested by the current tests, which only test lots with multiple services. Add a new test for these lots that will be skipped for frameworks that don't have these lots (i.e. g-cloud).