### PR TITLE
make test less specific to account for framework variance

### DIFF
--- a/features/step_definitions/supplier_steps.rb
+++ b/features/step_definitions/supplier_steps.rb
@@ -139,6 +139,6 @@ Given(/^I visit the start sign framework agreement page for that framework$/) do
 end
 
 Then(/^I see the sign agreement confirmation page$/) do
-  confirmation_message = "You’ve signed the #{@framework['name']} Framework Agreement"
+  confirmation_message = "You’ve signed the #{@framework['name']}"
   expect(page).to have_selector('h1', text: normalize_whitespace(confirmation_message))
 end

--- a/features/supplier/supplier_signs_framework_agreement.feature
+++ b/features/supplier/supplier_signs_framework_agreement.feature
@@ -14,10 +14,10 @@ Feature: Supplier can sign an agreement electronically
     And I choose 'Yes' radio button
     When I click 'Continue' button
     Then I am on 'Supplier appointment terms' page
-    And I see 'company: DM Functional Test Suppliers Ltd.' within the page's text
+    And I see 'DM Functional Test Suppliers Ltd.' within the page's text
     When I enter 'Jane Doe' in the 'Your full name' field
     And I enter 'Director' in the 'Your role in the company' field
-    And I check 'I accept the terms and conditions of the Framework Agreement' checkbox
-    When I click 'Sign agreement' button
+    And I check 'I accept the terms and conditions' checkbox
+    When I click 'Sign' button
     Then I see the sign agreement confirmation page
 


### PR DESCRIPTION
https://trello.com/c/75hbcRW8/607-3-implement-dos-5-e-signature

Not the most sophisticated of fixes. Makes the test less specific to allow for the variance between G-Cloud and DOS frameworks.