### PR TITLE
Add support for running with Chrome

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -14,7 +14,13 @@ if (ENV['BROWSER'] == 'true')
   Capybara.default_driver = :selenium
 
   Capybara.register_driver :selenium do |app|
-    browser_options = Selenium::WebDriver::Firefox::Options.new
+    if (ENV['CHROME'] == 'true')
+      browser = :chrome
+      browser_options = Selenium::WebDriver::Chrome::Options.new
+    else
+      browser = :firefox
+      browser_options = Selenium::WebDriver::Firefox::Options.new
+    end
 
     if (ENV['HEADLESS'] == 'true')
       browser_options.headless!
@@ -22,7 +28,7 @@ if (ENV['BROWSER'] == 'true')
 
     http_client = Selenium::WebDriver::Remote::Http::Default.new
     http_client.timeout = 180
-    Capybara::Selenium::Driver.new(app, browser: :firefox, http_client: http_client, options: browser_options)
+    Capybara::Selenium::Driver.new(app, browser: browser, http_client: http_client, options: browser_options)
   end
 else
   Capybara.default_driver = :poltergeist


### PR DESCRIPTION
Selenium can use Chrome instead of Firefox. From my testing, Chrome is much faster (~20-30%). So we may eventually want to switch over to it. But for now, just add Chrome as an undocumented option.

A future story covers working out how we want to use this functionality in future.

I've tested that this works locally for me - both with and without head.