### PR TITLE
Replace flash messages in brief responses and supplier frontends

### DIFF
--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -257,6 +257,10 @@ Then /^I see a (success|error|notice) flash message containing #{MAYBE_VAR}$/ do
   expect(flash_message).to have_content(message)
 end
 
+Then /^I don't see a flash message$/ do
+  expect(page).not_to have_selector(:css, ".dm-alert")
+end
+
 # the rescue is used because if a banner cannot be found the function throws an exception and does not look for the other option
 Then /^I see a (success|warning|destructive|temporary-message) banner message containing #{MAYBE_VAR}$/ do |status, message|
   begin

--- a/features/step_definitions/framework_application_steps.rb
+++ b/features/step_definitions/framework_application_steps.rb
@@ -175,7 +175,7 @@ end
 
 Then "I see confirmation that I have removed that draft service" do
   service_name = normalize_whitespace(@existing_service['serviceName'])
-  step "I see a success banner message containing '#{service_name} was removed'"
+  step "I see a success flash message containing '#{service_name} was removed'"
 end
 
 Then "I have submitted services for each lot" do

--- a/features/supplier/subscribe_mailing_list.feature
+++ b/features/supplier/subscribe_mailing_list.feature
@@ -10,7 +10,7 @@ Background:
   Then I am on the 'Become a supplier' page
   And I click 'Get notifications when applications are opening'
   Then I am on the 'Sign up for Digital Marketplace email alerts' page
-  And I don't see a banner message
+  And I don't see a flash message
 
 @requires-credentials @mailchimp
 Scenario: Successful mailing-list subscription from the home page
@@ -25,7 +25,7 @@ Scenario: Initially-rejected mailing-list subscription
   When I enter 'example@example.com' in the 'email_address' field
   And I click 'Subscribe'
   Then I am on the 'Sign up for Digital Marketplace email alerts' page
-  And I see a destructive banner message containing 'This email address cannot be used to sign up for Digital Marketplace alerts. Please use a different email address or contact cloud_digital@crowncommercial.gov.uk'
+  And I see a error flash message containing 'This email address cannot be used to sign up for Digital Marketplace alerts. Please use a different email address or contact cloud_digital@crowncommercial.gov.uk'
   # but this page should still be a valid, working form
   And I see 'example@example.com' as the value of the 'email_address' field
   When I enter 'functional-test-email@user.marketplace.team' in the 'email_address' field

--- a/features/supplier/supplier_account.feature
+++ b/features/supplier/supplier_account.feature
@@ -179,7 +179,7 @@ Scenario: Supplier user can add and remove contributors
   Given I have a random email address
   When I enter that email_address in the 'email_address' field
   And I click 'Send invite'
-  Then I see a success banner message containing 'Contributor invited'
+  Then I see a success flash message containing 'Contributor invited'
 
   Given I receive a 'create-user-account' email for that email_address
   When I click the link in that email
@@ -196,7 +196,7 @@ Scenario: Supplier user can add and remove contributors
   And I see 'that email_address' text on the page
 
   When I click 'Remove'
-  Then I see a success banner message containing 'has been removed as a contributor.'
+  Then I see a success flash message containing 'has been removed as a contributor.'
 
   Given I visit the /suppliers page
   When I click 'Contributors'

--- a/features/supplier/supplier_applies_for_an_opportunity.feature
+++ b/features/supplier/supplier_applies_for_an_opportunity.feature
@@ -101,7 +101,7 @@ Scenario: Supplier applies for a digital-specialists brief
 
   When I click 'Submit application'
   Then I am on the 'What happens next' page
-  And I see a success banner message containing 'Your application has been submitted.'
+  And I see a success flash message containing 'Your application has been submitted.'
 
 
 Scenario: Supplier applies for a digital-outcomes brief
@@ -158,7 +158,7 @@ Scenario: Supplier applies for a digital-outcomes brief
 
   When I click 'Submit application'
   Then I am on the 'What happens next' page
-  And I see a success banner message containing 'Your application has been submitted.'
+  And I see a success flash message containing 'Your application has been submitted.'
 
 
 Scenario: Supplier applies for a user-research-participants brief
@@ -217,7 +217,7 @@ Scenario: Supplier applies for a user-research-participants brief
 
   When I click 'Submit application'
   Then I am on the 'What happens next' page
-  And I see a success banner message containing 'Your application has been submitted.'
+  And I see a success flash message containing 'Your application has been submitted.'
 
 
 Scenario: Previous page links are used during response flow and existing data is replayed
