### PR TITLE
Tweaks to fix autocomplete input in ChromeDriver

### DIFF
--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -235,9 +235,9 @@ end
 
 When /^I enter #{MAYBE_VAR} in the '(.*)' field and click the selected autocomplete option?$/ do |value, field_name|
   field_element = page.find_field field_name
-  field_element.set ''  # clear the field before typing
   field_element.click
-  field_element.send_keys value
+  field_element.send_keys [:control, 'a'], :backspace  # clear the field before typing
+  slow_type(field_element, value)
   # Find the sibling <ul>'s focused autocomplete <li> and click it
   focused_dropdown_item = field_element.find(:xpath, "following-sibling::ul[contains(@class, 'autocomplete__menu')]/li[contains(@class, 'autocomplete__option--focused')]")
   focused_dropdown_item.click

--- a/features/support/helpers.rb
+++ b/features/support/helpers.rb
@@ -251,6 +251,13 @@ def convert_log(log)
   message
 end
 
+def slow_type(element, text, delay = 0.01)
+  text.chars.each { |c|
+    element.send_keys(c)
+    sleep(delay)
+  }
+end
+
 def inline_http_requests
   if is_chrome
     # Chrome does not support network_traffic, instead we can extract this from the performance logs


### PR DESCRIPTION
Couple of tweaks to make the country autocomplete work more reliably in ChromeDriver.

* Change the method of clearing the input
* Slow down the text input to allow the JavaScript to fire

## Testing
If you have ChromeDriver installed:
```
BROWSER=true CHROME=true make ARGS='--tags @company-details-edit' run
```
should pass.

Also:
```
make ARGS='--tags @company-details-edit' run
```
should still pass (i.e. this is backwards compatible with PhantomJS)
