### PR TITLE
Fix functional tests on preview

### DIFF
--- a/features/admin/company_details.feature
+++ b/features/admin/company_details.feature
@@ -33,9 +33,7 @@ Scenario Outline: Correct admin roles can view a supplier's details
     | Company registration number  | 87654321                             |
     | DUNS Number                  | <ANY>                                |
     | Address                      | 14 Duke Street Dublin H3 LY5 Ireland |
-  And I see an entry in the 'Frameworks' table with:
-    | field       | link1         | link2           |
-    | G-Cloud 12  | View services | View agreements |
+  And I see the framework the supplier is on in the 'Frameworks' table
   When I click the 'Users' link
   Then I am on the 'DM Functional Test Supplier - Company details feature' page
   And I see an entry in the 'Users' table with:

--- a/features/step_definitions/admin_steps.rb
+++ b/features/step_definitions/admin_steps.rb
@@ -36,3 +36,14 @@ Then "I am on that service's page" do
   step "I am on the '#{service_name}' page"
   puts "Service name: #{service_name}"
 end
+
+Then "I see the framework the supplier is on in the 'Frameworks' table" do
+  expected_row = [@framework['name'], "View services", "View agreements"]
+  table_rows = get_table_rows_by_caption('Frameworks')
+
+  match = table_rows.find do |row|
+    expected_row == row.all('td').map { |td| td.text }
+  end
+
+  expect(match).not_to be_nil, "Expected: #{expected_row.join(' | ')}"
+end


### PR DESCRIPTION
We've reopened G12 on preview for UCD work, this PR fixes the functional tests so that we no longer need to hardcode any framework names or slugs in the admin company details tests.