### PR TITLE
Fix Live Reload test in ChromeDriver

### DIFF
--- a/features/smoulder-tests/public/live_reload.feature
+++ b/features/smoulder-tests/public/live_reload.feature
@@ -7,9 +7,9 @@ Scenario: Live reload search hitting enter should not cause a full page reload
   And I am on the 'Digital Outcomes and Specialists opportunities' page
   Then I wait to see the 'Clear filters' link with href 'digital-outcomes-and-specialists/opportunities'
   And I set the page reload flag
-  When I enter 'Tea\n' in the 'search' field
+  When I enter 'Tea' in the 'search' field and press the 'return' key
   Then I see that the page has not been reloaded
-  And I wait to see the 'Clear filters' link with href '/digital-outcomes-and-specialists/opportunities?q=Tea%5Cn'
+  And I wait to see the 'Clear filters' link with href '/digital-outcomes-and-specialists/opportunities?q=Tea'
 
 Scenario: Live reload search button should not cause a full page reload
   Given I visit the homepage

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -233,6 +233,12 @@ When /^I enter #{MAYBE_VAR} in the '(.*)' field( and click its associated '(.*)'
   end
 end
 
+When /^I enter #{MAYBE_VAR} in the '(.*)' field and press the '(.*)' key?$/ do |value, field_name, key_name|
+  field_element = page.find_field field_name
+  field_element.set value
+  field_element.send_keys(key_name.to_sym)
+end
+
 When /^I enter #{MAYBE_VAR} in the '(.*)' field and click the selected autocomplete option?$/ do |value, field_name|
   field_element = page.find_field field_name
   field_element.click


### PR DESCRIPTION
https://trello.com/c/b6owLEB0/75-3-get-all-functional-tests-working-in-chrome

`\n` was not interpreted as a return keypress in ChromeDriver, e.g.
![download (2)](https://user-images.githubusercontent.com/1764158/127017591-5d6958af-cdf0-46dd-942c-d2c2771f6bf4.png)

This fixes it by sending a return keypress event.

## Testing

If you have ChromeDriver installed:
```
BROWSER=true CHROME=true make ARGS='--tags @live-reload' run
```
should pass

Should also be backwards compatible with PhantomJS i.e.
```
make ARGS='--tags @live-reload' run
```
should pass

