### PR TITLE
Fix brief responses summary table captions

### DIFF
--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -457,7 +457,7 @@ Then /^I see an entry in the '(.*)' table with:$/ do |table_heading, table|
 end
 
 
-Then /^I see the closing date of the brief in the '(.*)' summary table$/ do |table_heading|
+Then /^I see the closing date of the brief in the '(.*)' (summary )?table$/ do |table_heading|
   closing_date = DateTime.strptime(@brief['createdAt'], '%Y-%m-%dT%H:%M:%S') + 14
   step "I see '#{closing_date.strftime('%A %-d %B %Y')}' in the '#{table_heading}' summary table"
 end

--- a/features/supplier/supplier_applies_for_an_opportunity.feature
+++ b/features/supplier/supplier_applies_for_an_opportunity.feature
@@ -254,6 +254,90 @@ Scenario: Previous page links are used during response flow and existing data is
   And I don't see the 'Back to previous page' link
 
 
+@skip-preview
+Scenario: Supplier changes their answers before submission
+  Given that supplier has applied to be on that framework
+  And we accepted that suppliers application to the framework
+  And that supplier has returned a signed framework agreement for the framework
+  And that supplier has a service on the digital-specialists lot
+  And I have a live digital-specialists brief
+  And that supplier has filled in their response to that brief but not submitted it
+  And I go to that brief page
+  And I click 'Apply for this opportunity'
+  Then I am on the 'Before you start' page
+
+  When I click 'Continue application'
+  Then I am on the 'When is the earliest the specialist can start work?' page
+  And I see 'The buyer needs the specialist to start: Saturday 31 December 2016' replayed in the question advice
+  And I see '27/12/17' as the value of the 'availability' field
+
+  When I enter '28/09/17' in the 'availability' field
+  And I click 'Save and continue'
+  Then I am on the 'What’s the specialist’s day rate?' page
+  And I see '£200' replayed in the question advice
+  And I see '200' as the value of the 'dayRate' field
+
+  When I enter '100' in the 'dayRate' field
+  And I click 'Save and continue'
+  Then I am on the 'Do you have all the essential skills and experience?' page
+
+  When I click 'Save and continue'
+  Then I am on the 'Give evidence of the essential skills and experience' page
+  And I see 'first evidence' as the value of the 'Boil kettle' field
+  And I see 'second evidence' as the value of the 'Taste tea' field
+  And I see 'third evidence' as the value of the 'Wash mug' field
+  And I see 'fourth evidence' as the value of the 'Dry mug' field
+
+  When I enter 'Flick the switch' in the 'Boil kettle' field
+  And I enter 'Drink the tea' in the 'Taste tea' field
+  And I enter 'Use soap' in the 'Wash mug' field
+  And I click 'Save and continue'
+  Then I am on the 'Do you have any of the nice-to-have skills or experience?' page
+  And I see the 'Yes' radio button is checked for the 'Talk snobbishly about water quality' question
+  And I see 'First nice to have evidence' as the value of the 'Evidence of Talk snobbishly about water quality' field
+  And I see the 'Yes' radio button is checked for the 'Sip quietly' question
+  And I see 'Second nice to have evidence' as the value of the 'Evidence of Sip quietly' field
+  And I see the 'No' radio button is checked for the 'Provide biscuits' question
+  And I do not see the 'Evidence of Provide biscuits' field
+
+  When I choose 'No' radio button for the 'Sip quietly' question
+  And I choose 'Yes' radio button for the 'Provide biscuits' question
+  And I enter 'Only the finest' in the 'Evidence of Provide biscuits' field
+  And I click 'Save and continue'
+  Then I am on the 'Email address the buyer should use to contact you' page
+
+  When I enter 'moustachecup@example.gov.uk' in the 'respondToEmailAddress' field
+  And I click 'Save and continue'
+  Then I am on the 'Check and submit your answers' page
+  And I see the 'Your details' summary table filled with:
+      | field               | value                       |
+      | Day rate            | £100                        |
+      | Earliest start date | 28/09/17                    |
+      | Email address       | moustachecup@example.gov.uk |
+  And I see the 'Your essential skills and experience' summary table filled with:
+      | field       | value            |
+      | Boil kettle | Flick the switch |
+      | Taste tea   | Drink the tea    |
+      | Wash mug    | Use soap         |
+      | Dry mug     | fourth evidence  |
+  And I see the 'Your nice-to-have skills and experience' summary table filled with:
+      | field                               | value |
+      | Talk snobbishly about water quality | First nice to have evidence |
+      | Sip quietly                         |                             |
+      | Provide biscuits                    |  Only the finest            |
+  And I see 'Once you submit you can update your application until' text on the page
+  When I click 'Submit application'
+  Then I am on the 'What happens next' page
+  And I see a success flash message containing 'Your application has been submitted.'
+
+  When I click the 'View your account' link
+  And I click the 'View your opportunities' link
+  Then I see 'Tea drinker' in the 'Completed opportunities' summary table
+  And I see the closing date of the brief in the 'Completed opportunities' summary table
+  And I see 'Submitted' in the 'Completed opportunities' summary table
+
+
+@skip-staging
 Scenario: Supplier changes their answers before submission
   Given that supplier has applied to be on that framework
   And we accepted that suppliers application to the framework
