### PR TITLE
Make @file-download tests work in ChromeDriver

### DIFF
--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -544,16 +544,21 @@ Then(/^I should get an? (download|inline) file(?: with file.?name ending(?: in)?
     target_window = current_window
   end
   if is_chrome
-    disposition_parts = inline_http_requests.map { |r| r.dig('content-disposition') }.compact[0].split(";")
+    requests = inline_http_requests
+    disposition_parts = requests.map { |r| r.dig('content-disposition') }.compact[0].split(";")
   else
     within_window(target_window) do
       disposition_parts = page.response_headers['Content-Disposition'].split(";")
     end
-    expect(disposition_parts[0]).to eq(case download_inline when "download" then "attachment" else download_inline end)
-    if ending
-      expect(disposition_parts[1]).to match("^\s*filename=.*#{Regexp.escape(ending)}['\"]?\s*$")
-    end
-    if content_type
+  end
+  expect(disposition_parts[0]).to eq(case download_inline when "download" then "attachment" else download_inline end)
+  if ending
+    expect(disposition_parts[1]).to match("^\s*filename=.*#{Regexp.escape(ending)}['\"]?\s*$")
+  end
+  if content_type
+    if is_chrome
+      expect(requests.find { |r| r['content-type'] == content_type }).not_to be_nil
+    else
       expect(page.response_headers['Content-Type']).to eq(content_type)
     end
   end

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -543,9 +543,14 @@ Then(/^I should get an? (download|inline) file(?: with file.?name ending(?: in)?
   else
     target_window = current_window
   end
-
-  within_window(target_window) do
-    disposition_parts = page.response_headers['Content-Disposition'].split(";")
+  if ENV['CHROME']
+    require_relative 'cookies_steps.rb'
+    requests = inline_http_requests
+    disposition_parts = requests.map { |r| r.dig('content-disposition') }.compact[0].split(";")
+  else
+    within_window(target_window) do
+      disposition_parts = page.response_headers['Content-Disposition'].split(";")
+    end
     expect(disposition_parts[0]).to eq(case download_inline when "download" then "attachment" else download_inline end)
     if ending
       expect(disposition_parts[1]).to match("^\s*filename=.*#{Regexp.escape(ending)}['\"]?\s*$")

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -1,7 +1,6 @@
 require 'date'
 require 'securerandom'
 require 'uri'
-require_relative '../support/helpers.rb'
 
 Given /^I (?:re-?)?visit the homepage$/ do
   page.visit("#{dm_frontend_domain}")

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -1,6 +1,7 @@
 require 'date'
 require 'securerandom'
 require 'uri'
+require_relative '../support/helpers.rb'
 
 Given /^I (?:re-?)?visit the homepage$/ do
   page.visit("#{dm_frontend_domain}")
@@ -543,10 +544,8 @@ Then(/^I should get an? (download|inline) file(?: with file.?name ending(?: in)?
   else
     target_window = current_window
   end
-  if ENV['CHROME']
-    require_relative 'cookies_steps.rb'
-    requests = inline_http_requests
-    disposition_parts = requests.map { |r| r.dig('content-disposition') }.compact[0].split(";")
+  if is_chrome
+    disposition_parts = inline_http_requests.map { |r| r.dig('content-disposition') }.compact[0].split(";")
   else
     within_window(target_window) do
       disposition_parts = page.response_headers['Content-Disposition'].split(";")

--- a/features/step_definitions/cookies_steps.rb
+++ b/features/step_definitions/cookies_steps.rb
@@ -1,3 +1,4 @@
+require_relative '../support/helpers.rb'
 Then(/^I (see|do not see) a '_ga' tracking ID query parameter on the URL$/) do |can_see_ga|
   current_url_uri = URI(current_url)
   query_hash = Hash[URI::decode_www_form(current_url_uri.query || "")]
@@ -9,32 +10,6 @@ Then(/^I (see|do not see) a '_ga' tracking ID query parameter on the URL$/) do |
 end
 
 # Based on http://jbusser.github.io/2014/11/01/integration-testing-google-analytics-with-capybara-and-rspec.html
-
-def is_chrome
-  ENV['CHROME']
-end
-
-def inline_http_requests
-  if is_chrome
-    # Chrome does not support network_traffic, instead we can extract this from the performance logs
-    logs = page.driver.browser.manage.logs.get(:performance)
-    # Store messages in a structure which is easier to work with
-    messages_array = logs.each_with_object([]) do |entry, messages|
-      message = JSON.parse(entry.message)
-      timestamp = entry.timestamp
-      messages << message
-      message.store(:timestamp, timestamp)
-    end
-    # Filter to only messages after test has started and requests with headers
-    messages_after_test_start = messages_array.select { |m| m[:timestamp] > @timestamp }
-    messages_after_test_start.map { |l| l.dig('message', 'params', 'headers') }.compact
-  else
-    page.driver.network_traffic.map do |traffic|
-    # Return all HTTP requests made by Poltergeist
-      URI.parse traffic.url
-    end
-  end
-end
 
 def google_analytics_requests
   if is_chrome

--- a/features/step_definitions/cookies_steps.rb
+++ b/features/step_definitions/cookies_steps.rb
@@ -1,4 +1,3 @@
-require_relative '../support/helpers.rb'
 Then(/^I (see|do not see) a '_ga' tracking ID query parameter on the URL$/) do |can_see_ga|
   current_url_uri = URI(current_url)
   query_hash = Hash[URI::decode_www_form(current_url_uri.query || "")]

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -17,6 +17,8 @@ if (ENV['BROWSER'] == 'true')
     if (ENV['CHROME'] == 'true')
       browser = :chrome
       browser_options = Selenium::WebDriver::Chrome::Options.new
+      browser_options.add_preference(:download,
+                                     prompt_for_download: false)
       browser_capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
         "goog:loggingPrefs" => {
           performance: "ALL"

--- a/features/support/helpers.rb
+++ b/features/support/helpers.rb
@@ -240,3 +240,29 @@ def get_summary_list_rows_by_preceding_heading(heading)
   # some lists have a preceding paragraph
   page.all(:xpath, heading_xpath + dl_rows_xpath).any? ? page.all(:xpath, heading_xpath + dl_rows_xpath) : page.all(:xpath, heading_xpath + paragraph_xpath + dl_rows_xpath)
 end
+
+def is_chrome
+  ENV['CHROME']
+end
+
+def inline_http_requests
+  if is_chrome
+    # Chrome does not support network_traffic, instead we can extract this from the performance logs
+    logs = page.driver.browser.manage.logs.get(:performance)
+    # Store messages in a structure which is easier to work with
+    messages_array = logs.each_with_object([]) do |entry, messages|
+      message = JSON.parse(entry.message)
+      timestamp = entry.timestamp
+      messages << message
+      message.store(:timestamp, timestamp)
+    end
+    # Filter to only messages after test has started and requests with headers
+    messages_after_test_start = messages_array.select { |m| m[:timestamp] > @timestamp }
+    messages_after_test_start.map { |l| l.dig('message', 'params', 'headers') }.compact
+  else
+    page.driver.network_traffic.map do |traffic|
+    # Return all HTTP requests made by Poltergeist
+      URI.parse traffic.url
+    end
+  end
+end

--- a/features/support/helpers.rb
+++ b/features/support/helpers.rb
@@ -245,17 +245,18 @@ def is_chrome
   ENV['CHROME']
 end
 
+def convert_log(log)
+  message = JSON.parse(log.message)
+  message.store(:timestamp, log.timestamp)
+  message
+end
+
 def inline_http_requests
   if is_chrome
     # Chrome does not support network_traffic, instead we can extract this from the performance logs
     logs = page.driver.browser.manage.logs.get(:performance)
     # Store messages in a structure which is easier to work with
-    messages_array = logs.each_with_object([]) do |entry, messages|
-      message = JSON.parse(entry.message)
-      timestamp = entry.timestamp
-      messages << message
-      message.store(:timestamp, timestamp)
-    end
+    messages_array = logs.map { |l| convert_log(l) }
     # Filter to only messages after test has started and requests with headers
     messages_after_test_start = messages_array.select { |m| m[:timestamp] > @timestamp }
     messages_after_test_start.map { |l| l.dig('message', 'params', 'headers') }.compact

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -10,17 +10,11 @@ Before('@cookie-settings') do
   # We need to visit the domain before we can delete its cookies.
   # TODO remove once using Capybara 3.9.0+
   page.visit("#{dm_frontend_domain}")
-
-  @timestamp = Time.now.to_i
-end
-
-Before('@file-download') do
-  # Set timestamp to use Chrome performance API
-  @timestamp = Time.now.to_i
 end
 
 Before do
   Capybara.reset_sessions!
+  @timestamp = Time.now.to_i
 end
 
 require 'fileutils'

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -14,6 +14,11 @@ Before('@cookie-settings') do
   @timestamp = Time.now.to_i
 end
 
+Before('@file-download') do
+  # Set timestamp to use Chrome performance API
+  @timestamp = Time.now.to_i
+end
+
 Before do
   Capybara.reset_sessions!
 end


### PR DESCRIPTION
https://trello.com/c/b6owLEB0/75-3-get-all-functional-tests-working-in-chrome

Previously there were a couple of issues preventing the file download tests working in ChromeDriver:

* By default Chrome shows a user prompt before downloading a file, this PR sets a preference to disable that.
* The `response_headers` method is not available in ChromeDriver. Therefore similarly to #906 this uses the Chrome performance logs as a replacement to derive this data.

## Testing

If you have `chromedriver` installed.

Running:
```
BROWSER=true CHROME=true DM_ENVIRONMENT=preview make ARGS='--tags @file-download' run
```
should pass