### PR TITLE
Fix 'regex on page' step

### DIFF
--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -499,7 +499,9 @@ Then /^I (don't |)see '(.*?)'(?: or '(.*)')? text on the page/ do |negative, exp
 end
 
 Then /^I (don't |)see '(.*?)' regex on the page/ do |negative, expected_text|
-  step "I #{negative}see '#{Regexp.new(expected_text)}' text on the page"
+  method = negative.empty? ? :has_content? : :has_no_content?
+
+  expect(page.send(method, Regexp.new(expected_text))).to be true
 end
 
 Then /^I see a '(.*)' attribute with the value '(.*)'/ do |attribute_name, attribute_value|


### PR DESCRIPTION
At the end of https://github.com/alphagov/digitalmarketplace-functional-tests/pull/892 I made a small change to tidy it up, but neglected to re-test. Inevitably, that small change broke the whole thing.

It turns out that trying to re-use the 'text on page' step doesn't work - the regex gets converted back into text. So fix it by copying the necessary parts across. I've tested that this works this time.