### PR TITLE
Revert "Temporarily skip features requiring file upload"

### DIFF
--- a/features/supplier/view_and_edit_g_cloud_services.feature
+++ b/features/supplier/view_and_edit_g_cloud_services.feature
@@ -66,7 +66,7 @@ Scenario: Supplier user can edit the features and benefits of a service
   # tidy up
   Then I ensure that all update audit events for that service are acknowledged
 
-@requires-credentials @file-upload @skip-preview @skip-staging
+@requires-credentials @file-upload
 Scenario: Supplier user can replace the service definition document
   When I click the top-level summary table 'Edit' link for the section 'Documents'
   Then I am on the 'Documents' page
@@ -78,7 +78,7 @@ Scenario: Supplier user can replace the service definition document
   # tidy up
   Then I ensure that all update audit events for that service are acknowledged
 
-@requires-credentials @file-upload @skip-preview @skip-staging
+@requires-credentials @file-upload
 Scenario: Supplier user can not replace the service definition document with a non-pdf file
   When I click the top-level summary table 'Edit' link for the section 'Documents'
   Then I am on the 'Documents' page
@@ -88,7 +88,7 @@ Scenario: Supplier user can not replace the service definition document with a n
   And I see a validation message containing 'an Open Document Format (ODF) or PDF/A (eg .pdf, .odt).'
   And that service has no unacknowledged update audit events
 
-@requires-credentials @file-upload @skip-preview @skip-staging
+@requires-credentials @file-upload
 Scenario: Supplier user can not replace the service definition document with a file over 5MB
   When I click the top-level summary table 'Edit' link for the section 'Documents'
   Then I am on the 'Documents' page


### PR DESCRIPTION
Reverts alphagov/digitalmarketplace-functional-tests#913

After updating the version of Chrome Jenkins used to run the tests (see https://github.com/alphagov/digitalmarketplace-jenkins/pull/446), these scenarios are now [passing](https://ci.marketplace.team/job/functional-tests-preview/23648/) so we can re-enable them.

https://trello.com/c/pVDEUtX9/101-functional-tests-that-require-file-uploads-are-failing-on-jenkins