### PR TITLE
Make it simpler and more robust to get a supplier

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "gemset.nix",
     "lines": null
   },
-  "generated_at": "2020-12-18T08:50:53Z",
+  "generated_at": "2021-02-26T17:55:41Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"
@@ -108,7 +108,7 @@
         "hashed_secret": "4b3f840cf98d51f9fb96b68466a5a1fe78a4ab5e",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 434,
+        "line_number": 448,
         "type": "Secret Keyword"
       }
     ]

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -57,7 +57,8 @@ Given /^I have a supplier$/ do
 end
 
 Given /^I have a supplier with:$/ do |table|
-  @supplier = get_or_create_supplier(table.rows_hash)
+  supplier_data = table.rows_hash
+  @supplier = get_or_create_supplier_with_data(supplier_data.fetch("name"), supplier_data)
   puts "supplier id: #{@supplier['id']}"
 end
 


### PR DESCRIPTION
https://trello.com/c/iDOSq28L/2180-fix-tests-that-use-i-have-a-supplier-with-step

Previously, we would get the supplier by id/name/registered name and assume it had the right data, or create it with the right data.

This caused problems because it was possible for the system to be in a state where the supplier the test got had the wrong data for the test. Also, no tests get supplier by ID.

So simplify the helper by removing the ability to get by ID.

Also make it more robust by always doing an update to ensure that the supplier we got/created has the data we expect.