### PR TITLE
Fix user research studio test for DOS5

### DIFF
--- a/features/supplier/view_and_edit_dos_services.feature
+++ b/features/supplier/view_and_edit_dos_services.feature
@@ -9,6 +9,7 @@ Background:
   And we accepted that suppliers application to the framework
   And that supplier has returned a signed framework agreement for the framework
 
+@skip-preview
 Scenario Outline: Supplier coming from dashboard to view the detail page for one of their services
   Given that supplier has a service on the <lot_slug> lot
   And I visit the /suppliers page
@@ -28,3 +29,24 @@ Scenario Outline: Supplier coming from dashboard to view the detail page for one
     | digital-outcomes           | Digital outcomes           | Team capabilities           | Agile coaching   |
     | user-research-participants | User research participants | Recruitment approach        | Entirely offline |
     | user-research-studios      | GDSvieux Innovation Lab    | Lab address                 | GDSbury          |
+
+@skip-staging @skip-local
+Scenario Outline: Supplier coming from dashboard to view the detail page for one of their services
+  Given that supplier has a service on the <lot_slug> lot
+  And I visit the /suppliers page
+# The following step only works by virtue of there only being a single service for this supplier - multiple services on
+# multiple frameworks will cause multiple "View services" links to be present
+  When I click 'View services'
+  Then I see the page's h1 ends in 'services'
+  When I click '<service_name>'
+  Then I am on the '<service_name>' page
+  And I don't see the 'Edit' link
+  And I don't see 'Remove this service' text on the page
+  And I see '<expected_content>' in the '<summary_table_name>' summary table
+
+  Examples:
+    | lot_slug                   | service_name               | summary_table_name          | expected_content |
+    | digital-specialists        | Digital specialists        | Individual specialist roles | Developer        |
+    | digital-outcomes           | Digital outcomes           | Team capabilities           | Agile coaching   |
+    | user-research-participants | User research participants | Recruitment approach        | Entirely offline |
+    | user-research-studios      | GDSvieux Innovation Lab    | Research studio address     | GDSbury          |

--- a/features/support/api_helpers.rb
+++ b/features/support/api_helpers.rb
@@ -368,7 +368,11 @@ def create_live_service(framework_slug, lot_slug, supplier_id, role = nil)
     when 'user-research-participants'
       service_data['services'] = Fixtures.user_research_participants_service
     when 'user-research-studios'
-      service_data['services'] = Fixtures.user_research_studios_service
+      if framework_slug == 'digital-outcomes-and-specialists-5'
+        service_data['services'] = Fixtures.user_research_studios_service_dos5
+      else
+        service_data['services'] = Fixtures.user_research_studios_service
+      end
     when 'cloud-support'
       service_data['services'] = Fixtures.cloud_support_service
     else

--- a/features/support/fixtures.rb
+++ b/features/support/fixtures.rb
@@ -121,6 +121,37 @@ module Fixtures
     }
   end
 
+  def self.user_research_studios_service_dos5
+    {
+      # `nil` values should be updated within the step when this fixture is used
+      frameworkSlug: nil,
+      id: nil,
+      labAccessibility: "Access is via steps and no hearing loops are present",
+      labAddressBuilding: "The Great Briefs by Whitechapel, Marketplace Street",
+      labAddressPostcode: "GDS20 5DM",
+      labAddressTown: "GDSbury",
+      labBabyChanging: false,
+      labCarPark: "Local public parking provided",
+      labDesktopStreaming: "Yes, for an additional cost",
+      labDeviceStreaming: "Yes, for an additional cost",
+      labEyeTracking: "Yes, for an additional cost",
+      labHosting: "Yes, included as standard",
+      labPriceMin: "949",
+      labPublicTransport: "Regular bus services provided to local populations such as Gloucester and Cheltenham in addition to train stations",
+      labSize: "25",
+      labStreaming: "Yes, for an additional cost",
+      labTechAssistance: "Yes, for an additional cost",
+      labTimeMin: "8 hours",
+      labToilets: true,
+      labViewingArea: "No",
+      labWaitingArea: "Yes, included as standard",
+      labWiFi: true,
+      lot: 'user-research-studios',
+      serviceName: "GDSvieux Innovation Lab",
+      supplierId: nil
+    }
+  end
+
   def self.digital_specialists_brief
     {
       # `nil` values should be updated within the step when this fixture is used


### PR DESCRIPTION
In DOS5 some of the table names and expected answers have changed for responses to a user research studio brief. 

Add a new fixture with the expected answers and split the test for preview (DOS5 live) and staging (DOS4 live).