### PR TITLE
Add save a new search page to direct award steps

### DIFF
--- a/features/buyer/buyer_dashboard.feature
+++ b/features/buyer/buyer_dashboard.feature
@@ -1,6 +1,9 @@
 @buyer @buyer-dashboard
 Feature: Buyer Dashboard
 
+Background:
+  Given I have the latest live g-cloud framework
+
 Scenario: Users should see new Dashboard
   Given I am logged in as a buyer user
   And I visit the /buyers page

--- a/features/buyer/tell_us_about_contract.feature
+++ b/features/buyer/tell_us_about_contract.feature
@@ -1,6 +1,9 @@
 @buyer @direct-award
 Feature: Direct Award flows
 
+Background:
+  Given I have the latest live g-cloud framework
+
 Scenario: Unauthenticated user can save a search after logging in
   Given I have an existing buyer user
   And I visit the /g-cloud/search page

--- a/features/buyer/tell_us_about_contract.feature
+++ b/features/buyer/tell_us_about_contract.feature
@@ -12,6 +12,8 @@ Scenario: Unauthenticated user can save a search after logging in
   Then I see the 'Log out' link
   Then I am on the 'Save your search' page
   And I choose the 'Save a new search' radio button
+  And I click 'Save and continue'
+  Then I am on the 'Save a new search' page
   And I enter 'my cloud project' in the 'Name your search' field
   And I click 'Save and continue'
   Then I am on the 'my cloud project' page
@@ -21,6 +23,9 @@ Scenario: User can save a search
   And I visit the /g-cloud/search page
   And I click 'Save your search'
   Then I am on the 'Save your search' page
+  And I choose the 'Save a new search' radio button
+  And I click 'Save and continue'
+  Then I am on the 'Save a new search' page
   And I enter 'my cloud project' in the 'Name your search' field
   And I click 'Save and continue'
   Then I am on the 'my cloud project' page
@@ -32,6 +37,8 @@ Scenario: User with saved searches completes new saved search
   And I click 'Save your search'
   Then I am on the 'Save your search' page
   And I choose the 'Save a new search' radio button
+  And I click 'Save and continue'
+  Then I am on the 'Save a new search' page
   And I enter 'my cloud project2' in the 'Name your search' field
   And I click 'Save and continue'
   Then I am on the 'my cloud project2' page

--- a/features/buyer/tell_us_about_contract.feature
+++ b/features/buyer/tell_us_about_contract.feature
@@ -4,6 +4,23 @@ Feature: Direct Award flows
 Background:
   Given I have the latest live g-cloud framework
 
+@skip-local @skip-preview
+Scenario: Unauthenticated user can save a search after logging in
+  Given I have an existing buyer user
+  And I visit the /g-cloud/search page
+  And I click 'Save your search'
+  Then I am on the 'Log in to the Digital Marketplace' page
+  When I enter that user.emailAddress in the 'Email address' field
+  And I enter that user.password in the 'Password' field
+  And I click the 'Log in' button
+  Then I see the 'Log out' link
+  Then I am on the 'Save your search' page
+  And I choose the 'Save a new search' radio button
+  And I enter 'my cloud project' in the 'Name your search' field
+  And I click 'Save and continue'
+  Then I am on the 'my cloud project' page
+
+@skip-staging
 Scenario: Unauthenticated user can save a search after logging in
   Given I have an existing buyer user
   And I visit the /g-cloud/search page
@@ -21,6 +38,17 @@ Scenario: Unauthenticated user can save a search after logging in
   And I click 'Save and continue'
   Then I am on the 'my cloud project' page
 
+@skip-local @skip-preview
+Scenario: User can save a search
+  Given I am logged in as a buyer user
+  And I visit the /g-cloud/search page
+  And I click 'Save your search'
+  Then I am on the 'Save your search' page
+  And I enter 'my cloud project' in the 'Name your search' field
+  And I click 'Save and continue'
+  Then I am on the 'my cloud project' page
+
+@skip-staging
 Scenario: User can save a search
   Given I am logged in as a buyer user
   And I visit the /g-cloud/search page
@@ -33,6 +61,19 @@ Scenario: User can save a search
   And I click 'Save and continue'
   Then I am on the 'my cloud project' page
 
+@skip-local @skip-preview
+Scenario: User with saved searches completes new saved search
+  Given I am logged in as a buyer user
+  And I have created and saved a search called 'my cloud project'
+  And I visit the /g-cloud/search page
+  And I click 'Save your search'
+  Then I am on the 'Save your search' page
+  And I choose the 'Save a new search' radio button
+  And I enter 'my cloud project2' in the 'Name your search' field
+  And I click 'Save and continue'
+  Then I am on the 'my cloud project2' page
+
+@skip-staging
 Scenario: User with saved searches completes new saved search
   Given I am logged in as a buyer user
   And I have created and saved a search called 'my cloud project'

--- a/features/step_definitions/direct_award_steps.rb
+++ b/features/step_definitions/direct_award_steps.rb
@@ -1,19 +1,16 @@
 When (/^I have created and saved a search called '(.*)'$/) do |search_name|
-  case search_name
-    when 'my cloud project', 'my cloud project - existing'
-      steps "Given I visit the /g-cloud/search?q=email+analysis+provider+system page"
-    when 'export limit test project'
-      steps "Given I visit the /g-cloud/search?q=cloud+software+nhs page"
+  @project = get_direct_award_project(@user, search_name)
+  if not @project
+    case search_name
+      when 'my cloud project', 'my cloud project - existing'
+        search_query = "q=email+analysis+provider+system"
+      when 'export limit test project'
+        search_query = "q=cloud+software+nhs"
+    end
+    @project = create_direct_award_project(@user, search_name, search_query)
   end
-  steps %{
-    And I click 'Save your search'
-    Then I am on the 'Save your search' page
-    And I choose the 'Save a new search' radio button
-    And I click 'Save and continue'
-    Then I am on the 'Save a new search' page
-    And I enter '#{search_name}' in the 'Name your search' field
-    And I click 'Save and continue'
-  }
+  puts "#{@framework['name']} project: #{@project['id']}"
+  steps "Given I visit the /buyers/direct-award/g-cloud/projects/#{@project['id']} page"
 end
 
 When (/^I am ready to tell the outcome for the '(.*)' saved search$/) do |search_name|

--- a/features/step_definitions/direct_award_steps.rb
+++ b/features/step_definitions/direct_award_steps.rb
@@ -8,6 +8,9 @@ When (/^I have created and saved a search called '(.*)'$/) do |search_name|
   steps %{
     And I click 'Save your search'
     Then I am on the 'Save your search' page
+    And I choose the 'Save a new search' radio button
+    And I click 'Save and continue'
+    Then I am on the 'Save a new search' page
     And I enter '#{search_name}' in the 'Name your search' field
     And I click 'Save and continue'
   }


### PR DESCRIPTION
https://trello.com/c/UQtUlH0n/207-2-replace-radios-with-govuk-frontend-radios-component-in-search-g-cloud-services-journey

Adds the new page in the save a search Direct Award journey to the functional tests:
https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/1097