@@ -336,6 +420,53 @@ Scenario: Supplier changes their answers before submission
   And I see 'Submitted' in the 'Applications you’ve made' table
 
 
+@skip-preview
+Scenario: Supplier changes their answers after submission
+  Given that supplier has applied to be on that framework
+  And we accepted that suppliers application to the framework
+  And that supplier has returned a signed framework agreement for the framework
+  And that supplier has a service on the digital-specialists lot
+  And I have a live digital-specialists brief
+  And that supplier has filled in their response to that brief but not submitted it
+  And that supplier submits their response to that brief
+
+  When I click the 'View your account' link
+  And I click the 'View your opportunities' link
+  Then I see 'Tea drinker' in the 'Completed opportunities' summary table
+  And I see the closing date of the brief in the 'Completed opportunities' summary table
+  And I see 'Submitted' in the 'Completed opportunities' summary table
+
+  When I click the 'Tea drinker' link
+  Then I am on the 'Your application for ‘Tea drinker’' page
+  When I click the summary table 'Edit' link for 'Day rate'
+
+  Then I am on the 'What’s the specialist’s day rate?' page
+  And I see '£200' replayed in the question advice
+  And I see '200' as the value of the 'dayRate' field
+
+  When I enter '100' in the 'dayRate' field
+  And I click 'Save and continue'
+  Then I am on the 'Your application for ‘Tea drinker’' page
+  And I see the 'Your details' summary table filled with:
+      | field               | value                |
+      | Day rate            | £100                 |
+
+  And I don't see 'Submit application' text on the page
+  And I don't see 'Once you submit you can update your application until' text on the page
+  And I see 'View the opportunity' text on the page
+
+  When I click the 'View your account' link
+  And I click the 'View your opportunities' link
+  Then I see 'Tea drinker' in the 'Completed opportunities' summary table
+  And I see the closing date of the brief in the 'Completed opportunities' summary table
+  And I see 'Submitted' in the 'Completed opportunities' summary table
+  And I see 'You don’t have any draft applications' text on the page
+
+  When I click the 'Tea drinker' link
+  Then I am on the 'Your application for ‘Tea drinker’' page
+
+
+@skip-staging
 Scenario: Supplier changes their answers after submission
   Given that supplier has applied to be on that framework
   And we accepted that suppliers application to the framework
@@ -381,6 +512,37 @@ Scenario: Supplier changes their answers after submission
   Then I am on the 'Your application for ‘Tea drinker’' page
 
 
