### PR TITLE
remove update supplier name permissions tests

### DIFF
--- a/features/admin/update_supplier_name.feature
+++ b/features/admin/update_supplier_name.feature
@@ -24,28 +24,3 @@ Scenario Outline: Correct users can edit a supplier name
   Examples:
     | role                      | link-name                               |
     | admin                     | Edit supplier accounts or view services |
-    | admin-ccs-category        | Edit suppliers and services             |
-    | admin-ccs-data-controller | View and edit suppliers                 |
-
-Scenario Outline: Admin framework manager user can view but not update the supplier name
-  Given I am logged in as the existing <role> user
-  When I visit the /admin/suppliers?supplier_name=DM+Functional+Test+Supplier+-+Update+supplier+name+feature page
-  When I click the 'DM Functional Test Supplier - Update supplier name feature' link
-  And I am on the 'DM Functional Test Supplier - Update supplier name feature' page
-  Then I don't see the 'Edit supplier name' link
-
-  Examples:
-    | role                      |
-    | admin-framework-manager   |
-
-Scenario Outline: Correct users cannot update the supplier name
-  Given I am logged in as the existing <role> user
-  When I visit the /admin/suppliers?supplier_name=DM+Functional+Test+Supplier+-+Update+supplier+name+feature page
-  Then I don't see the 'Change name' link
-
-  Examples:
-    | role                      |
-    | admin-framework-manager   |
-    | admin-ccs-sourcing        |
-    | admin-manager             |
-    | admin-ccs-data-controller |

--- a/features/admin/update_supplier_name.feature
+++ b/features/admin/update_supplier_name.feature
@@ -2,10 +2,10 @@
 Feature: Update supplier name
 
 Scenario Outline: Correct users can edit a supplier name
-  Given I am logged in as the existing <role> user
+  Given I am logged in as the existing admin user
   And I have a supplier with:
     | name          | DM Functional Test Supplier - Update supplier name feature |
-  And I click the '<link-name>' link
+  And I click the 'Edit supplier accounts or view services' link
   And I enter 'DM Functional Test Supplier - Update supplier name feature' in the 'Find a supplier by name' field
   And I click the 'find_supplier_by_name_search' button
   And I click the 'DM Functional Test Supplier - Update supplier name feature' link
@@ -20,7 +20,3 @@ Scenario Outline: Correct users can edit a supplier name
   And I enter 'DM Functional Test Supplier - Update supplier name feature' in the 'New name' field
   And I click the 'Save' button
   Then I am on the 'DM Functional Test Supplier - Update supplier name feature' page
-
-  Examples:
-    | role                      | link-name                               |
-    | admin                     | Edit supplier accounts or view services |


### PR DESCRIPTION
https://trello.com/c/asIcsC2D/584-3-convert-all-tests-that-test-admin-frontend-user-permissions-into-unit-tests

These permissions are already unit tested in https://github.com/alphagov/digitalmarketplace-admin-frontend/blob/f7352cdc51e682cabc99e295f4efcd8f6f6b5fcb/tests/app/main/views/test_suppliers.py#L116-L153 and https://github.com/alphagov/digitalmarketplace-admin-frontend/blob/f7352cdc51e682cabc99e295f4efcd8f6f6b5fcb/tests/app/main/views/test_suppliers.py#L1748-L1755
so no need to replicate in a feature test

Also the previous test was using an incorrect link text and URL so would have always passed.
