### PR TITLE
Add @requires-credentials tag to DUNS integration tests

### DIFF
--- a/features/supplier/supplier_creation.feature
+++ b/features/supplier/supplier_creation.feature
@@ -105,6 +105,7 @@ Scenario: Create new supplier account (with duns flow) - summary lists
   # We can't ever click the "Create account" button to check the final page because this will create a supplier entry
   # with DUNS number 288305220 and the test will never pass again.
 
+@requires-credentials
 Scenario: DUNS Number already exists
   # Uses DUNS Number for CCS
   Given I visit the /suppliers/create/duns-number page
@@ -115,6 +116,7 @@ Scenario: DUNS Number already exists
   And I see a validation message containing 'DUNS number already used'
   And I see the 'DUNS number' field prefilled with '232204180'
 
+@requires-credentials
 Scenario: DUNS Number does not exist
   Given I visit the /suppliers/create/duns-number page
   And I am on the 'Enter your DUNS number' page


### PR DESCRIPTION
These tests require valid Dun and Bradstreet Direct+ API credentials to pass.