### PR TITLE
Make functional tests work when DOS5 is live on preview

### DIFF
--- a/features/supplier/supplier_applies_for_an_opportunity.feature
+++ b/features/supplier/supplier_applies_for_an_opportunity.feature
@@ -8,6 +8,7 @@ Background:
   And I have a supplier user
   And that supplier is logged in
 
+@skip-preview
 Scenario: Supplier is not eligible as they are not on the framework
   Given I go to that brief page
   And I click 'Apply for this opportunity'
@@ -15,6 +16,7 @@ Scenario: Supplier is not eligible as they are not on the framework
   And I see 'You can’t apply for this opportunity because you’re not a Digital Outcomes and Specialists 4 supplier.' text on the page
   And I see a 'data-reason' attribute with the value 'supplier-not-on-digital-outcomes-and-specialists-4'
 
+@skip-preview
 Scenario: Supplier is not eligible as they are not on the digital-specialists lot
   Given that supplier has applied to be on that framework
   And we accepted that suppliers application to the framework
@@ -26,6 +28,7 @@ Scenario: Supplier is not eligible as they are not on the digital-specialists lo
   And I see 'You can’t apply for this opportunity because you didn’t say you could provide services in this category when you applied to the Digital Outcomes and Specialists 4 framework.' text on the page
   And I see a 'data-reason' attribute with the value 'supplier-not-on-lot'
 
+@skip-preview
 Scenario: Supplier is not eligible as they can not provide the developer role
   Given that supplier has applied to be on that framework
   And we accepted that suppliers application to the framework
@@ -35,6 +38,38 @@ Scenario: Supplier is not eligible as they can not provide the developer role
   And I click 'Apply for this opportunity'
   Then I am on the 'You can’t apply for this opportunity' page
   And I see 'You can’t apply for this opportunity because you didn’t say you could provide this specialist role when you applied to the Digital Outcomes and Specialists 4 framework.' text on the page
+  And I see a 'data-reason' attribute with the value 'supplier-not-on-role'
+
+@skip-staging @skip-local
+  Scenario: Supplier is not eligible as they are not on the framework
+  Given I go to that brief page
+  And I click 'Apply for this opportunity'
+  Then I am on the 'You can’t apply for this opportunity' page
+  And I see 'You can’t apply for this opportunity because you’re not a Digital Outcomes and Specialists 5 supplier.' text on the page
+  And I see a 'data-reason' attribute with the value 'supplier-not-on-digital-outcomes-and-specialists-5'
+
+@skip-staging @skip-local
+Scenario: Supplier is not eligible as they are not on the digital-specialists lot
+  Given that supplier has applied to be on that framework
+  And we accepted that suppliers application to the framework
+  And that supplier has returned a signed framework agreement for the framework
+  And that supplier has a service on the digital-outcomes lot
+  And I go to that brief page
+  And I click 'Apply for this opportunity'
+  Then I am on the 'You can’t apply for this opportunity' page
+  And I see 'You can’t apply for this opportunity because you didn’t say you could provide services in this category when you applied to the Digital Outcomes and Specialists 5 framework.' text on the page
+  And I see a 'data-reason' attribute with the value 'supplier-not-on-lot'
+
+@skip-staging @skip-local
+Scenario: Supplier is not eligible as they can not provide the developer role
+  Given that supplier has applied to be on that framework
+  And we accepted that suppliers application to the framework
+  And that supplier has returned a signed framework agreement for the framework
+  And that supplier has a service on the digital-specialists lot for the designer role
+  And I go to that brief page
+  And I click 'Apply for this opportunity'
+  Then I am on the 'You can’t apply for this opportunity' page
+  And I see 'You can’t apply for this opportunity because you didn’t say you could provide this specialist role when you applied to the Digital Outcomes and Specialists 5 framework.' text on the page
   And I see a 'data-reason' attribute with the value 'supplier-not-on-role'
 
 @skip-local @skip-preview

--- a/features/support/fixtures.rb
+++ b/features/support/fixtures.rb
@@ -9,7 +9,6 @@ module Fixtures
       lot: 'digital-specialists',
       developerLocations: %w[London Scotland],
       developerPriceMax: "200",
-      developerPriceMin: "100",
       bespokeSystemInformation: true,
       dataProtocols: true,
       helpGovernmentImproveServices: true,

--- a/features/support/fixtures.rb
+++ b/features/support/fixtures.rb
@@ -9,6 +9,7 @@ module Fixtures
       lot: 'digital-specialists',
       developerLocations: %w[London Scotland],
       developerPriceMax: "200",
+      accessibleApplicationsOutcomes: true,
       bespokeSystemInformation: true,
       dataProtocols: true,
       helpGovernmentImproveServices: true,
@@ -49,6 +50,7 @@ module Fixtures
       helpGovernmentImproveServices: true,
       locations: %w[London Scotland],
       openStandardsPrinciples: true,
+      accessibleApplicationsOutcomes: true,
     }
   end
 


### PR DESCRIPTION
Preview has DOS5 live while all other environments have DOS4 live and DOS4 in standstill. Copy the scenarios which look for a specific DOS framework name and update them for DOS5. Also remove developerPriceMin from DOS service fixture, as it's no longer a field in DOS5.

These new scenarios are only run on preview, and the existing ones are skipped on preview. This means the functional tests should pass on all environments.

Once DOS5 is live on all environments we can remove the duplicate tests as well as the DOS4 only features.