### PR TITLE
use esignature boolean rather than hardcoded heuristic

### DIFF
--- a/features/step_definitions/supplier_steps.rb
+++ b/features/step_definitions/supplier_steps.rb
@@ -117,9 +117,7 @@ Given /^I have the latest live or standstill e-signature framework$/ do
   response = call_api(:get, "/frameworks")
   expect(response.code).to eq(200), _error(response, "Failed getting frameworks")
   frameworks = JSON.parse(response.body)['frameworks']
-  # we use frameworkLiveAtUTC as a proxy to detect g-cloud-12 or later frameworks which support e-signature
-  # TODO: Is there a more robust way to detect e-signature supporting frameworks?
-  live_or_standstill_e_signature_frameworks = frameworks.select { |f| (f['status'] == 'live' || f['status'] == 'standstill') && Date.parse(f['frameworkLiveAtUTC']) >= Date.parse('2020-09-28') }
+  live_or_standstill_e_signature_frameworks = frameworks.select { |f| (f['status'] == 'live' || f['status'] == 'standstill') && f['isESignatureSupported'] }
   if live_or_standstill_e_signature_frameworks.empty?
     puts 'SKIPPING as there are no live or standstill e-signature frameworks'
     skip_this_scenario


### PR DESCRIPTION
https://trello.com/c/qmUdpw9u/656-1-e-signature-cleanup-use-api-boolean-to-check-frameworks
address TODO: update step to use esignature boolean rather than hardcoded heuristic