### PR TITLE
Temporarily skip features requiring file upload

### DIFF
--- a/features/supplier/view_and_edit_g_cloud_services.feature
+++ b/features/supplier/view_and_edit_g_cloud_services.feature
@@ -66,7 +66,7 @@ Scenario: Supplier user can edit the features and benefits of a service
   # tidy up
   Then I ensure that all update audit events for that service are acknowledged
 
-@requires-credentials @file-upload
+@requires-credentials @file-upload @skip-preview @skip-staging
 Scenario: Supplier user can replace the service definition document
   When I click the top-level summary table 'Edit' link for the section 'Documents'
   Then I am on the 'Documents' page
@@ -78,7 +78,7 @@ Scenario: Supplier user can replace the service definition document
   # tidy up
   Then I ensure that all update audit events for that service are acknowledged
 
-@requires-credentials @file-upload
+@requires-credentials @file-upload @skip-preview @skip-staging
 Scenario: Supplier user can not replace the service definition document with a non-pdf file
   When I click the top-level summary table 'Edit' link for the section 'Documents'
   Then I am on the 'Documents' page
@@ -88,7 +88,7 @@ Scenario: Supplier user can not replace the service definition document with a n
   And I see a validation message containing 'an Open Document Format (ODF) or PDF/A (eg .pdf, .odt).'
   And that service has no unacknowledged update audit events
 
-@requires-credentials @file-upload
+@requires-credentials @file-upload @skip-preview @skip-staging
 Scenario: Supplier user can not replace the service definition document with a file over 5MB
   When I click the top-level summary table 'Edit' link for the section 'Documents'
   Then I am on the 'Documents' page


### PR DESCRIPTION
These steps are causing an error:

```
Selenium < 3.14 with remote Chrome doesn't support multiple file upload (ArgumentError)
./features/support/env.rb:152:in `synchronize'
./features/support/env.rb:187:in `synchronize_with_unload_wait'
SD: ./features/step_definitions/common_steps.rb:345:in `/^I choose file '(.*)' for the field '(.*)'$/'
FF: features/supplier/view_and_edit_g_cloud_services.feature:73:in `And I choose file 'test.pdf' for the field 'serviceDefinitionDocumentURL''
```

Skip the steps temporarily on preview and staging while we fix the problem.

https://trello.com/c/pVDEUtX9/101-file-upload-test-issue-with-chromedriver