### PR TITLE
remove re-testing by role

### DIFF
--- a/features/admin/search_for_suppliers.feature
+++ b/features/admin/search_for_suppliers.feature
@@ -2,7 +2,7 @@
 Feature: Search for suppliers by registered name, DUNS number and companies house number
 
 @search-supplier-name
-Scenario Outline: Correct users search for a supplier by registered name
+Scenario Outline: Search for a supplier by registered name
   Given I am logged in as the existing <role> user
   And I have a supplier with:
     | name           | DM Functional Test Supplier - Search supplier name feature |
@@ -17,9 +17,6 @@ Scenario Outline: Correct users search for a supplier by registered name
   Examples:
     | role                      | link-name                               |
     | admin                     | Edit supplier accounts or view services |
-    | admin-ccs-category        | Edit suppliers and services             |
-    | admin-ccs-data-controller | View and edit suppliers                 |
-
 
 @search-supplier-name @with-admin-ccs-sourcing-user
   Scenario: CCS Sourcing user can search for a supplier by registered name

--- a/features/admin/search_for_suppliers.feature
+++ b/features/admin/search_for_suppliers.feature
@@ -3,20 +3,16 @@ Feature: Search for suppliers by registered name, DUNS number and companies hous
 
 @search-supplier-name
 Scenario Outline: Search for a supplier by registered name
-  Given I am logged in as the existing <role> user
+  Given I am logged in as the existing 'admin' user
   And I have a supplier with:
     | name           | DM Functional Test Supplier - Search supplier name feature |
     | registeredName | DM Functional Test Supplier - Search registered supplier name |
-  And I click the '<link-name>' link
+  And I click the 'Edit supplier accounts or view services' link
   And I enter 'Functional Test Supplier - Search registered' in the 'Find a supplier by name' field
   And I click the 'find_supplier_by_name_search' button
   Then I see an entry in the 'Suppliers' table with:
     | Name                                                       | Users | Services |
     | DM Functional Test Supplier - Search supplier name feature | Users | Services |
-
-  Examples:
-    | role                      | link-name                               |
-    | admin                     | Edit supplier accounts or view services |
 
 @search-supplier-name @with-admin-ccs-sourcing-user
   Scenario: CCS Sourcing user can search for a supplier by registered name


### PR DESCRIPTION
https://trello.com/c/asIcsC2D/584-3-convert-all-tests-that-test-admin-frontend-user-permissions-into-unit-tests

The variance in link name is already unit tested in https://github.com/alphagov/digitalmarketplace-admin-frontend/blob/527eca037b6ba3cbbe50e2a8899c31e2157fe746/tests/app/main/views/test_index_page.py#L162L190 therefore there is no need to duplicate this in a feature test