### PR TITLE
Test submitting a copied service

### DIFF
--- a/features/step_definitions/framework_application_steps.rb
+++ b/features/step_definitions/framework_application_steps.rb
@@ -55,6 +55,12 @@ Then(/^I submit a service for each lot$/) do
   end
 end
 
+Then("I submit a copied service") do
+  answer_all_dos_lot_questions "Edit"
+  answer_all_service_questions "Add"
+  first(:button, "Mark as complete").click
+end
+
 And(/^I fill in all the missing details$/) do
   answer_all_service_questions "Answer required"
 end
@@ -145,12 +151,11 @@ Then "I click the 'Add' button for the existing service" do
   @new_service_href = "/suppliers/frameworks/#{@framework['slug']}/submissions/#{new_service['lotSlug']}/#{new_service['id']}"
 end
 
-Then /^I( don't)? see that service in the Draft services section$/ do |negate|
-  service_name = normalize_whitespace(@existing_service['serviceName'])
+Then(/^I( don't)? see that service in the Draft services section$/) do |negate|
   if negate
-    expect(page).not_to have_link(service_name, href: @new_service_href)
+    expect(page).not_to have_link(href: @new_service_href)
   else
-    expect(page).to have_link(service_name, href: @new_service_href)
+    expect(page).to have_link(href: @new_service_href)
   end
 end
 

--- a/features/step_definitions/supplier_steps.rb
+++ b/features/step_definitions/supplier_steps.rb
@@ -97,11 +97,11 @@ Given 'I have a supplier with a reusable declaration' do
 end
 
 Given 'I have a lot which accepts multiple services' do
-  @lot = @framework['lots'].find { |lot| lot["oneServiceLimit"] == false }
+  @lot = @framework['lots'].filter { |lot| lot["oneServiceLimit"] == false }.sample
 end
 
 Given 'I have a lot limited to a single service' do
-  @lot = @framework['lots'].find { |lot| lot["oneServiceLimit"] }
+  @lot = @framework['lots'].filter { |lot| lot["oneServiceLimit"] }.sample
   # This sort of lot does not exist on g-cloud
   unless @lot
     skip_this_scenario

--- a/features/supplier/supplier_applies_to_a_framework.feature
+++ b/features/supplier/supplier_applies_to_a_framework.feature
@@ -95,11 +95,17 @@ Scenario: Supplier copies a service from a previous framework
   And I click the link to edit the newly copied service
   Then I am on the draft service page
 
-  When I click the 'Remove draft service' button
+  When I submit a copied service
+  Then I see 'was marked as complete' text on the page
+
+  When I ensure I am on the services page
+  And I click the link to edit the newly copied service
+  And I click the 'Remove draft service' button
   Then I see 'Are you sure you want to remove this' text on the page
+
   When I click the 'Yes, remove' button
-  Then I see confirmation that I have removed that draft service
-  Then I don't see that service in the Draft services section
+  Then I see a success banner message containing 'was removed'
+  And I don't see that service in the Draft services section
 
   When I click the link to view and add services from the previous framework
   Then I am on the 'Previous lot services' page for that lot
@@ -127,7 +133,11 @@ Scenario: Supplier copies a service for a lot limited to one service from a prev
   And I click the 'Save and continue' button
   Then I am on the draft service page
 
-  When I click the 'Remove draft service' button
+  When I submit a copied service
+  Then I see 'was marked as complete' text on the page
+
+  When I click on the lot link for the existing service
+  And I click the 'Remove draft service' button
   Then I see 'Are you sure you want to remove' text on the page
 
   When I click the 'Yes, remove' button


### PR DESCRIPTION
Trello: https://trello.com/c/sF5d314l/475-2-improve-dos5-tests-for-framework-applications

For DOS 5, we introduced a bug that broke services that were copied from previous frameworks. This bug only showed up if you tried to complete your copied service for submission, so did not show up in our automated tests. So complete the copied service and mark it as complete during the test.

Also use `sample` so we don't use the same lot for every run of the test.