### PR TITLE
Fix accessible autocomplete step

### DIFF
--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -235,7 +235,9 @@ end
 
 When /^I enter #{MAYBE_VAR} in the '(.*)' field and click the selected autocomplete option?$/ do |value, field_name|
   field_element = page.find_field field_name
-  field_element.set value
+  field_element.set ''  # clear the field before typing
+  field_element.click
+  field_element.send_keys value
   # Find the sibling <ul>'s focused autocomplete <li> and click it
   focused_dropdown_item = field_element.find(:xpath, "following-sibling::ul[contains(@class, 'autocomplete__menu')]/li[contains(@class, 'autocomplete__option--focused')]")
   focused_dropdown_item.click


### PR DESCRIPTION
Fix the step for entering text into an accessible autocomplete field.

This stopped working when we bumped accessible-autocomplete to 1.0.1 in the admin frontend[[1]]. It appears that using the `set` method doesn't work with the JavaScript for this version of the accessible autocomplete, as the typed option was not being focused.

This commit fixes it by using the `send_key` method to emulate a user typing; this works with both the newer and older version of accessible-autocomplete.

[1]: https://ci.marketplace.team/job/functional-tests-preview/23280/functional_20test_20report/