### PR TITLE
Make the editing company details scenario more robust

### DIFF
--- a/features/admin/company_details_edit.feature
+++ b/features/admin/company_details_edit.feature
@@ -37,9 +37,9 @@ Scenario: Admin CCS Data Controller can edit a supplier's details
   And I see the 'Company details for supplier account' summary table filled with:
     | field                        | value                                           |
     | Company registered name      | We Have Edited These Company Details Ltd.       |
-    | Company registration number  | 87654321                                        |
+    | Company registration number  | <ANY>                                           |
     | DUNS Number                  | <ANY>                                           |
-    | Address                      | 14 Duke Street Dublin H3 LY5 Ireland            |
+    | Address                      | <ANY>                                           |
 
   When I click the summary table 'Change' link for 'Company registration number'
   Then I am on the 'Update registered company number for ‘DM Functional Test Supplier - Edit company details feature’' page
@@ -51,7 +51,7 @@ Scenario: Admin CCS Data Controller can edit a supplier's details
     | Company registered name      | We Have Edited These Company Details Ltd.       |
     | Company registration number  | 12345678                                        |
     | DUNS Number                  | <ANY>                                           |
-    | Address                      | 14 Duke Street Dublin H3 LY5 Ireland            |
+    | Address                      | <ANY>                                           |
 
   When I click the summary table 'Change' link for 'DUNS Number'
   Then I see 'You need to contact cloud_digital@crowncommercial.gov.uk to change a supplier DUNS number.' text on the page
@@ -76,12 +76,20 @@ Scenario: Admin CCS Data Controller can edit a supplier's details
 
   # Reset details for next test run
   When I click the summary table 'Change' link for 'Company registered name'
-  When I enter 'We Edit Company Details Ltd.' in the 'Registered company name' field and click its associated 'Save' button
-  When I click the summary table 'Change' link for 'Company registration number'
+  And I enter 'We Edit Company Details Ltd.' in the 'Registered company name' field and click its associated 'Save' button
+  And I click the summary table 'Change' link for 'Company registration number'
   And I enter '87654321' in the 'Companies House number' field and click its associated 'Save' button
-  When I click the summary table 'Change' link for 'Address'
+  And I click the summary table 'Change' link for 'Address'
   And I enter '14 Duke Street' in the 'Building and street' field
   And I enter 'Dublin' in the 'Town or city' field
   And I enter 'H3 LY5' in the 'Postcode' field
   And I enter 'Ireland' in the 'Country' field and click the selected autocomplete option
   And I click the 'Save' button
+  Then I am on the 'DM Functional Test Supplier - Edit company details feature' page
+  And I see a success banner message containing 'The details for ‘DM Functional Test Supplier - Edit company details feature’ have been updated.'
+  And I see the 'Company details for supplier account' summary table filled with:
+    | field                        | value                                       |
+    | Company registered name      | We Edit Company Details Ltd.                |
+    | Company registration number  | 87654321                                    |
+    | DUNS Number                  | <ANY>                                       |
+    | Address                      | 14 Duke Street Dublin H3 LY5 Ireland        |


### PR DESCRIPTION
This scenario tends to be flaky, and when it fails it creates an annoying scenario where the tests are in the incorrect state on the stage for the next test run to succeed.

This commit tries to work around this by making the assertions less persnickety; now the tests will only look at values after they (should) have been changed. Hopefully this will mean that if the values in the database aren't reset we won't have to log in to the admin frontend to change things manually.