### PR TITLE
Add new .app-search-summary classes

### DIFF
--- a/features/step_definitions/catalogue_steps.rb
+++ b/features/step_definitions/catalogue_steps.rb
@@ -47,7 +47,7 @@ Then (/^I continue clicking #{MAYBE_VAR} until I see that service in the search 
 end
 
 Then(/^I see #{MAYBE_VAR} in the search summary text$/) do |value|
-  expect(find(:xpath, "//*[@class='search-summary']").text).to include(normalize_whitespace(value))
+  expect(find(:css, ".app-search-summary, .search-summary").text).to include(normalize_whitespace(value))
 end
 
 Then (/^I note the number of search results$/) do

--- a/features/step_definitions/opportunities_steps.rb
+++ b/features/step_definitions/opportunities_steps.rb
@@ -12,7 +12,7 @@ When(/^I click a random result in the list of opportunity results returned$/) do
 end
 
 When(/^I note the result_count$/) do
-  @result_count = page.first(:css, ".search-summary-count").text.to_i
+  @result_count = page.first(:css, ".app-search-summary__count, .search-summary-count").text.to_i
   puts "Noted result_count: #{@result_count}"
 end
 
@@ -22,7 +22,7 @@ end
 
 Then (/^I see that the stated number of results (does not exceed|equals|is no fewer than) that (\w+)$/) do |comparison_string, variable_name|
   var_val = instance_variable_get("@#{variable_name}")
-  @new_result_count = page.first(:css, ".search-summary-count").text.to_i
+  @new_result_count = page.first(:css, ".app-search-summary__count, .search-summary-count").text.to_i
   puts "Number of results: #{@new_result_count}"
   if comparison_string == "does not exceed"
     expect(@new_result_count).to be <= var_val
@@ -56,7 +56,7 @@ Then (/^I see all the opportunities on the page are of the '(.*)' status$/) do |
 end
 
 Then (/^I see no results$/) do
-  expect(page.first(:css, ".search-summary-count").text.to_i).to eq(0)
+  expect(page.first(:css, ".app-search-summary__count, .search-summary-count").text.to_i).to eq(0)
   expect(page).to have_selector(:css, '.search-result', count: 0)
 end
 

--- a/features/support/catalogue_helpers.rb
+++ b/features/support/catalogue_helpers.rb
@@ -1,6 +1,6 @@
 module CatalogueHelpers
   def self.get_service_count(page)
-    page.find(:xpath, "//*[@class='search-summary-count']").text.to_i
+    page.find(:css, ".app-search-summary__count, .search-summary-count").text.to_i
   end
 
   def self.get_page_count(page)


### PR DESCRIPTION
https://trello.com/c/nGmcQJg6/206-1-replace-notice-panel-with-govuk-frontend-inset-text-component-in-buyer-frontend

As part of the above ticket, we replaced `search-summary` classes with `app-search-summary`, so we need to account for both in the tests.

We can remove the original classes once we've deployed.