### PR TITLE
add additional banner selector to fix test

### DIFF
--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -266,7 +266,7 @@ Then /^I see a (success|warning|destructive|temporary-message) banner message co
   begin
     banner_message = page.find(:css, ".dm-banner, .banner-#{status}-without-action", wait: false)
   rescue Capybara::ElementNotFound => e
-    banner_message = page.find(:css, ".banner-#{status}-with-action", wait: false)
+    banner_message = page.find(:css, ".dm-alert--#{status}, .banner-#{status}-with-action", wait: false)
   end
   expect(banner_message).to have_content(message)
 end


### PR DESCRIPTION
This step (which only happens during framework clarification questions open state) was failing locally.
https://github.com/alphagov/digitalmarketplace-functional-tests/blob/f2dcbfd004c37ddfbdb882a532568ce96eae0855/features/supplier/supplier_asks_a_framework_question.feature#L25
It appears this has been refactored and now uses a different kind of banner, this adds an additional selector to match the kind of banner currently used on the page.