+@skip-preview
+Scenario: Supplier can resume incomplete application
+  Given that supplier has applied to be on that framework
+  And we accepted that suppliers application to the framework
+  And that supplier has returned a signed framework agreement for the framework
+  And that supplier has a service on the digital-outcomes lot
+  And I have a live digital-outcomes brief
+  And I go to that brief page
+  And I click 'Apply for this opportunity'
+  Then I am on the 'Before you start' page
+
+  When I click 'Start application'
+  Then I am on the 'When is the earliest the team can start?' page
+  And I see 'The buyer needs the team to start: Thursday 28 September 2017' replayed in the question advice
+
+  When I enter '09/09/17' in the 'availability' field
+  And I click 'Save and continue'
+  Then I am on the 'Do you have all the essential skills and experience?' page
+
+  When I click the 'View your account' link
+  And I click the 'View your opportunities' link
+  Then I see 'Hide and seek ninjas' in the 'Draft opportunities' summary table
+  And I click the 'Complete your application' link
+  Then I am on the 'Before you start' page
+
+  When I click 'Continue application'
+  Then I am on the 'When is the earliest the team can start?' page
+  And I see '09/09/17' as the value of the 'availability' field
+
+
+@skip-staging
 Scenario: Supplier can resume incomplete application
   Given that supplier has applied to be on that framework
   And we accepted that suppliers application to the framework
@@ -443,7 +605,22 @@ Scenario: Supplier can see the link to the opportunities dashboard
   When I click the 'View your account' link
   Then I see the 'View your opportunities' link
 
-@opportunities-dashboard
+
+@opportunities-dashboard @skip-preview
+Scenario: Supplier can see their draft applications on the opportunities dashboard
+  Given that supplier has applied to be on that framework
+  And we accepted that suppliers application to the framework
+  And that supplier has returned a signed framework agreement for the framework
+  And that supplier has a service on the digital-specialists lot
+  And I have a live digital-specialists brief
+  And that supplier has filled in their response to that brief but not submitted it
+  When I click the 'View your account' link
+  And I click the 'View your opportunities' link
+  Then I see 'You haven’t applied to any opportunities' text on the page
+  Then I see 'Tea drinker' in the 'Draft opportunities' summary table
+
+
+@opportunities-dashboard @skip-staging
 Scenario: Supplier can see their draft applications on the opportunities dashboard
   Given that supplier has applied to be on that framework
   And we accepted that suppliers application to the framework

--- a/features/supplier/supplier_applies_for_an_opportunity.feature
+++ b/features/supplier/supplier_applies_for_an_opportunity.feature
@@ -331,9 +331,9 @@ Scenario: Supplier changes their answers before submission
 
   When I click the 'View your account' link
   And I click the 'View your opportunities' link
-  Then I see 'Tea drinker' in the 'Applications you’ve made' summary table
-  And I see the closing date of the brief in the 'Applications you’ve made' summary table
-  And I see 'Submitted' in the 'Applications you’ve made' summary table
+  Then I see 'Tea drinker' in the 'Applications you’ve made' table
+  And I see the closing date of the brief in the 'Applications you’ve made' table
+  And I see 'Submitted' in the 'Applications you’ve made' table
 
 
 Scenario: Supplier changes their answers after submission
@@ -347,9 +347,9 @@ Scenario: Supplier changes their answers after submission
 
   When I click the 'View your account' link
   And I click the 'View your opportunities' link
-  Then I see 'Tea drinker' in the 'Applications you’ve made' summary table
-  And I see the closing date of the brief in the 'Applications you’ve made' summary table
-  And I see 'Submitted' in the 'Applications you’ve made' summary table
+  Then I see 'Tea drinker' in the 'Applications you’ve made' table
+  And I see the closing date of the brief in the 'Applications you’ve made' table
+  And I see 'Submitted' in the 'Applications you’ve made' table
 
   When I click the 'Tea drinker' link
   Then I am on the 'Your application for ‘Tea drinker’' page
@@ -372,9 +372,9 @@ Scenario: Supplier changes their answers after submission
 
   When I click the 'View your account' link
   And I click the 'View your opportunities' link
-  Then I see 'Tea drinker' in the 'Applications you’ve made' summary table
-  And I see the closing date of the brief in the 'Applications you’ve made' summary table
-  And I see 'Submitted' in the 'Applications you’ve made' summary table
+  Then I see 'Tea drinker' in the 'Applications you’ve made' table
+  And I see the closing date of the brief in the 'Applications you’ve made' table
+  And I see 'Submitted' in the 'Applications you’ve made' table
   And I see 'You don’t have any draft applications' text on the page
 
   When I click the 'Tea drinker' link
@@ -401,7 +401,7 @@ Scenario: Supplier can resume incomplete application
 
   When I click the 'View your account' link
   And I click the 'View your opportunities' link
