### PR TITLE
Switch from Travis to Github Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,17 @@
+name: Test
+
+on: [pull_request]
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+    - name: Install dependencies
+      run: bundle install
+    - name: Run linting
+      run: bundle exec rubocop features

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,0 @@
-language: ruby
-before_install:
-  - yes | gem update --system
-  - gem install bundler
-bundler_args: --without development
-script:
-  - rubocop features
-notifications:
-  email: false


### PR DESCRIPTION
Trello: https://trello.com/c/cnNEUjhz/2126-epic-migrate-travis-ci-usages-to-github-actions

Because Travis is now excessively slow.

Based on the starter Ruby workflow (https://github.com/actions/starter-workflows/blob/master/ci/ruby.yml)