### PR TITLE
Fix get_user_by_email_address

### DIFF
--- a/features/support/api_helpers.rb
+++ b/features/support/api_helpers.rb
@@ -513,7 +513,7 @@ def get_user_by_email_address(email_address)
     '/users',
     params: { email_address: email_address }
   )
-  JSON.parse(response.body)["users"][0]
+  JSON.parse(response.body).dig("users", 0)
 end
 
 def get_or_create_user(custom_user_data)


### PR DESCRIPTION
Functional tests were failing on staging after a databse refresh (when the user did not exist), see https://ci.marketplace.team/job/functional-tests-staging/2454/functional_20test_20report/.

Use `dig` method[[1]] so that if the JSON response is empty (as in the case where no users are found) then an exception will not be raised.

[1]: https://ruby-doc.org/core-3.0.0/doc/dig_methods_rdoc.html