### PR TITLE
Make it simpler and more robust to get a user 

### DIFF
--- a/features/support/api_helpers.rb
+++ b/features/support/api_helpers.rb
@@ -507,26 +507,24 @@ def get_or_create_supplier_with_data(name_prefix, custom_supplier_data)
   update_supplier(supplier['id'], custom_supplier_data)
 end
 
+def get_user_by_email_address(email_address)
+  response = call_api(
+    :get,
+    '/users',
+    params: { email_address: email_address }
+  )
+  JSON.parse(response.body)["users"][0]
+end
+
 def get_or_create_user(custom_user_data)
-  # This method is used to search for a user, and if it does not exist create that user. It will return that user and
-  # also sets it to the global @user var.
-  # The possible argument combinations for the getting of a user are dependent on the available end points for users.
-  # Therefore this method supports:
-  # emailAddress: email_address of the account. This can be used independently.
-  # supplierId: supplier id of the user. May result in unpredictable behaviour if there is more than one user with the
-  #     supplierId and an emailAddress is not specified
-  # Should the user not be found we will attempt a post create with the provided user data.
+  # Get the user by email address if they exist. Then ensure the user has
+  # the supplied custom data.
+  # Create a new user if they do not already exist or if the caller does
+  # not provide an email address.
+  # In both cases, return the user and set the global `@user` variable.
   custom_user_data = custom_user_data.camelize(:lower)
-  if (custom_user_data["emailAddress"] != nil) || (custom_user_data["supplierId"] != nil)
-    response = call_api(
-      :get,
-      "/users",
-      params: {
-        email_address: custom_user_data['emailAddress'],
-        supplier_id: custom_user_data['supplierId']
-      }
-    )
-    @user = response.code == 200 ? JSON.parse(response.body)["users"][0] : nil
+  if custom_user_data["emailAddress"] != nil
+    @user = get_user_by_email_address(custom_user_data["emailAddress"])
 
     if @user != nil
       @user['password'] = ENV["DM_#{@user['role'].upcase.gsub('-', '_')}_USER_PASSWORD"]

--- a/features/support/api_helpers.rb
+++ b/features/support/api_helpers.rb
@@ -535,14 +535,11 @@ def get_or_create_user(custom_user_data)
         v == nil || @user[k] == nil || detect_boolean_strings(v) == detect_boolean_strings(@user[k])
       end.to_h
 
-      if mismatched_properties.empty?
-        return @user
+      if mismatched_properties.any?
+        @user = update_user(@user['id'], mismatched_properties)
       end
 
-      expect(custom_user_data["emailAddress"]).to(
-        be(nil),
-        "User specified by email address exists but doesn't match requested properties (#{mismatched_properties})"
-      )
+      return @user
     end
   end
 

--- a/features/support/api_helpers.rb
+++ b/features/support/api_helpers.rb
@@ -464,13 +464,21 @@ def create_user(user_role, custom_user_data = {})
 
   if (custom_user_data['active'] || '').casecmp("false").zero?
     # this can't be specified at creation time so we need to follow up with an update to the user
-    response = call_api(:post, "/users/#{@user['id']}", payload: { users: { 'active': false }, updated_by: 'functional_tests' })
-    expect(response.code).to eq(200), response.body
-    @user = JSON.parse(response.body)["users"]
+    @user = update_user(@user['id'], 'active': false)
   end
   @user['password'] = password
   puts "Email address: #{@user['emailAddress']}"
   @user
+end
+
+def update_user(user_id, data)
+  response = call_api(
+    :post,
+    "/users/#{user_id}",
+    payload: { updated_by: "functional tests", users: data }
+  )
+  expect(response.code).to eq(200), _error(response, "Failed to update user")
+  JSON.parse(response.body)['users']
 end
 
 def get_supplier_by_name_starting_with(name_prefix)


### PR DESCRIPTION
Currently, we fail the test if a supplier exists but has the wrong properties. This was a deliberate choice: https://github.com/alphagov/digitalmarketplace-functional-tests/pull/628.

> I realize that in cases we find a property mismatch, we could actually go ahead and update the found user to match the requested properties. I've held back on doing this for now though - it has the potential to create a lot of churn on our db and allow us to introduce more race problems for parallel tests.

This has come back to bite us. We've just seen a case where a user got into the wrong state, so the tests would fail for the rest of time without manual intervention. Also, I disagree with the original author about database churn and race conditions - the only time we would do a database update is when the tests would otherwise fail, so there's not much churn. And I don't think we run our tests in parallel - and these tests couldn't be run in parallel anyway due to operating on the same users.

Thus, I think we can safely switch to new logic where we update the user if we discover that they exist but don't match what we expect. This should mean that this test becomes a bit more robust.

Note that this could cause problems if we ever used this helper method against a user in production. However, that's not something we do in any of our smoke or smoulder tests, so I think we're safe.

Follows similar logic to https://github.com/alphagov/digitalmarketplace-functional-tests/pull/849, which did the same thing for suppliers.

Also remove the ability to get user by supplier ID. It wasn't being used in any of the tests, and added complexity. It's probably a bad idea to have supplier IDs in the tests anyway for reproducibility.