### PR TITLE
Add command to check feature syntax and run in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,5 +13,7 @@ jobs:
       uses: ruby/setup-ruby@v1
     - name: Install dependencies
       run: bundle install
-    - name: Run linting
-      run: bundle exec rubocop features
+    - name: Lint Ruby
+      run: make lint
+    - name: Check features
+      run: make parse

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,9 @@ clean:
 lint: install
 	bundle exec rubocop features
 
+parse: install
+	[ -f ${CONFIG} ] && . ${CONFIG} ; bundle exec cucumber --strict --dry-run
+
 index-services:
 	$(if ${FRAMEWORK},,$(error Must specify FRAMEWORK))
 	docker run --net=host digitalmarketplace/scripts scripts/index-to-search-service.py services dev --api-token=myToken --search-api-token=myToken --index=${FRAMEWORK} --frameworks=${FRAMEWORK}


### PR DESCRIPTION
We just had [a bunch of test failures](https://github.com/alphagov/digitalmarketplace-functional-tests/pull/881) because a PR was merged with a syntax error in a feature. This was not noticed before merging because the CI only linted the Ruby code.

Add a make command to parse (but not execute) all the features. This should catch future syntax errors. Run this command as part of pre-merge CI.

I've tested locally that this command succeeds for current main, and would have caught the syntax error.