### PR TITLE
Complete new question on staging

### DIFF
--- a/features/buyer/requirements.feature
+++ b/features/buyer/requirements.feature
@@ -5,115 +5,6 @@ Feature: Create and publish a requirement
   I want to be able to create and publish a requirement
 
 
-@skip-preview @skip-local
-Scenario: Create individual specialist requirement
-  Given I am logged in as a buyer user
-    And I have created an individual specialist requirement
-   Then I complete the following tasks:
-      | task_name                                       |
-      | Specialist role                                 |
-      | Location                                        |
-      | Set how long your requirements will be open for |
-
-  Given 'Description of work' should not be completed
-   When I click 'Description of work'
-    And I answer all summary questions with:
-      | field                 | value       | expected_summary_table_value |
-      | startDate-day         | 08          | Tuesday 8                    |
-      | startDate-month       | 9           | September                    |
-      | startDate-year        | 2020        | 2020                         |
-
-    And I click 'Return to overview'
-   Then 'Description of work' should be completed
-
-  Given 'Shortlist and evaluation process' should not be completed
-   When I click 'Shortlist and evaluation process'
-    And I answer all summary questions with:
-      | field              | value |
-      | numberOfSuppliers  | 5     |
-      | technicalWeighting | 10    |
-      | culturalWeighting  | 5     |
-      | priceWeighting     | 85    |
-   When I click 'Return to overview'
-   Then 'Shortlist and evaluation process' should be completed
-
-  Given 'Describe question and answer session' should not be completed
-   When I click 'Describe question and answer session'
-   And I answer all summary questions
-   And I click 'Return to overview'
-   Then 'Describe question and answer session' should be completed
-
-   When I click 'Preview your requirements'
-   Then I am on the 'Preview your requirements' page
-    And I see the 'Return to overview' link
-    And I see 'Incomplete applications' text in the desktop preview panel
-    And I see 'Tuesday 8 September 2020' text in the desktop preview panel
-    And I see 'Technical competence 10%' text in the desktop preview panel
-    And I click 'Confirm your requirements and publish'
-   Then I am on the 'Publish your requirements and evaluation criteria' page
-    And I click 'Publish requirements'
-
-  Then I don't see the 'Title' link
-   And I don't see the 'Specialist role' link
-   And I don't see the 'Location' link
-   And I don't see the 'Description of work' link
-   And I don't see the 'Shortlist and evaluation process' link
-   And I don't see the 'Set how long your requirements will be open for' link
-   And I don't see the 'Describe question and answer session' link
-   And I don't see the 'Publish your requirements' link
-
-@skip-preview @skip-local
-Scenario: Create team to provide an outcome
-  Given I am logged in as a buyer user
-    And I have created a team to provide an outcome requirement
-   Then I complete the following tasks:
-      | task_name |
-      | Location |
-
-  Given 'Description of work' should not be completed
-   When I click 'Description of work'
-    And I answer all summary questions with:
-      | field                 | value       | expected_summary_table_value |
-      | startDate-day         | 9           | Wednesday 9                    |
-      | startDate-month       | 9           | September                    |
-      | startDate-year        | 2020        | 2020                         |
-    And I click 'Return to overview'
-   Then 'Description of work' should be completed
-
-  Given 'Shortlist and evaluation process' should not be completed
-   When I click 'Shortlist and evaluation process'
-    And I answer all summary questions with:
-      | field              | value |
-      | numberOfSuppliers  | 5     |
-      | technicalWeighting | 10    |
-      | culturalWeighting  | 5     |
-      | priceWeighting     | 85    |
-    And I click 'Return to overview'
-   Then 'Shortlist and evaluation process' should be completed
-
-  Given 'Describe question and answer session' should not be completed
-   When I click 'Describe question and answer session'
-    And I answer all summary questions
-    And I click 'Return to overview'
-   Then 'Describe question and answer session' should be completed
-
-   When I click 'Preview your requirements'
-   Then I am on the 'Preview your requirements' page
-    And I see the 'Return to overview' link
-    And I see '0 SME, 0 large' text in the desktop preview panel
-    And I see 'Wednesday 9 September 2020' text in the desktop preview panel
-    And I see 'Cultural fit 5%' text in the desktop preview panel
-    And I click 'Confirm your requirements and publish'
-   Then I am on the 'Publish your requirements and evaluation criteria' page
-    And I click 'Publish requirements'
-
-  Then I don't see the 'Title' link
-   And I don't see the 'Location' link
-   And I don't see the 'Description of work' link
-   And I don't see the 'Shortlist and evaluation process' link
-   And I don't see the 'Publish your requirements' link
-
-@skip-staging
 Scenario: Create individual specialist requirement
   Given I am logged in as a buyer user
     And I have created an individual specialist requirement
@@ -171,7 +62,6 @@ Scenario: Create individual specialist requirement
    And I don't see the 'Describe question and answer session' link
    And I don't see the 'Publish your requirements' link
 
-@skip-staging
 Scenario: Create team to provide an outcome
   Given I am logged in as a buyer user
     And I have created a team to provide an outcome requirement


### PR DESCRIPTION
In https://github.com/alphagov/digitalmarketplace-functional-tests/pull/894 we duplicated this feature to account for the new question that's on preview but not on staging.

Once https://github.com/alphagov/digitalmarketplace-briefs-frontend/pull/447 has been released to staging, we no longer need different versions of the feature.

Remove the skip tags and update the feature so it always answers the new question.

https://trello.com/c/l9lnd1GD/14-2-add-new-ir35-question-to-the-create-an-opportunity-journey