### PR TITLE
Change clicking on summary links to use XPath

### DIFF
--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -346,7 +346,7 @@ When /^I click the top\-level summary table '(.*)' link for the section '(.*)'$/
 end
 
 When /I click the summary (table|list) #{MAYBE_VAR} (link|button) for #{MAYBE_VAR}$/ do |table_or_list, link_name, elem_type, field_to_edit|
-  row = page.find(table_or_list == "table" ? "td" : "dt", exact_text: field_to_edit).ancestor(table_or_list == "table" ? "tr" : "dl > *")
+  row = page.find(:xpath, "//*/#{table_or_list == 'table' ? 'td' : 'dt'}[normalize-space(.) = '#{field_to_edit}']").ancestor(table_or_list == "table" ? "tr" : "dl > *")
   case elem_type
     when 'link'
       edit_link = row.find_link(link_name)


### PR DESCRIPTION
Based on local testing this speeds up the [admin manager features](https://github.com/alphagov/digitalmarketplace-functional-tests/blob/main/features/admin/manage_admin_users.feature) by around 10% which are one of the slowest individual features to run.

~~If there is a neater way of doing string interpolation / concatenation in Ruby then I'm all ears~~ I now know [how to do this](http://ruby-for-beginners.rubymonstas.org/bonus/string_interpolation.html)

https://trello.com/c/qJcotD8J/26-3-investigate-why-steps-of-the-form-and-i-click-the-summary-table-take-5-10s-or-more-and-fix