### PR TITLE
Change tracking pageview step to be more specific

### DIFF
--- a/features/step_definitions/cookies_steps.rb
+++ b/features/step_definitions/cookies_steps.rb
@@ -39,10 +39,10 @@ And(/^a tracking pageview (has been|has not been) fired(?: with (.+@.+) redacted
       expect(google_analytics_request_with_param('[email]')).not_to be_nil
       expect(google_analytics_request_with_param(email)).to be_nil
     else
-      expect(google_analytics_requests).not_to be_empty
+      expect(google_analytics_request_with_param('t=pageview')).not_to be_nil
     end
   else
-    # Should be no requests sent to the GA domain
-    expect(google_analytics_requests).to be_empty
+    # Should be no track pageview requests sent to the GA domain
+    expect(google_analytics_request_with_param('t=pageview')).to be_nil
   end
 end


### PR DESCRIPTION
https://trello.com/c/ygYf9Whg/2162-functional-tests-are-failing-analytics-opt-out-tests-on-preview-and-staging

GOV.UK may send hit-only data to Google Analytics (see alphagov/frontend#2536), we need to update our tests to reflect this.

Thanks @karlbaker02 for helping triage and fix this.