### PR TITLE
ChromeDriver settings tweaks

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -18,7 +18,8 @@ if (ENV['BROWSER'] == 'true')
       browser = :chrome
       browser_options = Selenium::WebDriver::Chrome::Options.new
       browser_options.add_preference(:download,
-                                     prompt_for_download: false)
+                                     prompt_for_download: false,
+                                     default_directory: '/tmp')
       browser_options.add_argument('window-size=1400,1400')
       browser_capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
         "goog:loggingPrefs" => {

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -19,6 +19,7 @@ if (ENV['BROWSER'] == 'true')
       browser_options = Selenium::WebDriver::Chrome::Options.new
       browser_options.add_preference(:download,
                                      prompt_for_download: false)
+      browser_options.add_argument('window-size=1400,1400')
       browser_capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
         "goog:loggingPrefs" => {
           performance: "ALL"


### PR DESCRIPTION
A couple of settings tweaks that make ChromeDriver easier to work with. e.g. Jenkins was outputting screenshots in a very small window size (800x600) that made debugging difficult.
![download (1)](https://user-images.githubusercontent.com/1764158/126975361-dcb14f8a-f046-4e31-b09b-50f6586ffb49.png)
