### PR TITLE
Add support for running headless with Selenium

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -14,9 +14,15 @@ if (ENV['BROWSER'] == 'true')
   Capybara.default_driver = :selenium
 
   Capybara.register_driver :selenium do |app|
+    browser_options = Selenium::WebDriver::Firefox::Options.new
+
+    if (ENV['HEADLESS'] == 'true')
+      browser_options.headless!
+    end
+
     http_client = Selenium::WebDriver::Remote::Http::Default.new
     http_client.timeout = 180
-    Capybara::Selenium::Driver.new(app, browser: :firefox, http_client: http_client)
+    Capybara::Selenium::Driver.new(app, browser: :firefox, http_client: http_client, options: browser_options)
   end
 else
   Capybara.default_driver = :poltergeist


### PR DESCRIPTION
https://trello.com/c/OcwZuCo5/48-2-timebox-improve-reliability-of-selecting-an-autocomplete-option

I have a hypothesis that using Selenium might fix some of the performance/reliability issues we're currently seeing. To test this, I want to run an experiment where we try running the tests with Selenium and see what happens.

First, though, we need to add an option to run Firefox in headless mode. This is because it would be utterly pointless to run the user interface on Jenkins.