### PR TITLE
Temporarily skip public opportunity feature

### DIFF
--- a/features/public/public_opportunity.feature
+++ b/features/public/public_opportunity.feature
@@ -1,6 +1,7 @@
 @public-opportunity-view
 Feature: Published requirements can be viewed by the public
 
+@skip-local @skip-preview @skip-staging
 Scenario: Public views the publish requirements. Details presented matches what was published.
   Given I have the latest live digital-outcomes-and-specialists framework
   And I have a buyer user


### PR DESCRIPTION
This test is blocking the release of https://github.com/alphagov/digitalmarketplace-buyer-frontend/pull/1195
which includes the answer to the new employment status question.

Because this feature includes the expected data in the step definition instead of the feature, it's not so easy to duplicate it, update one part and use the skip tags to run the right data on the right environment like we've done in [other cases](https://github.com/alphagov/digitalmarketplace-functional-tests/pull/894)

Since this is only one feature and it's easy to manually verify that the answer to the question is appearing on the published brief, I think it's ok to temporarily skip it completely until we've finished releasing. At that point we can update the step with the new expected data and re-enable.

https://trello.com/c/l9lnd1GD/14-2-add-new-ir35-question-to-the-create-an-opportunity-journey