@@ -327,7 +327,7 @@ Scenario: Supplier changes their answers before submission
   And I see 'Once you submit you can update your application until' text on the page
   When I click 'Submit application'
   Then I am on the 'What happens next' page
-  And I see a success banner message containing 'Your application has been submitted.'
+  And I see a success flash message containing 'Your application has been submitted.'
 
   When I click the 'View your account' link
   And I click the 'View your opportunities' link
@@ -421,7 +421,7 @@ Scenario: Supplier asks a clarification question
   Then I am on the 'Ask a question about ‘Tea drinker’' page
   And I enter 'How do I ask a question?' in the 'clarification_question' field
   And I click 'Ask question'
-  Then I see a success banner message containing 'Your question has been sent.'
+  Then I see a success flash message containing 'Your question has been sent.'
 
 Scenario: Supplier can see sign framework agreement call to action
   Given that supplier has applied to be on that framework

--- a/features/supplier/supplier_applies_to_a_framework.feature
+++ b/features/supplier/supplier_applies_to_a_framework.feature
@@ -104,7 +104,7 @@ Scenario: Supplier copies a service from a previous framework
   Then I see 'Are you sure you want to remove this' text on the page
 
   When I click the 'Yes, remove' button
-  Then I see a success banner message containing 'was removed'
+  Then I see a success flash message containing 'was removed'
   And I don't see that service in the Draft services section
 
   When I click the link to view and add services from the previous framework

--- a/features/supplier/view_and_edit_g_cloud_services.feature
+++ b/features/supplier/view_and_edit_g_cloud_services.feature
@@ -26,7 +26,7 @@ Scenario: Supplier user can edit the name of a service
   And I enter 'Changed cloud support service' in the 'serviceName' field
   And I click 'Save and return'
   Then I am on the 'Changed cloud support service' page
-  And I see a success banner message containing 'You’ve edited your service. The changes are now live on the Digital Marketplace.'
+  And I see a success flash message containing 'You’ve edited your service. The changes are now live on the Digital Marketplace.'
   And that service has unacknowledged update audit events
   # tidy up
   Then I ensure that all update audit events for that service are acknowledged
@@ -40,7 +40,7 @@ Scenario: Supplier user can edit the description of a service
   And I enter 'This is an updated description' in the 'serviceDescription' field
   And I click 'Save and return'
   Then I am on that service.serviceName page
-  And I see a success banner message containing 'You’ve edited your service. The changes are now live on the Digital Marketplace.'
+  And I see a success flash message containing 'You’ve edited your service. The changes are now live on the Digital Marketplace.'
   And I see the 'About your service' summary table filled with:
     | field                        | value                          |
     | Service description          | This is an updated description |
@@ -58,7 +58,7 @@ Scenario: Supplier user can edit the features and benefits of a service
   And I enter 'Updated Benefit 2' in the 'input-serviceBenefits-2' field
   And I click 'Save and return'
   Then I am on that service.serviceName page
-  And I see a success banner message containing 'You’ve edited your service. The changes are now live on the Digital Marketplace.'
+  And I see a success flash message containing 'You’ve edited your service. The changes are now live on the Digital Marketplace.'
   And I see the 'Service features and benefits' summary table filled with:
     | field                         | value                                                                                  |
     | Service features and benefits | Service features Feature 1 New Feature 2 Service benefits Benefit 1 Updated Benefit 2  |
@@ -73,7 +73,7 @@ Scenario: Supplier user can replace the service definition document
   And I choose file 'test.pdf' for the field 'serviceDefinitionDocumentURL'
   And I click 'Save and return'
   Then I am on that service.serviceName page
-  And I see a success banner message containing 'You’ve edited your service. The changes are now live on the Digital Marketplace.'
+  And I see a success flash message containing 'You’ve edited your service. The changes are now live on the Digital Marketplace.'
   And that service has unacknowledged update audit events
   # tidy up
   Then I ensure that all update audit events for that service are acknowledged
@@ -103,7 +103,7 @@ Scenario: Supplier can remove their G-Cloud service from the marketplace
   Then I see a destructive banner message containing 'Are you sure you want to remove your service?'
 
   When I click 'Remove service'
-  Then I see a success banner message containing 'Test cloud support service has been removed.'
+  Then I see a success flash message containing 'Test cloud support service has been removed.'
 
   When I click that service.serviceName
   Then I see a temporary-message banner message containing 'This service was removed'


### PR DESCRIPTION
Changes to support alphagov/digitalmarketplace-supplier-frontend#1293 and alphagov/digitalmarketplace-brief-responses-frontend#246.

I've tested this locally against local and preview.