### PR TITLE
Fix choose radio step for govuk-frontend

### DIFF
--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -184,7 +184,7 @@ end
 
 When /I choose #{MAYBE_VAR} radio button(?: for the '(.*)' question)?$/ do |radio_label, question|
   if question
-    within(:xpath, "//span[normalize-space(text())='#{question}']/../..") do
+    within("fieldset", text: question) do
       choose_radio(radio_label, wait: false)
     end
   else


### PR DESCRIPTION
Ticket: https://trello.com/c/cMtAeSL2/764-3-add-support-for-conditionally-revealing-content-to-dmcontentgovukfronted

We need to be able to choose radio inputs for both govuk-frontend and frontend toolkit components. This commit works because both have a fieldset around the whole shebang.

This should fix the failure in https://ci.marketplace.team/job/functional-tests-preview/23057/functional_20test_20report/, I've tested it against both preview and staging (the `supplier_applies_for_an_opportunity` feature only).