### PR TITLE
Remove flaky test step

### DIFF
--- a/features/buyer/tell_us_about_contract.feature
+++ b/features/buyer/tell_us_about_contract.feature
@@ -131,7 +131,6 @@ Scenario: User confirms understanding how to assess services
   And I see the 'Award a contract' instruction list item status showing as 'Cannot start yet'
   When I click the 'Confirm you have read and understood how to assess services' button
   Then I am on the 'my cloud project' page
-  And I see a success flash message containing 'You’ve confirmed that you have read and understood how to assess services.'
   And I see the 'Start assessing services' instruction list item status showing as 'Completed'
 
 Scenario: User awards contract


### PR DESCRIPTION
We've had this test step fail a couple of times (https://ci.marketplace.team/job/functional-tests-staging/2334/ and https://ci.marketplace.team/job/functional-tests-preview/23034/). The flash does work - I've confirmed it manually. It's just that the test is inconsistent at detecting it.

These spurious test failures mean that this test step is now providing negative value. So let's get rid of it.