### PR TITLE
Change DUNS validation scenarios to always run

### DIFF
--- a/features/supplier/supplier_creation.feature
+++ b/features/supplier/supplier_creation.feature
@@ -1,11 +1,10 @@
 @smoulder-tests @supplier @supplier-creation
 Feature: User steps through supplier account creation process
 
-Background:
-  Given There is at least one framework that can be applied to
-
 Scenario: Create new supplier account (without duns flow) - summary lists
-  Given I visit the homepage
+  Given There is at least one framework that can be applied to
+  When I visit the homepage
+
   When I click 'Become a supplier'
   Then I am on the 'Become a supplier' page
 
@@ -63,7 +62,8 @@ Scenario: Create new supplier account (without duns flow) - summary lists
   # with DUNS number 000000001 and the test will never pass again.
 
 Scenario: Create new supplier account (with duns flow) - summary lists
-  Given I visit the homepage
+  Given There is at least one framework that can be applied to
+  When I visit the homepage
   When I click 'Become a supplier'
   And I click 'Create a supplier account'
   And I click 'Start'


### PR DESCRIPTION
Ticket: https://trello.com/c/52Xz6MJM/2184-users-are-able-to-create-supplier-accounts-with-invalid-duns-numbers

Scenarios which check our integration with the D&B DUNS service will now run even if no framework is open.

I think this is better because I think it would be good to know of any issues as soon as possible.

Scenarios which test the whole supplier application journey will still only run when a framework is open; just because it seemed overkill to me to run the whole thing every hour when it's not critical.