### PR TITLE
Stop using Capybara to normalise whitespace

### DIFF
--- a/features/support/helpers.rb
+++ b/features/support/helpers.rb
@@ -44,7 +44,7 @@ def closed_outcome_status?(text)
 end
 
 def normalize_whitespace(text)
-  Capybara::Helpers.normalize_whitespace(text)
+  text.to_s.gsub(/[[:space:]]+/, ' ').strip
 end
 
 ## finding and selecting invisible fields


### PR DESCRIPTION
Capybara 3 has deprecated this method, so we need to start normalising whitespace ourselves.