### PR TITLE
Fix supplier applies to a framework feature

### DIFF
--- a/features/step_definitions/framework_application_steps.rb
+++ b/features/step_definitions/framework_application_steps.rb
@@ -180,5 +180,5 @@ end
 
 Then "I have submitted services for each lot" do
   lot_count = @framework['lots'].length
-  step "I see '#{lot_count} services' text on the page"
+  step "I see '#{lot_count} SERVICES' text on the page"
 end

--- a/features/supplier/supplier_applies_to_a_framework.feature
+++ b/features/supplier/supplier_applies_to_a_framework.feature
@@ -16,7 +16,7 @@ Scenario: Supplier submits a framework application
   And I fill in all the missing details
   And I click 'Save and confirm'
   Then I am on the 'Apply to framework' page for that framework application
-  And I see 'Done' text on the page
+  And I see 'COMPLETED' text on the page
 
   When I click 'Make your supplier declaration'
   Then I am on the 'Make your supplier declaration' page
@@ -27,7 +27,7 @@ Scenario: Supplier submits a framework application
   When I follow the first 'Edit' link and answer all questions on that page and those following until I'm back on the 'Your declaration overview' page
   Then I click 'Make declaration' button
   And I am on the 'Apply to framework' page for that framework application
-  And I see 'Done' text on the page
+  And I see 'COMPLETED' text on the page
 
   When I click 'Add, edit and complete services'
   Then I am on the 'Your framework services' page for that framework application

--- a/features/support/form_helpers.rb
+++ b/features/support/form_helpers.rb
@@ -460,7 +460,8 @@ module FormHelper
   end
 
   def is_there_validation_header?
-    # Remove after all frontends use the validation mastheads from the toolkit (probably safe to remove any time after July 2018)
-    find_elements_by_xpath("//h1").length > 1 || find_elements_by_xpath("//h2[@class='validation-masthead-heading']").length > 0
+    # TODO: this can be simplified once all frontends are using govuk-frontend error summary component
+    # (not gonna put a date on that)
+    find_elements_by_xpath("//h2[@class='validation-masthead-heading'] | //div[contains(@class, 'govuk-error-summary')]").length > 0
   end
 end


### PR DESCRIPTION
Ticket https://trello.com/c/rsndMO72/2186-functional-tests-fail-when-framework-is-open-for-applications

Tested locally with DOS5 open (and DOS4 live) for applications and `make run ARGS="features/supplier/supplier_applies_to_a_framework.feature"`.