### PR TITLE
Stop testing exact framework versions

### DIFF
--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -498,8 +498,17 @@ Then /^I (don't |)see '(.*?)'(?: or '(.*)')? text on the page/ do |negative, exp
   expect(result || alternative_result).to be true
 end
 
+Then /^I (don't |)see '(.*?)' regex on the page/ do |negative, expected_text|
+  step "I #{negative}see '#{Regexp.new(expected_text)}' text on the page"
+end
+
 Then /^I see a '(.*)' attribute with the value '(.*)'/ do |attribute_name, attribute_value|
   place = "//*[@#{attribute_name} = \"#{attribute_value}\"]"
+  expect(all(:xpath, place).length).to eq(1)
+end
+
+Then /^I see a '(.*)' attribute with the value starting with '(.*)'/ do |attribute_name, attribute_value|
+  place = "//*[starts-with(@#{attribute_name}, \"#{attribute_value}\")]"
   expect(all(:xpath, place).length).to eq(1)
 end
 

--- a/features/supplier/supplier_applies_for_an_opportunity.feature
+++ b/features/supplier/supplier_applies_for_an_opportunity.feature
@@ -12,8 +12,8 @@ Scenario: Supplier is not eligible as they are not on the framework
   Given I go to that brief page
   And I click 'Apply for this opportunity'
   Then I am on the 'You can’t apply for this opportunity' page
-  And I see 'You can’t apply for this opportunity because you’re not a Digital Outcomes and Specialists 5 supplier.' text on the page
-  And I see a 'data-reason' attribute with the value 'supplier-not-on-digital-outcomes-and-specialists-5'
+  And I see 'You can’t apply for this opportunity because you’re not a Digital Outcomes and Specialists \d supplier.' regex on the page
+  And I see a 'data-reason' attribute with the value starting with 'supplier-not-on-digital-outcomes-and-specialists'
 
 Scenario: Supplier is not eligible as they are not on the digital-specialists lot
   Given that supplier has applied to be on that framework
@@ -23,7 +23,7 @@ Scenario: Supplier is not eligible as they are not on the digital-specialists lo
   And I go to that brief page
   And I click 'Apply for this opportunity'
   Then I am on the 'You can’t apply for this opportunity' page
-  And I see 'You can’t apply for this opportunity because you didn’t say you could provide services in this category when you applied to the Digital Outcomes and Specialists 5 framework.' text on the page
+  And I see 'You can’t apply for this opportunity because you didn’t say you could provide services in this category when you applied to the Digital Outcomes and Specialists \d framework.' regex on the page
   And I see a 'data-reason' attribute with the value 'supplier-not-on-lot'
 
 Scenario: Supplier is not eligible as they can not provide the developer role
@@ -34,7 +34,7 @@ Scenario: Supplier is not eligible as they can not provide the developer role
   And I go to that brief page
   And I click 'Apply for this opportunity'
   Then I am on the 'You can’t apply for this opportunity' page
-  And I see 'You can’t apply for this opportunity because you didn’t say you could provide this specialist role when you applied to the Digital Outcomes and Specialists 5 framework.' text on the page
+  And I see 'You can’t apply for this opportunity because you didn’t say you could provide this specialist role when you applied to the Digital Outcomes and Specialists \d framework.' regex on the page
   And I see a 'data-reason' attribute with the value 'supplier-not-on-role'
 
 Scenario: Supplier applies for a digital-specialists brief


### PR DESCRIPTION
Some of the tests expect a particular version to be live, and so break if this changes. Update the matching to match other frameworks in the same family. This should reduce the amount of work involved in switching to a new framework.