-  Then I see 'Hide and seek ninjas' in the 'Applications you’ve started' summary table
+  Then I see 'Hide and seek ninjas' in the 'Applications you’ve started' table
   And I click the 'Complete your application' link
   Then I am on the 'Before you start' page
 
@@ -454,4 +454,4 @@ Scenario: Supplier can see their draft applications on the opportunities dashboa
   When I click the 'View your account' link
   And I click the 'View your opportunities' link
   Then I see 'You haven’t applied to any opportunities' text on the page
-  Then I see 'Tea drinker' in the 'Applications you’ve started' summary table
+  Then I see 'Tea drinker' in the 'Applications you’ve started' table

--- a/features/supplier/supplier_applies_for_an_opportunity.feature
+++ b/features/supplier/supplier_applies_for_an_opportunity.feature
@@ -331,9 +331,9 @@ Scenario: Supplier changes their answers before submission
 
   When I click the 'View your account' link
   And I click the 'View your opportunities' link
-  Then I see 'Tea drinker' in the 'Completed opportunities' summary table
-  And I see the closing date of the brief in the 'Completed opportunities' summary table
-  And I see 'Submitted' in the 'Completed opportunities' summary table
+  Then I see 'Tea drinker' in the 'Applications you’ve made' summary table
+  And I see the closing date of the brief in the 'Applications you’ve made' summary table
+  And I see 'Submitted' in the 'Applications you’ve made' summary table
 
 
 Scenario: Supplier changes their answers after submission
@@ -347,9 +347,9 @@ Scenario: Supplier changes their answers after submission
 
   When I click the 'View your account' link
   And I click the 'View your opportunities' link
-  Then I see 'Tea drinker' in the 'Completed opportunities' summary table
-  And I see the closing date of the brief in the 'Completed opportunities' summary table
-  And I see 'Submitted' in the 'Completed opportunities' summary table
+  Then I see 'Tea drinker' in the 'Applications you’ve made' summary table
+  And I see the closing date of the brief in the 'Applications you’ve made' summary table
+  And I see 'Submitted' in the 'Applications you’ve made' summary table
 
   When I click the 'Tea drinker' link
   Then I am on the 'Your application for ‘Tea drinker’' page
@@ -372,9 +372,9 @@ Scenario: Supplier changes their answers after submission
 
   When I click the 'View your account' link
   And I click the 'View your opportunities' link
-  Then I see 'Tea drinker' in the 'Completed opportunities' summary table
-  And I see the closing date of the brief in the 'Completed opportunities' summary table
-  And I see 'Submitted' in the 'Completed opportunities' summary table
+  Then I see 'Tea drinker' in the 'Applications you’ve made' summary table
+  And I see the closing date of the brief in the 'Applications you’ve made' summary table
+  And I see 'Submitted' in the 'Applications you’ve made' summary table
   And I see 'You don’t have any draft applications' text on the page
 
   When I click the 'Tea drinker' link
@@ -401,7 +401,7 @@ Scenario: Supplier can resume incomplete application
 
   When I click the 'View your account' link
   And I click the 'View your opportunities' link
-  Then I see 'Hide and seek ninjas' in the 'Draft opportunities' summary table
+  Then I see 'Hide and seek ninjas' in the 'Applications you’ve started' summary table
   And I click the 'Complete your application' link
   Then I am on the 'Before you start' page
 
@@ -454,4 +454,4 @@ Scenario: Supplier can see their draft applications on the opportunities dashboa
   When I click the 'View your account' link
   And I click the 'View your opportunities' link
   Then I see 'You haven’t applied to any opportunities' text on the page
-  Then I see 'Tea drinker' in the 'Draft opportunities' summary table
+  Then I see 'Tea drinker' in the 'Applications you’ve started' summary table


### PR DESCRIPTION
https://trello.com/c/jgoHhWX3/284-3-replace-summary-table-in-opportunities-dashboard-in-brief-responses-frontend

With govukTables, we don't use separate captions and headings for tables, so we no longer use "Draft applications" and "Completed applications" as captions.

This adjusts the tests to target the displayed captions - "Applications you've started" and "Applications you've made".