### PR TITLE
Handle multiple services with the same name

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "gemset.nix",
     "lines": null
   },
-  "generated_at": "2020-10-08T13:26:31Z",
+  "generated_at": "2020-10-20T16:49:54Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/features/step_definitions/framework_application_steps.rb
+++ b/features/step_definitions/framework_application_steps.rb
@@ -112,21 +112,6 @@ Then /^I click the link to view and add services from the previous framework/ do
   step "I visit the /suppliers/frameworks/#{framework_slug}/submissions/#{lot_slug}/previous-services page"
 end
 
-# Some suppliers have multiple services with the same name. Delete all existing
-# drafts with the same name as the service we want to add to avoid later
-# trouble finding links.
-Then 'I remove existing drafts with the same name' do
-  loop do
-    draft_services_with_same_name = page.all(:xpath, "//a[contains(text(), \"#{normalize_whitespace(@existing_service['serviceName'])}\")]")
-    break if draft_services_with_same_name.empty?
-
-    draft_services_with_same_name.first.click
-    step "I click the 'Remove draft service' button"
-    step "I see 'Are you sure you want to remove this' text on the page"
-    step "I click the 'Yes, remove' button"
-  end
-end
-
 When 'I ensure I am on the services page' do
   if ! page.all(:xpath, "//a[contains(text(), 'Back to services')]").empty?
     step "I click 'Back to services'"
@@ -155,20 +140,22 @@ Then "I click the 'Add' button for the existing service" do
   button_analytics_label = "ID: #{@existing_service['id']}"
   button = page.all(:xpath, "//form//button[@data-analytics-label='#{button_analytics_label}']")[0]
   button.click
+
+  new_service = get_draft_service_copied_from(@existing_service, @framework['slug'])
+  @new_service_href = "/suppliers/frameworks/#{@framework['slug']}/submissions/#{new_service['lotSlug']}/#{new_service['id']}"
 end
 
 Then /^I( don't)? see that service in the Draft services section$/ do |negate|
   service_name = normalize_whitespace(@existing_service['serviceName'])
   if negate
-    expect(page).not_to have_link(service_name)
+    expect(page).not_to have_link(service_name, href: @new_service_href)
   else
-    expect(page).to have_link(service_name)
+    expect(page).to have_link(service_name, href: @new_service_href)
   end
 end
 
 Then "I click the link to edit the newly copied service" do
-  service_name = normalize_whitespace(@existing_service['serviceName'])
-  step "I click the '#{service_name}' link"
+  find_link(href: @new_service_href).click
 end
 
 Then "I am on the draft service page" do

--- a/features/supplier/supplier_applies_to_a_framework.feature
+++ b/features/supplier/supplier_applies_to_a_framework.feature
@@ -78,7 +78,6 @@ Scenario: Supplier copies a service from a previous framework
   When I click 'Add, edit and complete services'
   Then I am on the 'Your framework services' page for that framework application
   Then I click on the lot link for the existing service
-  And I remove existing drafts with the same name
   And I click the link to view and add services from the previous framework
   Then I am on the 'Previous lot services' page for that lot
   And I see the existing service in the copyable services table

--- a/features/support/api_helpers.rb
+++ b/features/support/api_helpers.rb
@@ -636,3 +636,18 @@ def set_supplier_framework_prefill_declaration(supplier_id, framework_slug, from
   )
   expect(response.code).to eq(200), response.body
 end
+
+def get_draft_service_copied_from(old_service, framework_slug)
+  response = call_api(
+    :get,
+    "/draft-services",
+    params: {
+      supplier_id: old_service['supplierId'],
+      framework: framework_slug,
+    },
+  )
+
+  expect(response.code).to eq(200), response.body
+  all_services = JSON.parse(response.body)["services"]
+  all_services.find { |s| s['copiedFromServiceId'] == old_service['id'] }
+end


### PR DESCRIPTION
Trello: https://trello.com/c/sF5d314l/475-2-improve-dos5-tests-for-framework-applications

A DOS supplier has multiple services with the same name. This broke a test which assumed that service names were unique for a supplier. We worked around this by deleting the services with the same name during setup (https://github.com/alphagov/digitalmarketplace-functional-tests/pull/809).

Be more discriminating about service links by getting the service ID so we can construct the href. This allows us to remove the hack and means this test now passes again for suppliers with multiple services with the same name without needing to delete them all.