### PR TITLE
Choose a lot journey changes

### DIFF
--- a/features/step_definitions/framework_application_steps.rb
+++ b/features/step_definitions/framework_application_steps.rb
@@ -31,10 +31,12 @@ Then(/^I follow the first 'Edit' link and answer all questions on that page and 
 end
 
 Then(/^I submit a service for each lot$/) do
-  lots_links = find_elements_by_xpath("//ul[@class='browse-list']//a")
-  lots_links.each_with_index do |_link, index|
-    link = find_elements_by_xpath("//ul[@class='browse-list']//a")[index]
+  lots_options = find_elements_by_xpath("//input[@type='radio']")
+
+  lots_options.each_with_index do |_option, index|
+    link = find_elements_by_xpath("//input[@type='radio']")[index]
     link.click
+    click_on 'Save and continue', wait: false
     begin
       click_on 'Add a service', wait: false
     rescue Capybara::ElementNotFound => e
@@ -50,9 +52,7 @@ Then(/^I submit a service for each lot$/) do
       first(:button, "Mark as complete").click
       click_on "Back to application", wait: false
     end
-
-    # turn on when debugging to make a screenshot when a service for a lot is submitted:
-    # page.save_screenshot("screenshot#{index}.png")
+    click_on 'Add a service', wait: false
   end
 end
 
@@ -109,10 +109,11 @@ Then /^I( don't)? receive a (follow-up|clarification) question( confirmation)? e
 end
 
 
-Then 'I click on the lot link for the existing service' do
+Then 'I select the lot for the existing service' do
   lotSlug = @existing_service['lotSlug']
-  lot_link = page.all(:xpath, "//div[@class='govuk-grid-column-two-thirds framework-lots-table']//a[contains(@href, '#{lotSlug}')]")
-  lot_link[0].click
+  page.save_screenshot("select.png")
+  lot_option = find_elements_by_xpath("//input[@type='radio' and @value='#{lotSlug}']")
+  lot_option[0].click
 end
 
 
@@ -182,4 +183,10 @@ end
 Then "I have submitted services for each lot" do
   lot_count = @framework['lots'].length
   step "I see '#{lot_count} SERVICES' text on the page"
+end
+
+Then "I see all my services are ready for submission" do
+  lot_count = @framework['lots'].length
+
+  step "I see 'Ready for submission (#{lot_count})' text on the page"
 end

--- a/features/supplier/supplier_applies_to_a_framework.feature
+++ b/features/supplier/supplier_applies_to_a_framework.feature
@@ -31,8 +31,11 @@ Scenario: Supplier submits a framework application
 
   When I click 'Add, edit and complete services'
   Then I am on the 'Your framework services' page for that framework application
+  And I click 'Add a service'
   Then I submit a service for each lot
-  And I see '1 service will be submitted' or '1 research studio will be submitted' text on the page
+  And I click 'Back to your framework services' link for that framework application
+  Then I am on the 'Your framework services' page for that framework application
+  And I see all my services are ready for submission
   And I click 'Back to framework application' link for that framework application
 
   Then I am on the 'Apply to framework' page for that framework application
@@ -78,7 +81,10 @@ Scenario: Supplier copies a service from a previous framework
 
   When I click 'Add, edit and complete services'
   Then I am on the 'Your framework services' page for that framework application
-  Then I click on the lot link for the existing service
+  And I click 'Add a service'
+  Then I am on the 'What type of service do you want to add?' page
+  And I select the lot for the existing service
+  And I click 'Save and continue'
   And I click the link to view and add services from the previous framework
   Then I am on the 'Previous lot services' page for that lot
   And I see the existing service in the copyable services table
@@ -126,7 +132,10 @@ Scenario: Supplier copies a service for a lot limited to one service from a prev
   When I click 'Add, edit and complete services'
   Then I am on the 'Your framework services' page for that framework application
   
-  When I click on the lot link for the existing service
+  And I click 'Add a service'
+  Then I am on the 'What type of service do you want to add?' page
+  And I select the lot for the existing service
+  And I click 'Save and continue'
   Then I see 'Do you want to reuse your previous' text on the page
 
   When I choose the 'Yes' radio button
@@ -136,7 +145,10 @@ Scenario: Supplier copies a service for a lot limited to one service from a prev
   When I submit a copied service
   Then I see 'was marked as complete' text on the page
 
-  When I click on the lot link for the existing service
+  And I click 'Add a service'
+  Then I am on the 'What type of service do you want to add?' page
+  And I select the lot for the existing service
+  And I click 'Save and continue'
   And I click the 'Remove draft service' button
   Then I see 'Are you sure you want to remove' text on the page
 


### PR DESCRIPTION
https://trello.com/c/r8CxfKTO/820-5-replace-choose-a-lot-page-in-create-a-service-journey

The new flow on the framework application journey includes a new page to choose a lot from a collection of radio inputs.

This adjusts the tests to account for this page.

The first commit splits out the old scenarios, so we should be able to just revert it once we've deployed to preview.