### PR TITLE
Change Declaration Overview Edit links xpath

### DIFF
--- a/features/step_definitions/framework_application_steps.rb
+++ b/features/step_definitions/framework_application_steps.rb
@@ -13,7 +13,8 @@ Then /^I click #{MAYBE_VAR} link for that framework application$/ do |link_title
 end
 
 Then(/^I follow the first 'Edit' link and answer all questions on that page and those following until I'm (?:back )?on #{MAYBE_VAR} page$/) do |terminating_page_name|
-  edit_links = page.all(:xpath, "//p[@class='summary-item-top-level-action']/a[text()='Edit']")
+  # TODO: We can remove the first branch of xpath when we've deployed the Declaration Overview changes
+  edit_links = page.all(:xpath, "//p[@class='summary-item-top-level-action']/a[text()='Edit'] | //div[@class='dm-section-action-link']/a[contains(text(),'Edit')]")
   edit_links[0].click
   page_name = nil
   until page.all(:xpath, "//h1")[0].text == terminating_page_name


### PR DESCRIPTION
https://trello.com/c/IzTERgai/857-2-replace-your-declaration-overview-summary-table-with-govuk-summary-list

The Declaration overview page now uses a govukSummaryList, so we need to target the right classes.

See: https://github.com/alphagov/digitalmarketplace-supplier-frontend/pull/1375

To test this change, set a framework to 'open' and the previous framework in that family to 'live'.