### PR TITLE
Re-enable public opportunity feature

### DIFF
--- a/features/public/public_opportunity.feature
+++ b/features/public/public_opportunity.feature
@@ -1,7 +1,6 @@
 @public-opportunity-view
 Feature: Published requirements can be viewed by the public
 
-@skip-local @skip-preview @skip-staging
 Scenario: Public views the publish requirements. Details presented matches what was published.
   Given I have the latest live digital-outcomes-and-specialists framework
   And I have a buyer user

--- a/features/step_definitions/opportunities_steps.rb
+++ b/features/step_definitions/opportunities_steps.rb
@@ -65,6 +65,7 @@ Then /^I see the details of the brief match what was published$/ do
     Given I see the 'Overview' summary list filled with:
       | field                        | value                         |
       | Specialist role              | Developer                     |
+      | Off-payroll (IR35) determination | #{@brief['employmentStatus']} |
       | Summary of the work          | #{@brief['summary']}          |
       | Latest start date            | #{DateTime.strptime(@brief['startDate'], '%Y-%m-%d').strftime('%A %-d %B %Y')} |
       | Expected contract length     |                               |


### PR DESCRIPTION
This feature was paused in #895 because it was blocking the release of the new employment status question. That change is now released, so we can add the question to the expected data and re-enable the test.

https://trello.com/c/l9lnd1GD/14-2-add-new-ir35-question-to-the-create-an-opportunity-journey