### PR TITLE
Add test cases for govuk-frontend errors on Brief Responses

### DIFF
--- a/features/step_definitions/brief_response_steps.rb
+++ b/features/step_definitions/brief_response_steps.rb
@@ -76,7 +76,7 @@ Then /^I visit the '(.*)' question page for that brief response$/ do |question|
 end
 
 Then /^I see '(.*)' replayed in the question advice$/ do |replayed_info|
-  expect(page).to have_xpath("//span[@class='question-advice']/p", text: replayed_info)
+  expect(page).to have_xpath("//span[@class='question-advice']/p | //p[@class='govuk-body']", text: replayed_info)
 end
 
 Then /^I am on the '(.*)' page with brief '(.*)'/ do |str, brief_attribute|

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -467,7 +467,7 @@ Then /^I see the '(.*)' (radio button|checkbox) is (not |)checked(?: for the '(.
     elem_type = 'radio'
   end
   if question
-    within(:xpath, "//span[normalize-space(text())=\"#{question}\"]/../..") do
+    within(:xpath, "//span[normalize-space(text())=\"#{question}\"]/../.. | //legend[normalize-space(text())=\"#{question}\"]/..") do
       if negative.empty?
         expect(first_field(elem_name, type: elem_type)).to be_checked
       else


### PR DESCRIPTION
https://trello.com/c/13tOvxuu/285-2-replace-content-loader-form-macros-in-brief-responses-frontend

We've replaced most of the Brief Response journey with govuk-frontend components.

However, we've left some toolkit components in place (specifically the `pricing` type and the `niceToHaveRequirements` question).

This PR makes both of these cases pass.

https://github.com/alphagov/digitalmarketplace-brief-responses-frontend/pull/245